### PR TITLE
Prevent offset split tables

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -205,7 +205,7 @@ module.exports = [
 				icon : 'fa-th-large',
 				gen  : function(){
 					return [
-						'<div style=\'column-count:2\'>',
+						'<div class=\'split-table\' style=\'column-count:2\'>',
 						'| d10 | Damage Type |',
 						'|:---:|:------------|',
 						'|  1  | Acid        |',

--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -349,6 +349,7 @@ body {
 	//Text indent right after table
 	table+p{
 		text-indent : 1em;
+        padding     : 0em;
 	}
 	// Nested lists
 	ul ul,ol ol,ul ol,ol ul{

--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -349,7 +349,10 @@ body {
 	//Text indent right after table
 	table+p{
 		text-indent : 1em;
-        padding     : 0em;
+	}
+	//Prevent offset split tables
+	.split-table p{
+	    padding: 0em;
 	}
 	// Nested lists
 	ul ul,ol ol,ul ol,ol ul{


### PR DESCRIPTION
Fixes #844 by removing padding from paragraphs that follow tables which caused split tables to be offset.