### PR TITLE
line-heights consistent in bq li (#1085)

### DIFF
--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -189,7 +189,7 @@ body {
 		border-image        : @noteBorderImage 11;
 		border-image-outset : 9px 0px;
 		box-shadow          : 1px 4px 14px #888;
-		p, ul{
+		p, li{
 			font-size   : 0.352cm;
 			line-height : 1.1em;
 		}


### PR DESCRIPTION
applies same line-height for both ol and ul inside a blockquote quote. See #1085.