### PR TITLE
FreeBSD installation

### DIFF
--- a/README.FREEBSD.md
+++ b/README.FREEBSD.md
@@ -1,0 +1,35 @@
+# FreeBSD/FreeNAS Installation Instructions
+
+## Before Installing
+
+These instructions assume that you are installing to a completely new, fresh FreeBSD/FreeNAS jail. As such, some steps will not be necessary if you are installing to an existing FreeBSD/FreeNAS install.
+
+## Installation instructions
+
+1. Create a new jail, with the appropriate network settings to access the internet.
+
+2. Install wget (`pkg install -y wget`). On a fresh jail, you will be prompted to press 'Y' to set up `pkg`.
+
+3. Download the installation script (`wget --no-check-certificate https://raw.githubusercontent.com/naturalcrit/homebrewery/master/freebsd/install.sh`). The parameter `--no-check-certificate` is required as we haven't set up any trusted certificates/authorities yet.
+
+4. Make the downloaded file executable (`chmod +x install.sh`).
+
+5. Run the script (`./install.sh`). This will automatically download all of the required packages, install both them and HomeBrewery, configure the system and finally start HomeBrewery.
+
+**NOTE:** At this time, the script **ONLY** installs HomeBrewery. It does **NOT** install the NaturalCrit login system, as that is currently a completely separate project.
+
+---
+
+### Testing
+
+These installation instructions have been tested on the following FreeBSD/FreeNAS platforms:
+
+* FreeNAS-11.3-U5; Jail 11.4-RELEASE-p2
+
+## Final Notes
+
+While this installation process works successfully at the time of writing (December 28, 2020), it relies on all of the Node.JS packages used in the HomeBrewery project retaining their cross-platform capabilities to continue to function under FreeBSD. This is one of the inherent advantages of Node.JS, but it is by no means guaranteed and as such, functionality or even installation under FreeBSD may fail without warning at some point in the future.
+
+Regards,  
+G  
+December 28, 2020

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ You should now be able to go to [http://localhost:8000](http://localhost:8000) i
 
 Please see the docs here: [README.DOCKER.md](./README.DOCKER.md)
 
+### Running the application on FreeBSD or FreeNAS
+
+Please see the docs here: [README.FreeBSD.md](./README.FREEBSD.md)
+
 ### Standalone PHB Stylesheet
 If you just want the stylesheet that is generated to make pages look like they are from the Player's Handbook, you will find it in the [phb.standalone.css](./phb.standalone.css) file.
 

--- a/config/default.json
+++ b/config/default.json
@@ -2,5 +2,5 @@
 	"host" : "homebrewery.local.naturalcrit.com:8000",
 	"naturalcrit_url" : "local.naturalcrit.com:8010",
 	"secret" : "secret",
-	"web_port" : 8001,
+	"web_port" : 8000
 }

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,7 @@
 {
 	"host" : "homebrewery.local.naturalcrit.com:8000",
 	"naturalcrit_url" : "local.naturalcrit.com:8010",
-	"secret" : "secret"
+	"secret" : "secret",
+	"web_port" : 8001,
+	"environment" : "local"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -3,5 +3,4 @@
 	"naturalcrit_url" : "local.naturalcrit.com:8010",
 	"secret" : "secret",
 	"web_port" : 8001,
-	"environment" : "local"
 }

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -16,5 +16,5 @@ npm run postinstall
 cp freebsd/rc.d/homebrewery /etc/rc.d/
 chmod +x /etc/rc.d/homebrewery
 
-sysrc homebrewery=YES
+sysrc homebrewery_enable=YES
 service homebrewery start

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -5,7 +5,7 @@ pkg install -y git nano node npm mongodb44-4.4.1
 sysrc mongod_enable=YES
 service mongod start
 
-cd /
+cd /usr/local/
 git clone https://github.com/naturalcrit/homebrewery.git
 
 cd homebrewery

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -6,7 +6,7 @@ sysrc mongod_enable=YES
 service mongod start
 
 cd /
-git clone https://github.com/G-Ambatte/homebrewery.git
+git clone https://github.com/naturalcrit/homebrewery.git
 
 cd homebrewery
 npm install

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -10,7 +10,7 @@ git clone https://github.com/G-Ambatte/homebrewery.git
 
 cd homebrewery
 npm install
-npm audit fix -force
+npm audit fix
 npm run postinstall
 
 cp freebsd/rc.d/homebrewery /etc/rc.d/

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-pkg install -y git nano node npm mongodb44-4.4.1
+pkg install -y git nano node npm mongodb44
 
 sysrc mongod_enable=YES
 service mongod start
@@ -13,8 +13,8 @@ npm install
 npm audit fix
 npm run postinstall
 
-cp freebsd/rc.d/homebrewery /etc/rc.d/
-chmod +x /etc/rc.d/homebrewery
+cp freebsd/rc.d/homebrewery /usr/local/etc/rc.d/
+chmod +x /usr/local/etc/rc.d/homebrewery
 
 sysrc homebrewery_enable=YES
 service homebrewery start

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-pkg install -y git nano node npm mongodb36-3.6.20
+pkg install -y git nano node npm mongodb44-4.4.1
 
 sysrc mongod_enable=YES
 service mongod start

--- a/freebsd/install.sh
+++ b/freebsd/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+pkg install -y git nano node npm mongodb36-3.6.20
+
+sysrc mongod_enable=YES
+service mongod start
+
+cd /
+git clone https://github.com/G-Ambatte/homebrewery.git
+
+cd homebrewery
+npm install
+npm audit fix -force
+npm run postinstall
+
+cp freebsd/rc.d/homebrewery /etc/rc.d/
+chmod +x /etc/rc.d/homebrewery
+
+sysrc homebrewery=YES
+service homebrewery start

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -35,8 +35,6 @@ pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep
 
 # Env Setup
 export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
-export NODE_ENV="local"
-export PORT=8001
 
 # Command Setup
 exec_cmd="/homebrewery/server.js" 		# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -37,7 +37,7 @@ pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep
 # Env Setup
 export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
 export NODE_ENV="local"
-export PORT=8001
+export PORT=8000
 
 # Command Setup
 exec_cmd="${location}/${program_name}/server.js" 	# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -29,6 +29,8 @@ title="HomeBrewery"           # Title to display in top/htop
 load_rc_config $name      # Loading rc config vars
 : ${homebrewery_enable="NO"}  # Default: Do not enable HomeBrewery
 : ${homebrewery_runAs="root"} # Default: Run HomeBrewery as root
+: ${homebrewery_port=8000}    # Default: Run HomeBrewery on port 8000
+: ${homebrewery_NODE_ENV="local"}  # Default: Run HomeBrewery in local mode
 
 # Freebsd Setup
 rcvar=homebrewery_enable                   # Enables the rc.conf YES/NO flag
@@ -36,8 +38,8 @@ pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep
 
 # Env Setup
 export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
-export NODE_ENV="local"
-export PORT=8000
+export NODE_ENV=${homebrewery_NODE_ENV}
+export PORT=${homebrewery_port}
 
 # Command Setup
 exec_cmd="${location}/${program_name}/server.js" 	# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -1,0 +1,51 @@
+#!/bin/sh
+#
+# PROVIDE: homebrewery
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+# Author: S Robertson
+# Version: 1.0.0
+
+# Description:
+#    This script runs HomeBrewery as a service under the supplied user on boot
+
+# How to use:
+#    Place this file in /usr/local/etc/rc.d/
+#    Add homebrewery_enable="YES" to /etc/rc.config
+#    (Optional) To run as non-root, add homebrewery_runAs="homebrewery" to /etc/rc.config
+#    (Optional) To pass HomeBrewery args, add homebrewery_args="" to /etc/rc.config
+
+# Freebsd rc library
+. /etc/rc.subr
+
+# General Info
+name="homebrewery"            # Safe name of program
+program_name="homebrewery"    # Name of exec
+title="HomeBrewery"           # Title to display in top/htop
+
+# RC.config vars
+load_rc_config $name      # Loading rc config vars
+: ${homebrewery_enable="NO"}  # Default: Do not enable HomeBrewery
+: ${homebrewery_runAs="root"} # Default: Run HomeBrewery as root
+
+# Freebsd Setup
+rcvar=homebrewery_enable                   # Enables the rc.conf YES/NO flag
+pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep track of HomeBrewery status
+
+# Env Setup
+export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
+export NODE_ENV="local"
+export PORT=8001
+
+# Command Setup
+exec_cmd="/homebrewery/server.js" 		# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally
+output_file="/var/log/${program_name}.log" 	# Path to HomeBrewery output file
+
+# Command
+command="/usr/sbin/daemon"
+command_args="-r -t ${title} -u ${homebrewery_runAs} -o ${output_file} -P ${pidfile} /usr/local/bin/node ${exec_cmd} ${homebrewery_args}"
+
+# Loading Config
+load_rc_config ${name}
+run_rc_command "$1"

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -21,6 +21,7 @@
 
 # General Info
 name="homebrewery"            # Safe name of program
+location="/usr/local/"	      # Install location
 program_name="homebrewery"    # Name of exec
 title="HomeBrewery"           # Title to display in top/htop
 
@@ -37,12 +38,23 @@ pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep
 export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
 
 # Command Setup
-exec_cmd="/usr/local/homebrewery/server.js" 		# Path to the HomeBrewery server.js
-output_file="/var/log/${program_name}.log" 			# Path to HomeBrewery output file
+exec_cmd="${location}/${program_name}/server.js" 	# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally
+output_file="/var/log/${program_name}.log" 		# Path to HomeBrewery output file
 
 # Command
 command="/usr/sbin/daemon"
 command_args="-r -t ${title} -u ${homebrewery_runAs} -o ${output_file} -P ${pidfile} /usr/local/bin/node ${exec_cmd} ${homebrewery_args}"
+
+# Extra Commands
+extra_commands="dev_mode"
+
+dev_mode_cmd="homebrewery_dev_mode"
+
+homebrewery_dev_mode() {
+echo "Starting HomeBrewery in live rebuild Developer mode..."
+cd ${location}/${program_name}/
+/usr/local/bin/node ${location}/${program_name}/scripts/buildHomebrew.js --dev
+}
 
 # Loading Config
 load_rc_config ${name}

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -36,6 +36,8 @@ pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep
 
 # Env Setup
 export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
+export NODE_ENV="local"
+export PORT=8001
 
 # Command Setup
 exec_cmd="${location}/${program_name}/server.js" 	# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally

--- a/freebsd/rc.d/homebrewery
+++ b/freebsd/rc.d/homebrewery
@@ -37,8 +37,8 @@ pidfile="/var/run/${program_name}.pid" 	   # File that allows the system to keep
 export HOME=$( getent passwd "homebrewery_runAs" | cut -d: -f6 ) # Gets the home directory of the runAs user
 
 # Command Setup
-exec_cmd="/homebrewery/server.js" 		# Path to the HomeBrewery server.js, /usr/local/bin/ when installed globally
-output_file="/var/log/${program_name}.log" 	# Path to HomeBrewery output file
+exec_cmd="/usr/local/homebrewery/server.js" 		# Path to the HomeBrewery server.js
+output_file="/var/log/${program_name}.log" 			# Path to HomeBrewery output file
 
 # Command
 command="/usr/sbin/daemon"

--- a/server.js
+++ b/server.js
@@ -27,6 +27,11 @@ const config = require('nconf')
 	.file('environment', { file: `config/${process.env.NODE_ENV}.json` })
 	.file('defaults', { file: 'config/default.json' });
 
+if ( !process.env.NODE_ENV && config.get('environment') ) {
+	process.env.NODE_ENV = config.get('environment');
+	console.log('NODE_ENV set from config')
+}
+
 //DB
 const mongoose = require('mongoose');
 mongoose.connect(config.get('mongodb_uri') || config.get('mongolab_uri') || 'mongodb://localhost/naturalcrit',
@@ -232,6 +237,6 @@ app.use((req, res)=>{
 });
 
 
-const PORT = process.env.PORT || 8000;
+const PORT = process.env.PORT || config.get('web_port') || 8000;
 app.listen(PORT);
 console.log(`server on port:${PORT}`);

--- a/server.js
+++ b/server.js
@@ -27,15 +27,7 @@ const config = require('nconf')
 	.file('environment', { file: `config/${process.env.NODE_ENV}.json` })
 	.file('defaults', { file: 'config/default.json' });
 
-if ( !process.env.NODE_ENV) {
-	if ( config.get('environment') ) {
-		process.env.NODE_ENV = config.get('environment');
-		console.log('NODE_ENV set from config');
-	} else {
-		process.env.NODE_ENV = 'local';
-		console.log('NODE_ENV set to "local" as no other values were set');
-	}
-}
+if(!process.env.NODE_ENV) { process.env.NODE_ENV = ( config.get('environment') || 'local' ); }
 
 //DB
 const mongoose = require('mongoose');

--- a/server.js
+++ b/server.js
@@ -27,9 +27,14 @@ const config = require('nconf')
 	.file('environment', { file: `config/${process.env.NODE_ENV}.json` })
 	.file('defaults', { file: 'config/default.json' });
 
-if ( !process.env.NODE_ENV && config.get('environment') ) {
-	process.env.NODE_ENV = config.get('environment');
-	console.log('NODE_ENV set from config')
+if ( !process.env.NODE_ENV) {
+	if ( config.get('environment') ) {
+		process.env.NODE_ENV = config.get('environment');
+		console.log('NODE_ENV set from config');
+	} else {
+		process.env.NODE_ENV = 'local';
+		console.log('NODE_ENV set to "local" as no other values were set');
+	}
 }
 
 //DB

--- a/server.js
+++ b/server.js
@@ -27,8 +27,6 @@ const config = require('nconf')
 	.file('environment', { file: `config/${process.env.NODE_ENV}.json` })
 	.file('defaults', { file: 'config/default.json' });
 
-if(!process.env.NODE_ENV) {process.env.NODE_ENV = (config.get('environment') || 'local');}
-
 //DB
 const mongoose = require('mongoose');
 mongoose.connect(config.get('mongodb_uri') || config.get('mongolab_uri') || 'mongodb://localhost/naturalcrit',

--- a/server.js
+++ b/server.js
@@ -27,7 +27,7 @@ const config = require('nconf')
 	.file('environment', { file: `config/${process.env.NODE_ENV}.json` })
 	.file('defaults', { file: 'config/default.json' });
 
-if(!process.env.NODE_ENV) { process.env.NODE_ENV = ( config.get('environment') || 'local' ); }
+if(!process.env.NODE_ENV) {process.env.NODE_ENV = (config.get('environment') || 'local');}
 
 //DB
 const mongoose = require('mongoose');

--- a/server.js
+++ b/server.js
@@ -14,6 +14,8 @@ app.use('/', expressStaticGzip(`${__dirname}/build`, {
 	index           : false
 }));
 
+process.chdir(__dirname);
+
 //app.use(express.static(`${__dirname}/build`));
 app.use(require('body-parser').json({ limit: '25mb' }));
 app.use(require('cookie-parser')());


### PR DESCRIPTION
# Installation in a FreeBSD/FreeNAS Jail

## Purpose

The purpose of this branch is to allow simplified installation of the Homebrewery project in a FreeBSD or FreeNAS jail. This is currently not possible as Docker is currently broken on FreeBSD and has been for some 15+ months, so the provided Dockerfiles do not allow the project to run.

### Work Completed So Far

- Get Homebrewery installed and working on a FreeBSD jail - **COMPLETE**  
- Determine minimum viable package (MVP) installation required for previous step - **COMPLETE**
- Script installation of MVP - **COMPLETE**
- Test with multiple available versions of MongoDB - **COMPLETE**
- Create rc.d files to run Homebrewery as a service, supporting service commands "start", "stop", and "restart" - **COMPLETE**
- Script installation of Homebrewery as a service - **COMPLETE**
- Parameterize configuration options NODE_ENV and PORT - **COMPLETE**
- Eliminate requirement for the current working directory to contain the **server.js** script - **COMPLETE**

### Future Improvements/In Development

- Add custom command "devmode" to service options to start in development auto-rebuild mode
- Write FreeBSD install documentation and add to repository - **IN PROGRESS** (see [instructions here](https://www.reddit.com/r/homebrewery/comments/k7rcfs/homebrewery_in_a_freenasbsd_jail_part_2))

## Integration Considerations

### FreeBSD/Install.sh

This script currently clones from my fork (https://github.com/G-Ambatte/homebrewery.git) rather than the master project. This will need to be corrected during the integration process.
The script also currently clones the project into a new "homebrewery" folder in the root directory; whereas another location may be deemed to be more appropriate (i.e. "/usr/local/etc/homebrewery"). This will have flow on effects to the **freebsd/rc.d/homebrewery** file.

Finally, this script runs the command `npm audit fix -force`, which updates and corrects any security issues with the NPM modules. However the inclusion of the `-force` parameter allows the installation of potentially breaking changes to the required packages, and while this has not caused any issues to date, the `-force` parameter should be removed from the default installation script before wider promulgation, in order to reduce the potential for future issues.

### FreeBSD/RC.D/HomeBrewery

If the install directory for Homebrewery is changed, the "exec_cmd" will need to be changed to the new location of the "server.js" file.

## Modified Files and Rationale

### Server.js

- As the service starts the command from an as yet undetermined working directory, Homebrewery would immediately crash due to files being unable to be found. The addition of `process.chdir(__dirname);` towards the start of the "server.js" file changes the current working directory of the calling thread to the directory containing the script, eliminating this as a source of issues.
- Attempting to set the NODE_ENV environment variable prior to running the command "node server.js" was possible but not particularly clean, especially when writing the command into the script. Instead, I pushed this value into the **config/default.json** file as the key pair "environment", with a hard-coded default value of "local" if it is not set via environment variable or in the default configuration file.
- Similar arguments can be made of the PORT environment variable, so I pushed this to **config/default.json** as the key pair "web_port". Again, if not set via environment variable or default configuration, it reverts to the hard-coded value of "8000".

### Config/Default.json

New key pairs "environment" and "web_port" were added to support the changes as previously discussed in **server.js**.

## Conclusion

I hope that I have managed to lay out a clear and concise description of the changes made and the reasoning behind them in order to simplify the process of installing Homebrewery in a FreeBSD jail.

I look forward to receiving any feedback that you might have.
-- G