### PR TITLE
Small bug causing crashes with Tags

### DIFF
--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -73,8 +73,6 @@ GoogleActions = {
 				console.error(err);
 			});
 
-			console.log('created new drive folder with ID:');
-			console.log(obj.data.id);
 			folderId = obj.data.id;
 		} else {
 			folderId = obj.data.files[0].id;
@@ -149,13 +147,7 @@ GoogleActions = {
 	updateGoogleBrew : async (auth, brew)=>{
 		const drive = google.drive({ version: 'v3', auth: auth });
 
-		console.log('trying to update a brew');
-		console.log(brew);
-
 		if(await GoogleActions.existsGoogleBrew(auth, brew.googleId) == true) {
-			console.log('the brew exists at least');
-			console.log('going to put this text:');
-			console.log(brew.text);
 			await drive.files.update({
 				fileId   : brew.googleId,
 				resource : { name        : `${brew.title}.txt`,
@@ -282,7 +274,7 @@ GoogleActions = {
 				text    : file.data,
 
 				description : obj.data.description,
-				tags        : obj.data.properties.tags    ? obj.data.properties.tags.split(',')    : [],
+				tags        : obj.data.properties.tags    ? obj.data.properties.tags               : '',
 				systems     : obj.data.properties.systems ? obj.data.properties.systems.split(',') : [],
 				authors     : [],
 				published   : obj.data.properties.published ? obj.data.properties.published == 'true' : false,
@@ -323,8 +315,9 @@ GoogleActions = {
 			throw ('Not authorized to delete this Google brew');
 		}
 
-		await drive.files.delete({
-			fileId : googleId
+		await drive.files.update({
+			fileId   : googleId,
+			resource : { trashed: true }
 		})
 		.catch((err)=>{
 			console.log('Can\'t delete Google file');


### PR DESCRIPTION
Also: Force Google to always send to trash instead of fully deleting.

Remove unneeded console.logs to speed up server.