### PR TITLE
Fix Footer Issues after inserting a cover page

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/coverpage.gen.js
+++ b/client/homebrew/editor/snippetbar/snippets/coverpage.gen.js
@@ -102,6 +102,13 @@ module.exports = ()=>{
 	return `<style>
   .phb#p1{ text-align:center; }
   .phb#p1:after{ display:none; }
+  .phb#p2 { counter-reset:phb-page-numbers; }
+  .phb:nth-child(2n) .pageNumber { left: inherit !important; right: 2px !important; }
+  .phb:nth-child(2n+1) .pageNumber { right: inherit !important; left: 2px !important; }
+  .phb:nth-child(2n)::after { transform: scaleX(1); }
+  .phb:nth-child(2n+1)::after { transform: scaleX(-1); }
+  .phb:nth-child(2n) .footnote { left: inherit; text-align: right; }
+  .phb:nth-child(2n+1) .footnote { left: 80px; text-align: left; }
 </style>
 
 <div style='margin-top:450px;'></div>


### PR DESCRIPTION
# Footer Issues After Inserting a Cover Page

## Purpose

The purpose of this PR is to fix the issues that arise with footer graphics, footnotes, and automatic page numbers after inserting a cover page, as reported in [this Reddit post.](https://redd.it/kncoe7)

### Work Completed So Far

- [x] Craft `<style>` that resolves issues - **COMPLETE**
- [x] Incorporate into Cover Page snippet script - **COMPLETE**

### Future Improvements/In Development

- [ ] Identify any other snippets that insert a `\page` as they may suffer from the same issue

## Modified Files and Rationale

### CoverPage.gen.js

I have inserted the additional styling into the script between the existing `<style>` tags so that the fix will be applied at the time that the cover page snippet is inserted.

## Conclusion

As always, I look forward to receiving any feedback that you might have.  
-- G