### PR TITLE
Fix delete buttons

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -42,8 +42,14 @@ const MetadataEditor = createClass({
 	},
 
 	handleDelete : function(){
-		if(!confirm('are you sure you want to delete this brew?')) return;
-		if(!confirm('are you REALLY sure? You will not be able to recover it')) return;
+		if(this.props.metadata.authors.length <= 1){
+			if(!confirm('Are you sure you want to delete this brew? Because you are the only owner of this brew, the document will be deleted permanently.')) return;
+			if(!confirm('Are you REALLY sure? You will not be able to recover the document.')) return;
+		}
+		else{
+			if(!confirm('Are you sure you want to remove this brew from your collection? This will remove you as an editor, but other owners will still be able to access the document.')) return;
+			if(!confirm('Are you REALLY sure? You will lose editor access to this document.')) return;
+		}
 
 		request.get(`/api/remove/${this.props.metadata.editId}`)
 			.send()

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -45,8 +45,7 @@ const MetadataEditor = createClass({
 		if(this.props.metadata.authors.length <= 1){
 			if(!confirm('Are you sure you want to delete this brew? Because you are the only owner of this brew, the document will be deleted permanently.')) return;
 			if(!confirm('Are you REALLY sure? You will not be able to recover the document.')) return;
-		}
-		else{
+		} else {
 			if(!confirm('Are you sure you want to remove this brew from your collection? This will remove you as an editor, but other owners will still be able to access the document.')) return;
 			if(!confirm('Are you REALLY sure? You will lose editor access to this document.')) return;
 		}

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -18,9 +18,15 @@ const BrewItem = createClass({
 	},
 
 	deleteBrew : function(){
-		if(!confirm('are you sure you want to delete this brew?')) return;
-		if(!confirm('are you REALLY sure? You will not be able to recover it')) return;
-
+		if(this.props.brew.authors.length <= 1){
+			if(!confirm('Are you sure you want to delete this brew? Because you are the only owner of this brew, the document will be deleted permanently.')) return;
+			if(!confirm('Are you REALLY sure? You will not be able to recover the document.')) return;
+		}
+		else{
+			if(!confirm('Are you sure you want to remove this brew from your collection? This will remove you as an editor, but other owners will still be able to access the document.')) return;
+			if(!confirm('Are you REALLY sure? You will lose editor access to this document.')) return;
+		}
+		
 		request.get(`/api/remove/${this.props.brew.editId}`)
 			.send()
 			.end(function(err, res){

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -21,12 +21,11 @@ const BrewItem = createClass({
 		if(this.props.brew.authors.length <= 1){
 			if(!confirm('Are you sure you want to delete this brew? Because you are the only owner of this brew, the document will be deleted permanently.')) return;
 			if(!confirm('Are you REALLY sure? You will not be able to recover the document.')) return;
-		}
-		else{
+		} else {
 			if(!confirm('Are you sure you want to remove this brew from your collection? This will remove you as an editor, but other owners will still be able to access the document.')) return;
 			if(!confirm('Are you REALLY sure? You will lose editor access to this document.')) return;
 		}
-		
+
 		request.get(`/api/remove/${this.props.brew.editId}`)
 			.send()
 			.end(function(err, res){

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -68,13 +68,13 @@ router.get('/api/remove/:id', (req, res)=>{
 	HomebrewModel.find({ editId: req.params.id }, (err, objs)=>{
 		if(!objs.length || err) return res.status(404).send('Can not find homebrew with that id');
 		const brew = objs[0];
-		
+
 		// Remove current user as author
 		if(req.account){
 			brew.authors = _.pull(brew.authors, req.account.username);
 			brew.markModified('authors');
 		}
-		
+
 		// Delete brew if there are no authors left
 		if(!brew.authors.length)
 			brew.remove((err)=>{


### PR DESCRIPTION
Delete should now first remove the current user as an editor, and only delete the file if he was the last editor. Currently, anyone who views your brew is added as an editor and if they delete it, the whole brew is deleted for everyone.