### PR TITLE
Change text in RenderWarning popup

### DIFF
--- a/shared/homebrewery/renderWarnings/renderWarnings.jsx
+++ b/shared/homebrewery/renderWarnings/renderWarnings.jsx
@@ -25,10 +25,10 @@ const RenderWarnings = createClass({
 			if(!isChrome){
 				return <li key='chrome'>
 					<em>Built for Chrome </em> <br />
-					Other browsers do not support &nbsp;
-					<a target='_blank' href='https://developer.mozilla.org/en-US/docs/Web/CSS/column-span#Browser_compatibility'>
-						key features
-					</a> this site uses.
+					Other browsers have not been tested for compatiblilty. If you
+					experience issues with your document not rendering or printing
+					properly, please try using the latest version of Chrome before
+					submitting a bug report.
 				</li>;
 			}
 		},


### PR DESCRIPTION
Reflect our policy of testing only on Chrome, but remove the specific issue of column-span support as that is now supported by other browsers.