### PR TITLE
Fix metadata in Google docs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # changelog
 
+### Wednesday, 25/11/2020 - v2.10.4
+- Fixed Google Drive brews not saving metadata (view count, description, etc.) Note that we are still working on making published Google brews visible to the public when viewing your profile page.
+- Fixed inconsistent font size for bullet lists inside notes (thanks /u/garumoo! re:1085)
+
 ### Thursday, 22/10/2020 - v2.10.3
 - Fixed brews with broken code crashing the edit page when loaded (the "blue screen of death" bug).
 
@@ -33,14 +37,14 @@
 - Fixed issue of being unable to change brew metadata
 - Sanitized script tags-javascript typed into the editor was crashing brews
 
+```
+```
+
 ### Sunday, 08/04/2018 - v2.8.0
 - Re-enabled box shadows for PDF output
 - Added a "contributing guide" for the GitHub
 - "Report Issue" navbar button now links to the subreddit
 - Refactored background code
-
-```
-```
 
 ### Sunday, 04/06/2017 - v2.7.5
 - Fixed the class feature snippet duplicating the entire brew

--- a/client/homebrew/pages/userPage/brewItem/brewItem.less
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.less
@@ -25,7 +25,7 @@
 		font-family : ScalySans;
 		font-size   : 1.2em;
 		&>span{
-			margin-right : 15px;
+			margin-right : 12px;
 		}
 	}
 	&:hover{

--- a/client/homebrew/pages/userPage/userPage.jsx
+++ b/client/homebrew/pages/userPage/userPage.jsx
@@ -22,9 +22,8 @@ const BrewItem = require('./brewItem/brewItem.jsx');
 const UserPage = createClass({
 	getDefaultProps : function() {
 		return {
-			username    : '',
-			brews       : [],
-			googleBrews : []
+			username : '',
+			brews    : []
 		};
 	},
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "homebrewery",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebrewery",
   "description": "Create authentic looking D&D homebrews using only markdown",
-  "version": "2.10.3",
+  "version": "2.10.4",
   "engines": {
     "node": "12.16.x"
   },

--- a/server.js
+++ b/server.js
@@ -150,6 +150,10 @@ app.get('/share/:id', (req, res, next)=>{
 		const shareId = req.params.id.slice(-12);
 		GoogleActions.readFileMetadata(config.get('google_api_key'), googleId, shareId, 'share')
 		.then((brew)=>{
+			GoogleActions.increaseView(googleId, shareId, 'share', brew);
+			return brew;
+		})
+		.then((brew)=>{
 			req.brew = brew; //TODO Need to sanitize later
 			return next();
 		})

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -87,11 +87,17 @@ GoogleActions = {
 
 		oAuth2Client = GoogleActions.authCheck(req.account, res);
 
+		//TODO: Change to service account to allow non-owners to view published files.
+		// Requires a driveId parameter in the drive.files.list command
+		// const keys = JSON.parse(config.get('service_account'));
+		// const auth = google.auth.fromJSON(keys);
+		// auth.scopes = ['https://www.googleapis.com/auth/drive'];
+
 		const drive = google.drive({ version: 'v3', auth: oAuth2Client });
 
 		const obj = await drive.files.list({
 			pageSize : 100,
-			fields   : 'nextPageToken, files(id, name, modifiedTime, properties)',
+			fields   : 'nextPageToken, files(id, name, description, modifiedTime, properties)',
 			q        : 'mimeType != \'application/vnd.google-apps.folder\' and trashed = false'
 		})
 		.catch((err)=>{
@@ -107,15 +113,16 @@ GoogleActions = {
 	      text      : '',
 	      shareId   : file.properties.shareId,
 	      editId    : file.properties.editId,
-	      createdAt : null,
+	      createdAt : file.createdTime,
 	      updatedAt : file.modifiedTime,
 	      gDrive    : true,
 	      googleId  : file.id,
 
 	      title       : file.properties.title,
-	      description : '',
+	      description : file.description,
+				views       : file.properties.views,
 	      tags        : '',
-	      published   : false,
+	      published   : file.properties.published ? file.properties.published == 'true' : false,
 	      authors     : [req.account.username],	//TODO: properly save and load authors to google drive
 	      systems     : []
 	    };
@@ -129,6 +136,8 @@ GoogleActions = {
 
 		const result = await drive.files.get({ fileId: id })
 		.catch((err)=>{
+			console.log('error checking file exists...');
+			console.log(err);
 			return false;
 		});
 
@@ -140,12 +149,24 @@ GoogleActions = {
 	updateGoogleBrew : async (auth, brew)=>{
 		const drive = google.drive({ version: 'v3', auth: auth });
 
-		if(await GoogleActions.existsGoogleBrew(auth, brew.googleId) == true) {
+		console.log('trying to update a brew');
+		console.log(brew);
 
+		if(await GoogleActions.existsGoogleBrew(auth, brew.googleId) == true) {
+			console.log('the brew exists at least');
+			console.log('going to put this text:');
+			console.log(brew.text);
 			await drive.files.update({
 				fileId   : brew.googleId,
-				resource : { name       : `${brew.title}.txt`,
-										 properties : { title: brew.title } //AppProperties is not accessible via API key
+				resource : { name        : `${brew.title}.txt`,
+										 description : `${brew.description}`,
+										 properties  : { title   			: brew.title,
+										 								published  : brew.published,
+																	  lastViewed : brew.lastViewed,
+																	  views      : brew.views,
+																	  version    : brew.version,
+																	  tags       : brew.tags,
+																	  systems    : brew.systems.join() }
 									 },
 				media : { mimeType : 'text/plain',
 										 body     : brew.text }
@@ -171,12 +192,14 @@ GoogleActions = {
 		const folderId = await GoogleActions.getGoogleFolder(auth);
 
 		const fileMetadata = {
-			'name'       : `${brew.title}.txt`,
-			'parents'    : [folderId],
-			'properties' : {								//AppProperties is not accessible
+			'name'        : `${brew.title}.txt`,
+			'description' : `${brew.description}`,
+			'parents'     : [folderId],
+			'properties'  : {								//AppProperties is not accessible
 				'shareId' : nanoid(12),
 				'editId'  : nanoid(12),
 				'title'   : brew.title,
+				'views'   : '0'
 			}
 		};
 
@@ -206,15 +229,15 @@ GoogleActions = {
 			text      : brew.text,
 			shareId   : fileMetadata.properties.shareId,
 			editId    : fileMetadata.properties.editId,
-			createdAt : null,
-			updatedAt : null,
+			createdAt : new Date(),
+			updatedAt : new Date(),
 			gDrive    : true,
 			googleId  : obj.data.id,
 
 			title       : brew.title,
-			description : '',
+			description : brew.description,
 			tags        : '',
-			published   : false,
+			published   : brew.published,
 			authors     : [],
 			systems     : []
 		};
@@ -227,7 +250,7 @@ GoogleActions = {
 
 		const obj = await drive.files.get({
 			fileId : id,
-			fields : 'properties'
+			fields : 'properties, createdTime, modifiedTime, description'
 		})
 		.catch((err)=>{
 			console.log('Error loading from Google');
@@ -244,6 +267,7 @@ GoogleActions = {
 
 			const file = await drive.files.get({
 				fileId : id,
+				fields : 'description, properties',
 				alt    : 'media'
 			})
 			.catch((err)=>{
@@ -252,20 +276,25 @@ GoogleActions = {
 			});
 
 			const brew = {
-				text      : file.data,
-				shareId   : obj.data.properties.shareId,
-				editId    : obj.data.properties.editId,
-				createdAt : null,
-				updatedAt : null,
-				gDrive    : true,
-				googleId  : id,
+				shareId : obj.data.properties.shareId,
+				editId  : obj.data.properties.editId,
+				title   : obj.data.properties.title,
+				text    : file.data,
 
-				title       : obj.data.properties.title,
-				description : '',
-				tags        : '',
-				published   : false,
+				description : obj.data.description,
+				tags        : obj.data.properties.tags    ? obj.data.properties.tags.split(',')    : [],
+				systems     : obj.data.properties.systems ? obj.data.properties.systems.split(',') : [],
 				authors     : [],
-				systems     : []
+				published   : obj.data.properties.published ? obj.data.properties.published == 'true' : false,
+
+				createdAt  : obj.data.createdTime,
+				updatedAt  : obj.data.modifiedTime,
+				lastViewed : obj.data.properties.lastViewed,
+				views      : parseInt(obj.data.properties.views) || 0, //brews with no view parameter will return undefined
+				version    : parseInt(obj.data.properties.version) || 0,
+
+				gDrive   : true,
+				googleId : id
 			};
 
 			return (brew);
@@ -303,6 +332,29 @@ GoogleActions = {
 		});
 
 		return res.status(200).send();
+	},
+
+	increaseView : async (id, accessId, accessType, brew)=>{
+		//service account because this is modifying another user's file properties
+		//so we need extended scope
+		const keys = JSON.parse(config.get('service_account'));
+		const auth = google.auth.fromJSON(keys);
+		auth.scopes = ['https://www.googleapis.com/auth/drive'];
+
+		const drive = google.drive({ version: 'v3', auth: auth });
+
+		await drive.files.update({
+			fileId   : brew.googleId,
+			resource : { properties : { views      : brew.views + 1,
+		 															lastViewed : new Date() } }
+		})
+		.catch((err)=>{
+			console.log('Error updating Google views');
+			console.error(err);
+			//return res.status(500).send('Error while saving');
+		});
+
+		return;
 	}
 };
 


### PR DESCRIPTION
Update view counts via service account since modifying another users' file properties requires increased permission scope