### PR TITLE
Fix for box-shadow/border-image issues on blockquotes in new columns

### DIFF
--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -189,6 +189,7 @@ body {
 		border-image        : @noteBorderImage 11;
 		border-image-outset : 9px 0px;
 		box-shadow          : 1px 4px 14px #888;
+		transform           : translateZ(0);
 		p, ul{
 			font-size   : 0.352cm;
 			line-height : 1.1em;

--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -189,7 +189,7 @@ body {
 		border-image        : @noteBorderImage 11;
 		border-image-outset : 9px 0px;
 		box-shadow          : 1px 4px 14px #888;
-		transform           : translateZ(0);
+		-webkit-transform           : translateZ(0);
 		p, ul{
 			font-size   : 0.352cm;
 			line-height : 1.1em;

--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -189,7 +189,7 @@ body {
 		border-image        : @noteBorderImage 11;
 		border-image-outset : 9px 0px;
 		box-shadow          : 1px 4px 14px #888;
-		-webkit-transform           : translateZ(0);
+		-webkit-transform   : translateZ(0); //Prevents shadows from breaking across columns
 		p, ul{
 			font-size   : 0.352cm;
 			line-height : 1.1em;


### PR DESCRIPTION
As per issue reported on Reddit [here](https://redd.it/kpcbw6), with the fix found by /u/alexey152.

I was able to replicate the issue in Chrome and Edge, but not Firefox.  
I have confirmed that this change fixes the issue in both Chrome and Edge.