### PR TITLE
Add Ctrl-B and Ctrl-I shortcuts for bold, italic

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -30,7 +30,7 @@
 .ppr_msg{
 	position         : absolute;
 	left             : 0px;
-	top              : 0; // This obscures the horizonal scrollbar (when shown) when it's on the bottom
+	bottom           : 0;
 	z-index          : 1000;
 	padding          : 8px 10px;
 	background-color : #333;

--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -30,7 +30,7 @@
 .ppr_msg{
 	position         : absolute;
 	left             : 0px;
-	bottom           : 0;
+	top              : 0; // This obscures the horizonal scrollbar (when shown) when it's on the bottom
 	z-index          : 1000;
 	padding          : 8px 10px;
 	background-color : #333;

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -41,7 +41,7 @@ const CodeEditor = createClass({
 		this.codeMirror.on('cursorActivity', this.handleCursorActivity);
 		this.updateSize();
 	},
-	
+
 	makeBold : function() {
 		const selection = this.codeMirror.getSelection();
 		this.codeMirror.replaceSelection(`**${selection}**`, 'around');
@@ -51,7 +51,7 @@ const CodeEditor = createClass({
 		const selection = this.codeMirror.getSelection();
 		this.codeMirror.replaceSelection(`*${selection}*`, 'around');
 	},
-	
+
 	componentWillReceiveProps : function(nextProps){
 		if(this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
 			this.codeMirror.setValue(nextProps.value);

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -30,14 +30,28 @@ const CodeEditor = createClass({
 			value        : this.props.value,
 			lineNumbers  : true,
 			lineWrapping : this.props.wrap,
-			mode         : this.props.language
+			mode         : this.props.language,
+			extraKeys    : {
+				'Ctrl-B' : this.makeBold,
+				'Ctrl-I' : this.makeItalic
+			}
 		});
 
 		this.codeMirror.on('change', this.handleChange);
 		this.codeMirror.on('cursorActivity', this.handleCursorActivity);
 		this.updateSize();
 	},
+	
+	makeBold : function() {
+		const selection = this.codeMirror.getSelection();
+		this.codeMirror.replaceSelection(`**${selection}**`, 'around');
+	},
 
+	makeItalic : function() {
+		const selection = this.codeMirror.getSelection();
+		this.codeMirror.replaceSelection(`*${selection}*`, 'around');
+	},
+	
 	componentWillReceiveProps : function(nextProps){
 		if(this.codeMirror && nextProps.value !== undefined && this.codeMirror.getValue() != nextProps.value) {
 			this.codeMirror.setValue(nextProps.value);


### PR DESCRIPTION
This commit adds two shortcut commands to the editor:

* Ctrl-B: surrounds the selected text with double asterisks to render as bold
* Ctrl-I: surrounds the selected text with single asterisks to render as italic