### PR TITLE
(WIP) Filter brews on User page by tagged system

### DIFF
--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -90,6 +90,7 @@ const BrewItem = createClass({
 		const brew = this.props.brew;
 		return <div className='brewItem'>
 			<h2>{brew.title}</h2>
+			<h5>Systems: {brew.systems}</h5>
 			<p className='description' >{brew.description}</p>
 			<hr />
 

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -89,9 +89,12 @@ const BrewItem = createClass({
 	render : function(){
 		const brew = this.props.brew;
 		
+		let systemsText = 'Uncategorized';
+		if(this.props.brew.systems.length > 0) { systemsText = this.props.brew.systems.toString(); }
+		
 		return <div className='brewItem'>
 			<h2>{brew.title}</h2>
-			<h5>Systems:- {this.props.brew.systems.toString()}</h5>
+			<h5>Systems:- {systemsText}</h5>
 			<p className='description' >{brew.description}</p>
 			<hr />
 

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -88,9 +88,10 @@ const BrewItem = createClass({
 
 	render : function(){
 		const brew = this.props.brew;
+		
 		return <div className='brewItem'>
 			<h2>{brew.title}</h2>
-			<h5>Systems: {brew.systems}</h5>
+			<h5>Systems:- {this.props.brew.systems.toString()}</h5>
 			<p className='description' >{brew.description}</p>
 			<hr />
 

--- a/client/homebrew/pages/userPage/userPage.jsx
+++ b/client/homebrew/pages/userPage/userPage.jsx
@@ -62,10 +62,18 @@ const UserPage = createClass({
 			<div className='content'>
 				<div className='phb'>
 					<div>
+						<table className='systemFilter'>
+							<tr>
+								<td><a href={`/user/${this.props.username}`}>All</a></td>
+								<td><a href={`/user/${this.props.username}/3.5e`}>3.5E</a></td>
+								<td><a href={`/user/${this.props.username}/4e`}>4E</a></td>
+								<td><a href={`/user/${this.props.username}/5e`}>5E</a></td>
+							</tr>
+						</table>
+						<br />
 						<h1>{this.getUsernameWithS()} brews</h1>
 						{this.renderBrews(brews.published)}
-					</div>
-					<div>
+						<br />
 						<h1>{this.getUsernameWithS()} unpublished brews</h1>
 						{this.renderBrews(brews.private)}
 					</div>

--- a/client/homebrew/pages/userPage/userPage.less
+++ b/client/homebrew/pages/userPage/userPage.less
@@ -27,7 +27,19 @@
 				font-size  : 1.3em;
 				font-style : italic;
 			}
-
+			.systemFilter{
+				border-bottom	: 2px solid #58180D;
+				color			: #58180D;
+				font-family		: 'Open Sans';
+				font-size		: 2em;
+				padding			: 10px;
+			}
+			.systemFilter td{
+				width			: 15%;
+				text-align		: center;
+				padding			: 10px;
+				border			: none;
+			}
 		}
 	}
 }

--- a/config/googleTemplate.json
+++ b/config/googleTemplate.json
@@ -1,0 +1,9 @@
+{
+	"google_api_key" : "XYZ",
+	"google_client_id" : "XYZ.apps.googleusercontent.com",
+	"google_client_secret" : "XYZ",
+	"authentication_token_issuer" : "your-app-name",
+	"authentication_token_secret" : "your-app-secret",
+	"authentication_token_audience" : "your-app-name",
+	"service_account" : "your-app-service-account"
+}

--- a/server.js
+++ b/server.js
@@ -100,18 +100,17 @@ app.get('/source/:id', (req, res)=>{
 app.get('/user/:username/:system?', async (req, res, next)=>{
 	const fullAccess = req.account && (req.account.username == req.params.username);
 
-	let googleBrews = [];
-
-	if(req.account && req.account.googleId){
-		googleBrews = await GoogleActions.listGoogleBrews(req, res)
-		.catch((err)=>{
-			console.error(err);
-		});
-	}
-
 	let systems = {};
 	if(req.params.system) {
 		systems = (req.params.system).toLowerCase().split(',');
+	}
+
+	let googleBrews = [];
+	if(req.account && req.account.googleId){
+		googleBrews = await GoogleActions.listGoogleBrews(req, res, systems)
+		.catch((err)=>{
+			console.error(err);
+		});
 	}
 
 	const brews = await HomebrewModel.getByUser(req.params.username, fullAccess, systems)

--- a/server.js
+++ b/server.js
@@ -111,7 +111,7 @@ app.get('/user/:username/:system?', async (req, res, next)=>{
 
 	let systems = {};
 	if(req.params.system) {
-		systems = (req.params.system).split(',');
+		systems = (req.params.system).toLowerCase().split(',');
 	}
 
 	const brews = await HomebrewModel.getByUser(req.params.username, fullAccess, systems)

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+/*eslint max-lines: ["warn", {"max": 250, "skipBlankLines": true, "skipComments": true}]*/
 const _ = require('lodash');
 const jwt = require('jwt-simple');
 const expressStaticGzip = require('express-static-gzip');
@@ -96,7 +97,7 @@ app.get('/source/:id', (req, res)=>{
 });
 
 //User Page
-app.get('/user/:username', async (req, res, next)=>{
+app.get('/user/:username/:system?', async (req, res, next)=>{
 	const fullAccess = req.account && (req.account.username == req.params.username);
 
 	let googleBrews = [];
@@ -108,7 +109,12 @@ app.get('/user/:username', async (req, res, next)=>{
 		});
 	}
 
-	const brews = await HomebrewModel.getByUser(req.params.username, fullAccess)
+	let systems = {};
+	if(req.params.system) {
+		systems = (req.params.system).split(',');
+	}
+
+	const brews = await HomebrewModel.getByUser(req.params.username, fullAccess, systems)
 	.catch((err)=>{
 		console.log(err);
 	});

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -125,11 +125,11 @@ GoogleActions = {
 	      systems     : file.properties.systems
 	    };
 	  });
-	  
+
 	  console.log('Filtering Google Brews...');
 	  console.log(systemFilter);
 	  if(!systemFilter && !systemFilter.length) {
-		  brews.systems = brews.systems.filter(sys => systemFilter.includes(sys));
+		  brews.systems = brews.systems.filter((sys)=>systemFilter.includes(sys));
 	  }
 
 	  return brews;

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -244,7 +244,8 @@ GoogleActions = {
 	},
 
 	readFileMetadata : async (auth, id, accessId, accessType)=>{
-		const drive = google.drive({ version: 'v3', auth: auth });
+		oAuth2Client = GoogleActions.authCheck(req.account, res);
+		const drive = google.drive({ version: 'v3', auth: oAuth2Client });
 
 		const obj = await drive.files.get({
 			fileId : id,

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -81,7 +81,7 @@ GoogleActions = {
 		return folderId;
 	},
 
-	listGoogleBrews : async (req, res)=>{
+	listGoogleBrews : async (req, res, systemFilter=false)=>{
 
 		oAuth2Client = GoogleActions.authCheck(req.account, res);
 
@@ -122,9 +122,15 @@ GoogleActions = {
 	      tags        : '',
 	      published   : file.properties.published ? file.properties.published == 'true' : false,
 	      authors     : [req.account.username],	//TODO: properly save and load authors to google drive
-	      systems     : []
+	      systems     : file.properties.systems
 	    };
 	  });
+	  
+	  console.log('Filtering Google Brews...');
+	  console.log(systemFilter);
+	  if(!systemFilter && !systemFilter.length) {
+		  brews.systems = brews.systems.filter(sys => systemFilter.includes(sys));
+	  }
 
 	  return brews;
 	},

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -262,7 +262,15 @@ GoogleActions = {
 			}
 
 			//Access actual file with service account. Just api key is causing "automated query" errors.
-			const keys = JSON.parse(config.get('service_account'));
+			//console.log(config.get('service_account'));
+			//const keys = JSON.parse(config.get('service_account'));
+			
+			const actionList = {
+				"string" : function() { return JSON.parse(config.get('service_account')); },
+				"object" : function() { return config.get('service_account') }
+			}
+			const keys = actionList[typeof(config.get('service_account'))]();
+			
 			const serviceAuth = google.auth.fromJSON(keys);
 			serviceAuth.scopes = ['https://www.googleapis.com/auth/drive'];
 
@@ -361,5 +369,6 @@ GoogleActions = {
 		return;
 	}
 };
+
 
 module.exports = GoogleActions;

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -106,7 +106,7 @@ GoogleActions = {
 	    console.log('No files found.');
 	  }
 
-		const brews = obj.data.files.map((file)=>{
+		let brews = obj.data.files.map((file)=>{
 	    return {
 	      text      : '',
 	      shareId   : file.properties.shareId,
@@ -126,10 +126,8 @@ GoogleActions = {
 	    };
 	  });
 
-	  console.log('Filtering Google Brews...');
-	  console.log(systemFilter);
-	  if(!systemFilter && !systemFilter.length) {
-		  brews.systems = brews.systems.filter((sys)=>systemFilter.includes(sys));
+	  if(systemFilter && systemFilter.length) {
+		  brews = brews.filter((_brew)=> systemFilter.includes(_brew.systems));
 	  }
 
 	  return brews;
@@ -164,7 +162,7 @@ GoogleActions = {
 																	  views      : brew.views,
 																	  version    : brew.version,
 																	  tags       : brew.tags,
-																	  systems    : brew.systems.join() }
+																	  systems    : brew.systems.join(',') }
 									 },
 				media : { mimeType : 'text/plain',
 										 body     : brew.text }
@@ -236,16 +234,15 @@ GoogleActions = {
 			description : brew.description,
 			tags        : '',
 			published   : brew.published,
-			authors     : [],
-			systems     : []
+			authors     : brew.authors.join(','),
+			systems     : brew.systems.join(',')
 		};
 
 		return newHomebrew;
 	},
 
 	readFileMetadata : async (auth, id, accessId, accessType)=>{
-		oAuth2Client = GoogleActions.authCheck(req.account, res);
-		const drive = google.drive({ version: 'v3', auth: oAuth2Client });
+		const drive = google.drive({ version: 'v3', auth: auth });
 
 		const obj = await drive.files.get({
 			fileId : id,
@@ -290,7 +287,7 @@ GoogleActions = {
 				description : obj.data.description,
 				tags        : obj.data.properties.tags    ? obj.data.properties.tags               : '',
 				systems     : obj.data.properties.systems ? obj.data.properties.systems.split(',') : [],
-				authors     : [],
+				authors     : obj.data.properties.authors ? obj.data.properties.authors.split(',') : [],
 				published   : obj.data.properties.published ? obj.data.properties.published == 'true' : false,
 
 				createdAt  : obj.data.createdTime,

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -122,7 +122,7 @@ GoogleActions = {
 	      tags        : '',
 	      published   : file.properties.published ? file.properties.published == 'true' : false,
 	      authors     : [req.account.username],	//TODO: properly save and load authors to google drive
-	      systems     : file.properties.systems
+	      systems     : file.properties.systems.split(',').sort()
 	    };
 	  });
 
@@ -294,8 +294,8 @@ GoogleActions = {
 
 				description : obj.data.description,
 				tags        : obj.data.properties.tags    ? obj.data.properties.tags               : '',
-				systems     : obj.data.properties.systems ? obj.data.properties.systems.split(',') : [],
-				authors     : obj.data.properties.authors ? obj.data.properties.authors.split(',') : [],
+				systems     : obj.data.properties.systems ? obj.data.properties.systems.split(',').sort() : [],
+				authors     : obj.data.properties.authors ? obj.data.properties.authors.split(',').sort() : [],
 				published   : obj.data.properties.published ? obj.data.properties.published == 'true' : false,
 
 				createdAt  : obj.data.createdTime,

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -60,7 +60,7 @@ HomebrewSchema.statics.get = function(query){
 	});
 };
 
-HomebrewSchema.statics.getByUser = function(username, allowAccess=false, systemFilter){
+HomebrewSchema.statics.getByUser = function(username, allowAccess=false, systemFilter=false){
 	return new Promise((resolve, reject)=>{
 		const query = { authors: username, published: true, systems: { $in: systemFilter } };
 

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -60,14 +60,19 @@ HomebrewSchema.statics.get = function(query){
 	});
 };
 
-HomebrewSchema.statics.getByUser = function(username, allowAccess=false){
+HomebrewSchema.statics.getByUser = function(username, allowAccess=false, systemFilter){
 	return new Promise((resolve, reject)=>{
-		const query = { authors: username, published: true };
+		const query = { authors: username, published: true, systems: { $in: systemFilter } };
+
+		if(!systemFilter || !systemFilter.length) {
+			delete query.systems;
+		}
 		if(allowAccess){
 			delete query.published;
 		}
+
 		Homebrew.find(query, (err, brews)=>{
-			if(err) return reject('Can not find brew');
+			if(err) return reject('No brews found!');
 			return resolve(_.map(brews, (brew)=>{
 				return brew.sanatize(!allowAccess);
 			}));


### PR DESCRIPTION
Adds optional `system` ID to User page; this is a comma separated list which is compared to the `systems` array in the HomebrewModel, returning all brews (that the logged in user is permitted to see) that match any item in the list,

Examples:  
- `/user/test_user` returns all brews authored by `test_user`, exactly as per the current functionality
- `/user/test_user/5e` returns only the brews flagged for the 5E system authored by `test_user`
- `/user/test_user/4e,5e` returns any brews flagged for 4E or 5E, authored by `test_user`

---

Currently, this functionality is only working for non-Google brews - `GoogleActions.js` and calls to that module have not yet been altered.

As always, any feedback/discussion is appreciated.