### PR TITLE
API Code Cleanup + Alt Endpoints

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -9,25 +9,25 @@ const zlib = require('zlib');
 // 	});
 // };
 
-const getGoodBrewTitle = (text) => {
+const getGoodBrewTitle = (text)=>{
 	const titlePos = text.indexOf('# ');
-	if (titlePos !== -1) {
+	if(titlePos !== -1) {
 		const ending = text.indexOf('\n', titlePos);
 		return text.substring(titlePos + 2, ending);
 	} else {
-		return _.find(text.split('\n'), line => line);
+		return _.find(text.split('\n'), (line)=>line);
 	}
 };
 
-const newBrew = (req, res) => {
-	let authors = (req.account) ? [req.account.username] : [];
+const newBrew = (req, res)=>{
+	const authors = (req.account) ? [req.account.username] : [];
 
 	const newHomebrew = new HomebrewModel(_.merge({},
 		req.body,
 		{ authors: authors }
 	));
 
-	if (!newHomebrew.title) {
+	if(!newHomebrew.title) {
 		newHomebrew.title = getGoodBrewTitle(newHomebrew.text);
 	}
 
@@ -36,8 +36,8 @@ const newBrew = (req, res) => {
 	// Delete the non-binary text field since it's not needed anymore
 	newHomebrew.text = undefined;
 
-	newHomebrew.save((err, obj) => {
-		if (err) {
+	newHomebrew.save((err, obj)=>{
+		if(err) {
 			console.error(err, err.toString(), err.stack);
 			return res.status(500).send(`Error while creating new brew, ${err.toString()}`);
 		}
@@ -45,11 +45,9 @@ const newBrew = (req, res) => {
 	});
 };
 
-router.post('/api', newBrew);
-
-const updateBrew = (req, res) => {
+const updateBrew = (req, res)=>{
 	HomebrewModel.get({ editId: req.params.id })
-		.then((brew) => {
+		.then((brew)=>{
 			brew = _.merge(brew, req.body);
 			// Compress brew text to binary before saving
 			brew.textBin = zlib.deflateRawSync(req.body.text);
@@ -57,57 +55,59 @@ const updateBrew = (req, res) => {
 			brew.text = undefined;
 			brew.updatedAt = new Date();
 
-			if (req.account) {
+			if(req.account) {
 				brew.authors = _.uniq(_.concat(brew.authors, req.account.username));
 			}
 
 			brew.markModified('authors');
 			brew.markModified('systems');
 
-			brew.save((err, obj) => {
-				if (err) throw err;
+			brew.save((err, obj)=>{
+				if(err) throw err;
 				return res.status(200).send(obj);
 			});
 		})
-		.catch((err) => {
+		.catch((err)=>{
 			console.error(err);
 			return res.status(500).send('Error while saving');
 		});
 };
 
-router.put('/api/update/:id', updateBrew);
-router.put('/api/:id', updateBrew);
-
-const deleteBrew = (req, res) => {
-	HomebrewModel.find({ editId: req.params.id }, (err, objs) => {
-		if (!objs.length || err)
+const deleteBrew = (req, res)=>{
+	HomebrewModel.find({ editId: req.params.id }, (err, objs)=>{
+		if(!objs.length || err) {
 			return res.status(404).send('Can not find homebrew with that id');
+		}
+
 		const brew = objs[0];
 
-		// Remove current user as author
-		if (req.account) {
+		if(req.account) {
+			// Remove current user as author
 			brew.authors = _.pull(brew.authors, req.account.username);
 			brew.markModified('authors');
 		}
 
-		if (brew.authors.length === 0) {
+		if(brew.authors.length === 0) {
 			// Delete brew if there are no authors left
-			brew.remove((err) => {
-				if (err) return res.status(500).send('Error while removing');
+			brew.remove((err)=>{
+				if(err) return res.status(500).send('Error while removing');
 				return res.status(200).send();
 			});
 		} else {
 			// Otherwise, save the brew with updated author list
-			brew.save((err, savedBrew) => {
-				if (err) throw err;
+			brew.save((err, savedBrew)=>{
+				if(err) throw err;
 				return res.status(200).send(savedBrew);
 			});
 		}
 	});
 };
 
-router.get('/api/remove/:id', deleteBrew);
+router.post('/api', newBrew);
+router.put('/api/:id', updateBrew);
+router.put('/api/update/:id', updateBrew);
 router.delete('/api/:id', deleteBrew);
+router.get('/api/remove/:id', deleteBrew);
 
 module.exports = router;
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -3,127 +3,128 @@ const HomebrewModel = require('./homebrew.model.js').model;
 const router = require('express').Router();
 const zlib = require('zlib');
 
-// const getTopBrews = (cb)=>{
+// const getTopBrews = (cb) => {
 // 	HomebrewModel.find().sort({ views: -1 }).limit(5).exec(function(err, brews) {
 // 		cb(brews);
 // 	});
 // };
 
-const getGoodBrewTitle = (text)=>{
+const getGoodBrewTitle = (text) => {
 	const titlePos = text.indexOf('# ');
-	if(titlePos !== -1){
+	if (titlePos !== -1) {
 		const ending = text.indexOf('\n', titlePos);
 		return text.substring(titlePos + 2, ending);
 	} else {
-		return _.find(text.split('\n'), (line)=>{
-			return line;
-		});
+		return _.find(text.split('\n'), line => line);
 	}
 };
 
-
-
-router.post('/api', (req, res)=>{
-
-	let authors = [];
-	if(req.account) authors = [req.account.username];
+const newBrew = (req, res) => {
+	let authors = (req.account) ? [req.account.username] : [];
 
 	const newHomebrew = new HomebrewModel(_.merge({},
 		req.body,
 		{ authors: authors }
 	));
 
-	if(!newHomebrew.title){
+	if (!newHomebrew.title) {
 		newHomebrew.title = getGoodBrewTitle(newHomebrew.text);
 	}
 
-	newHomebrew.textBin = zlib.deflateRawSync(newHomebrew.text);	// Compress brew text to binary before saving
-	newHomebrew.text = undefined;									// Delete the non-binary text field since it's not needed anymore
+	// Compress brew text to binary before saving
+	newHomebrew.textBin = zlib.deflateRawSync(newHomebrew.text);
+	// Delete the non-binary text field since it's not needed anymore
+	newHomebrew.text = undefined;
 
-	newHomebrew.save((err, obj)=>{
-		if(err){
+	newHomebrew.save((err, obj) => {
+		if (err) {
 			console.error(err, err.toString(), err.stack);
 			return res.status(500).send(`Error while creating new brew, ${err.toString()}`);
 		}
 		return res.json(obj);
 	});
-});
+};
 
-router.put('/api/update/:id', (req, res)=>{
+router.post('/api', newBrew);
+
+const updateBrew = (req, res) => {
 	HomebrewModel.get({ editId: req.params.id })
-		.then((brew)=>{
+		.then((brew) => {
 			brew = _.merge(brew, req.body);
-			brew.textBin = zlib.deflateRawSync(req.body.text);	// Compress brew text to binary before saving
-			brew.text = undefined;								// Delete the non-binary text field since it's not needed anymore
+			// Compress brew text to binary before saving
+			brew.textBin = zlib.deflateRawSync(req.body.text);
+			// Delete the non-binary text field since it's not needed anymore
+			brew.text = undefined;
 			brew.updatedAt = new Date();
 
-			if(req.account) brew.authors = _.uniq(_.concat(brew.authors, req.account.username));
+			if (req.account) {
+				brew.authors = _.uniq(_.concat(brew.authors, req.account.username));
+			}
 
 			brew.markModified('authors');
 			brew.markModified('systems');
 
-			brew.save((err, obj)=>{
-				if(err) throw err;
+			brew.save((err, obj) => {
+				if (err) throw err;
 				return res.status(200).send(obj);
 			});
 		})
-		.catch((err)=>{
-			console.log(err);
+		.catch((err) => {
+			console.error(err);
 			return res.status(500).send('Error while saving');
 		});
-});
+};
 
-router.get('/api/remove/:id', (req, res)=>{
-	HomebrewModel.find({ editId: req.params.id }, (err, objs)=>{
-		if(!objs.length || err) return res.status(404).send('Can not find homebrew with that id');
+router.put('/api/update/:id', updateBrew);
+router.put('/api/:id', updateBrew);
+
+const deleteBrew = (req, res) => {
+	HomebrewModel.find({ editId: req.params.id }, (err, objs) => {
+		if (!objs.length || err)
+			return res.status(404).send('Can not find homebrew with that id');
 		const brew = objs[0];
 
 		// Remove current user as author
-		if(req.account){
+		if (req.account) {
 			brew.authors = _.pull(brew.authors, req.account.username);
 			brew.markModified('authors');
 		}
 
-		// Delete brew if there are no authors left
-		if(!brew.authors.length)
-			brew.remove((err)=>{
-				if(err) return res.status(500).send('Error while removing');
+		if (brew.authors.length === 0) {
+			// Delete brew if there are no authors left
+			brew.remove((err) => {
+				if (err) return res.status(500).send('Error while removing');
 				return res.status(200).send();
 			});
-		// Otherwise, save the brew with updated author list
-		else
-			brew.save((err, savedBrew)=>{
-				if(err) throw err;
+		} else {
+			// Otherwise, save the brew with updated author list
+			brew.save((err, savedBrew) => {
+				if (err) throw err;
 				return res.status(200).send(savedBrew);
 			});
+		}
 	});
-});
+};
 
+router.get('/api/remove/:id', deleteBrew);
+router.delete('/api/:id', deleteBrew);
 
 module.exports = router;
 
 /*
-
-
-
-module.exports = function(app){
-
+module.exports = function(app) {
 	app;
 
-
-
-
-	app.get('/api/search', mw.adminOnly, function(req, res){
-
+	app.get('/api/search', mw.adminOnly, function(req, res) {
 		var page = req.query.page || 0;
 		var count = req.query.count || 20;
 
 		var query = {};
-		if(req.query && req.query.id){
+		if (req.query && req.query.id) {
 			query = {
-				"$or" : [{
+				"$or": [{
 					editId : req.query.id
-				},{
+				}, {
 					shareId : req.query.id
 				}]
 			};
@@ -134,20 +135,16 @@ module.exports = function(app){
 		}, {
 			skip: page*count,
 			limit: count*1
-		}, function(err, objs){
-			if(err) console.log(err);
+		}, function(err, objs) {
+			if (err) console.error(err);
 			return res.json({
 				page : page,
 				count : count,
 				total : homebrewTotal,
 				brews : objs
 			});
-
 		});
 	})
-
-
-
 
 	return app;
 }


### PR DESCRIPTION
Added 2 new API Endpoints as alternatives to existing ones:
- `PUT /api/:id` (same as `PUT /api/update/:id`)
- `DELETE /api/:id` (same as `GET /api/remove/:id`)