### PR TITLE
Fix: Do not force SSL when running in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM node:8
 
+ENV NODE_ENV=docker
+
 # Create app directory
 WORKDIR /usr/src/app
 
-# Bundle app source
+# Copy package.json into the image, then run yarn install
+# This improves caching so we don't have to download the dependencies every time the code changes
+COPY package.json ./
+# --ignore-scripts tells yarn not to run postbuild.  We run it explicitly later
+RUN yarn install --ignore-scripts
+
+# Bundle app source and build application
 COPY . .
-
-ENV NODE_ENV=docker
-
-RUN yarn
+RUN yarn build
 
 EXPOSE 8000
 CMD [ "yarn", "start" ]

--- a/README.DOCKER.md
+++ b/README.DOCKER.md
@@ -1,0 +1,12 @@
+# Running Homebrewery via Docker
+
+The repo includes a Dockerfile and a docker-compose.yml file.
+
+To run the application via docker-compose.yml:
+`docker-compose up -d`
+
+To stop the application:
+`docker-compose down`
+
+To stop the application and remove all data:
+`docker-compose down -v`

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Fourth, you will need to install the program and run it using the two commands:
 
 You should now be able to go to [http://localhost:8000](http://localhost:8000) in your browser and use the Homebrewery offline.
 
+### Running the application via Docker
+
+Please see the docs here: [README.DOCKER.md](./README.DOCKER.md)
+
 ### Standalone PHB Stylesheet
 If you just want the stylesheet that is generated to make pages look like they are from the Player's Handbook, you will find it in the [phb.standalone.css](./phb.standalone.css) file.
 

--- a/server/forcessl.mw.js
+++ b/server/forcessl.mw.js
@@ -1,5 +1,5 @@
 module.exports = (req, res, next)=>{
-	if(process.env.NODE_ENV === 'local') return next();
+	if(process.env.NODE_ENV === 'local' || process.env.NODE_ENV === 'docker') return next();
 	if(req.header('x-forwarded-proto') !== 'https') {
 		return res.redirect(302, `https://${req.get('Host')}${req.url}`);
 	}


### PR DESCRIPTION
This PR includes several minor changes related to Docker.  First off, thank you for keeping the Dockerfile and docker-compose.yml file around.  It makes running the application much easier for people who use docker.

Changes:
- Add a short README with basic information on how to run the application using docker
- Minor refactoring of the Dockerfile to improve image layer caching.  By rearranging the commands, we download the dependencies
- Make a small change to the application code to prevent forcing SSL redirect when running in Docker.  I considered using `process.env.NODE_ENV !== 'production'`, I can make that change if that is preferable.  This was preventing the application from being accessible when running in a docker container, and this fix is required to use the application in docker.  It's currently broken.

Thank you!