### PR TITLE
Compress brews

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -50,8 +50,8 @@ router.put('/api/update/:id', (req, res)=>{
 			brew = _.merge(brew, req.body);
 			brew.textBin = zlib.deflateSync(req.body.text);		// Compress brew text to binary before saving
 			brew.text = '';										// Clear out the non-binary text field so its not saved twice
-			
 			brew.updatedAt = new Date();
+
 			if(req.account) brew.authors = _.uniq(_.concat(brew.authors, req.account.username));
 
 			brew.markModified('authors');

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -48,7 +48,7 @@ router.put('/api/update/:id', (req, res)=>{
 	HomebrewModel.get({ editId: req.params.id })
 		.then((brew)=>{
 			brew = _.merge(brew, req.body);
-			brew.textBin = zlib.deflateSync(req.body.text);		// Compress brew text to binary before saving
+			brew.textBin = zlib.deflateRawSync(req.body.text);		// Compress brew text to binary before saving
 			brew.text = '';										// Clear out the non-binary text field so its not saved twice
 			brew.updatedAt = new Date();
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -32,9 +32,14 @@ router.post('/api', (req, res)=>{
 		req.body,
 		{ authors: authors }
 	));
+
 	if(!newHomebrew.title){
 		newHomebrew.title = getGoodBrewTitle(newHomebrew.text);
 	}
+
+	newHomebrew.textBin = zlib.deflateRawSync(newHomebrew.text);	// Compress brew text to binary before saving
+	newHomebrew.text = '';											// Clear out the non-binary text field so its not saved twice
+
 	newHomebrew.save((err, obj)=>{
 		if(err){
 			console.error(err, err.toString(), err.stack);
@@ -48,7 +53,7 @@ router.put('/api/update/:id', (req, res)=>{
 	HomebrewModel.get({ editId: req.params.id })
 		.then((brew)=>{
 			brew = _.merge(brew, req.body);
-			brew.textBin = zlib.deflateRawSync(req.body.text);		// Compress brew text to binary before saving
+			brew.textBin = zlib.deflateRawSync(req.body.text);	// Compress brew text to binary before saving
 			brew.text = '';										// Clear out the non-binary text field so its not saved twice
 			brew.updatedAt = new Date();
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -1,6 +1,7 @@
 const _ = require('lodash');
 const HomebrewModel = require('./homebrew.model.js').model;
 const router = require('express').Router();
+const zlib = require('zlib');
 
 // const getTopBrews = (cb)=>{
 // 	HomebrewModel.find().sort({ views: -1 }).limit(5).exec(function(err, brews) {
@@ -47,6 +48,9 @@ router.put('/api/update/:id', (req, res)=>{
 	HomebrewModel.get({ editId: req.params.id })
 		.then((brew)=>{
 			brew = _.merge(brew, req.body);
+			brew.textBin = zlib.deflateSync(req.body.text);		// Compress brew text to binary before saving
+			brew.text = '';										// Clear out the non-binary text field so its not saved twice
+			
 			brew.updatedAt = new Date();
 			if(req.account) brew.authors = _.uniq(_.concat(brew.authors, req.account.username));
 

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -1,12 +1,14 @@
 const mongoose = require('mongoose');
 const shortid = require('shortid');
 const _ = require('lodash');
+const zlib = require('zlib');
 
 const HomebrewSchema = mongoose.Schema({
 	shareId : { type: String, default: shortid.generate, index: { unique: true } },
 	editId  : { type: String, default: shortid.generate, index: { unique: true } },
 	title   : { type: String, default: '' },
 	text    : { type: String, default: '' },
+	textBin : { type: Buffer }, 
 
 	description : { type: String, default: '' },
 	tags        : { type: String, default: '' },
@@ -51,6 +53,10 @@ HomebrewSchema.statics.get = function(query){
 	return new Promise((resolve, reject)=>{
 		Homebrew.find(query, (err, brews)=>{
 			if(err || !brews.length) return reject('Can not find brew');
+			if(!_.isUndefined(brews[0].textBin)) {			// Uncompress zipped text field
+				unzipped = zlib.unzipSync(brews[0].textBin);
+				brews[0].text = unzipped.toString();
+			}
 			return resolve(brews[0]);
 		});
 	});

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -8,7 +8,7 @@ const HomebrewSchema = mongoose.Schema({
 	editId  : { type: String, default: shortid.generate, index: { unique: true } },
 	title   : { type: String, default: '' },
 	text    : { type: String, default: '' },
-	textBin : { type: Buffer }, 
+	textBin : { type: Buffer },
 
 	description : { type: String, default: '' },
 	tags        : { type: String, default: '' },

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -54,7 +54,7 @@ HomebrewSchema.statics.get = function(query){
 		Homebrew.find(query, (err, brews)=>{
 			if(err || !brews.length) return reject('Can not find brew');
 			if(!_.isUndefined(brews[0].textBin)) {			// Uncompress zipped text field
-				unzipped = zlib.unzipSync(brews[0].textBin);
+				unzipped = zlib.inflateRawSync(brews[0].textBin);
 				brews[0].text = unzipped.toString();
 			}
 			return resolve(brews[0]);


### PR DESCRIPTION
Brand new files were still being saved with their text field full. Meaning it had both a compressed *and* uncompressed version of the text being saved.