### PR TITLE
Remove metadata on the Homepage

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -23,6 +23,7 @@ const Editor = createClass({
 
 			metadata         : {},
 			onMetadataChange : ()=>{},
+			showMetaButton   : true
 		};
 	},
 	getInitialState : function() {
@@ -118,7 +119,8 @@ const Editor = createClass({
 					brew={this.props.value}
 					onInject={this.handleInject}
 					onToggle={this.handgleToggle}
-					showmeta={this.state.showMetadataEditor} />
+					showmeta={this.state.showMetadataEditor}
+					showMetaButton={this.props.showMetaButton} />
 				{this.renderMetadataEditor()}
 				<CodeEditor
 					ref='codeEditor'

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -15,10 +15,10 @@ const execute = function(val, brew){
 const Snippetbar = createClass({
 	getDefaultProps : function() {
 		return {
-			brew     : '',
-			onInject : ()=>{},
-			onToggle : ()=>{},
-			showmeta : false,
+			brew           : '',
+			onInject       : ()=>{},
+			onToggle       : ()=>{},
+			showmeta       : false,
 			showMetaButton : true
 		};
 	},
@@ -45,7 +45,7 @@ const Snippetbar = createClass({
 		return <div className={cx('toggleMeta', { selected: this.props.showmeta })}
 			onClick={this.props.onToggle}>
 			<i className='fa fa-bars' />
-		</div>
+		</div>;
 	},
 
 	render : function(){

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -12,15 +12,14 @@ const execute = function(val, brew){
 	return val;
 };
 
-
-
 const Snippetbar = createClass({
 	getDefaultProps : function() {
 		return {
 			brew     : '',
 			onInject : ()=>{},
 			onToggle : ()=>{},
-			showmeta : false
+			showmeta : false,
+			showMetaButton : true
 		};
 	},
 
@@ -41,13 +40,18 @@ const Snippetbar = createClass({
 		});
 	},
 
+	renderMetadataButton : function(){
+		if(!this.props.showMetaButton) return;
+		return <div className={cx('toggleMeta', { selected: this.props.showmeta })}
+			onClick={this.props.onToggle}>
+			<i className='fa fa-bars' />
+		</div>
+	},
+
 	render : function(){
 		return <div className='snippetBar'>
 			{this.renderSnippetGroups()}
-			<div className={cx('toggleMeta', { selected: this.props.showmeta })}
-				onClick={this.props.onToggle}>
-				<i className='fa fa-bars' />
-			</div>
+			{this.renderMetadataButton()}
 		</div>;
 	}
 });

--- a/client/homebrew/pages/homePage/homePage.jsx
+++ b/client/homebrew/pages/homePage/homePage.jsx
@@ -77,7 +77,7 @@ const HomePage = createClass({
 
 			<div className='content'>
 				<SplitPane onDragFinish={this.handleSplitMove} ref='pane'>
-					<Editor value={this.state.text} onChange={this.handleTextChange} ref='editor'/>
+					<Editor value={this.state.text} onChange={this.handleTextChange} showMetaButton={false} ref='editor'/>
 					<BrewRenderer text={this.state.text} />
 				</SplitPane>
 			</div>


### PR DESCRIPTION
The Homepage is intended as a playground for users, but does not actually save the brew unless the user deliberately clicks the "save current" button. This avoids generating tons of "test" brews with no author, but allows users to get a feel for the site without needing to worry about signing in or committing to a document.

We are removing the "metadata" tag from this home page for two purposes:

1) Make it more clear that the Homepage is meant as a sandbox to test out the site, not a real brew that will be saved.
2) Also, avoid errors resulting from trying to modify the metadata of a brew that doesn't really exist yet.