### PR TITLE
make all li inside bq smaller font for backwards compatibility

### DIFF
--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -189,8 +189,12 @@ body {
 		border-image        : @noteBorderImage 11;
 		border-image-outset : 9px 0px;
 		box-shadow          : 1px 4px 14px #888;
-		p, li{
+		p{
 			font-size   : 0.352cm;
+			line-height : 1.1em;
+		}
+		li, li p{
+			font-size   : 0.317cm;
 			line-height : 1.1em;
 		}
 	}


### PR DESCRIPTION
Some brews were relying on the smaller font-size for column wrap
so make all `<li>` within `<bq>` smaller (including if inside `<p>`).

Some brews might now have extra space (vs some brews now overflowing the space they had before)
https://github.com/naturalcrit/homebrewery/issues/1085#issuecomment-734322530