### PR TITLE
Created css for third-caster table with snippet

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -167,6 +167,38 @@ module.exports = [
 				gen  : ClassTableGen.half,
 			},
 			{
+				name : 'Third-Caster Spells Table',
+				icon : 'fa-table',
+				gen  : function() {
+					return [
+						'<div class=\'arch-table\'>',
+						'##### Third-Caster Spellcasting',
+						'###### —Spell Slots per Spell Level—',
+						'| Class<br>Level | Cantrips<br>Known | Spells<br>Known | 1st | 2nd | 3rd | 4th |',
+						'|:---:|:-:|:-:|:-:|:-:|:-:|:-:|',
+						'| 3rd | 2 | 3 | 2 | — | — | — |',
+						'| 4th | 2 | 4 | 3 | — | — | — |',
+						'| 5th | 2 | 4 | 3 | — | — | — |',
+						'| 6th | 2 | 4 | 3 | — | — | — |',
+						'| 7th | 2 | 5 | 4 | 2 | — | — |',
+						'| 8th | 2 | 6 | 4 | 2 | — | — |',
+						'| 9th | 2 | 6 | 4 | 2 | — | — |',
+						'|10th | 3 | 7 | 4 | 3 | — | — |',
+						'|11th | 3 | 8 | 4 | 3 | — | — |',
+						'|12th | 3 | 8 | 4 | 3 | — | — |',
+						'|13th | 3 | 9 | 4 | 3 | 2 | — |',
+						'|14th | 3 |10 | 4 | 3 | 2 | — |',
+						'|15th | 3 |10 | 4 | 3 | 2 | — |',
+						'|16th | 3 |11 | 4 | 3 | 3 | — |',
+						'|17th | 3 |11 | 4 | 3 | 3 | — |',
+						'|18th | 3 |11 | 4 | 3 | 3 | — |',
+						'|19th | 3 |12 | 4 | 3 | 3 | 1 |',
+						'|20th | 3 |13 | 4 | 3 | 3 | 1 |',
+						'</div>',
+					].join('\n');
+				},
+			},
+			{
 				name : 'Table',
 				icon : 'fa-th-list',
 				gen  : function(){

--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -412,6 +412,47 @@ body {
 		margin-bottom : 10px;
 	}
 }
+//*****************************
+// * ARCHETYPE CLASS TABLE
+// *****************************/
+.phb .arch-table{
+	table {
+		margin-top: 8px;
+	}
+	td:nth-child(1) {
+		width: 60px
+	}
+	td:nth-child(2) {
+		width: 60px
+	}
+	td:nth-child(3) {
+		width: 60px
+	}
+	td:nth-child(4) {
+		width: 36px
+	}
+	td:nth-child(5) {
+		width: 36px
+	}
+	td:nth-child(6) {
+		width: 36px
+	}
+	td:nth-child(7) {
+		width: 36px
+	}
+	table thead th {
+		font-size: 95%;
+	}
+	h6 {
+		font-family:'ScalySans';
+		font-size: 95%;
+		font-weight: bold;
+		line-height: 1.3em;
+		margin-bottom: -25px;
+		padding-bottom: .8em;
+		text-align: right;
+	};
+}
 //************************************
 // *       DESCRIPTIVE TEXT BOX
 // ************************************/


### PR DESCRIPTION
So, I created the css for third-caster tables (see image) and added a button to add a snippet with an example. 

From Player's Handbook: 
![image](https://user-images.githubusercontent.com/30464993/97247574-b6ae8000-17de-11eb-9442-01e9b9d44179.png)

Snippet example:
![image](https://user-images.githubusercontent.com/30464993/97247702-f1b0b380-17de-11eb-9eda-8b21a3264059.png)

Addresses #191.