### PR TITLE
Fix title issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
 	root          : true,
 	parserOptions : {
-		ecmaVersion  : 9,
+		ecmaVersion  : 2021,
 		sourceType   : 'module',
 		ecmaFeatures : {
 			jsx : true

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -15,7 +15,10 @@ const MAX_TITLE_LENGTH = 100;
 
 const getGoodBrewTitle = (text)=>{
 	const tokens = Markdown.marked.lexer(text);
- 	const title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text.substr(0,MAX_TITLE_LENGTH);
+ 	let title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text;
+	if(title.length > MAX_TITLE_LENGTH) {
+		title = title.substr(0, MAX_TITLE_LENGTH);
+	}
 	return title;
 };
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -128,6 +128,8 @@ const newGoogleBrew = async (req, res, next)=>{
 
 	req.body = brew;
 
+	console.log(oAuth2Client);
+
 	const newBrew = await GoogleActions.newGoogleBrew(oAuth2Client, brew);
 
 	return res.status(200).send(newBrew);

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -11,9 +11,15 @@ const Markdown = require('../shared/naturalcrit/markdown.js');
 // 	});
 // };
 
+const MAX_TITLE_LENGTH = 100;
+
 const getGoodBrewTitle = (text)=>{
 	const tokens = Markdown.marked.lexer(text);
- 	return title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text;
+ 	let title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text;
+	if(title.length > MAX_TITLE_LENGTH) {
+		title = title.substr(0, MAX_TITLE_LENGTH);
+	}
+	return title;
 };
 
 const newBrew = (req, res)=>{
@@ -121,8 +127,6 @@ const newGoogleBrew = async (req, res, next)=>{
 	delete brew.googleId;
 
 	req.body = brew;
-
-	console.log(oAuth2Client);
 
 	const newBrew = await GoogleActions.newGoogleBrew(oAuth2Client, brew);
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -15,10 +15,7 @@ const MAX_TITLE_LENGTH = 100;
 
 const getGoodBrewTitle = (text)=>{
 	const tokens = Markdown.marked.lexer(text);
- 	let title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text;
-	if(title.length > MAX_TITLE_LENGTH) {
-		title = title.substr(0, MAX_TITLE_LENGTH);
-	}
+ 	const title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text.substr(0,MAX_TITLE_LENGTH);
 	return title;
 };
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -15,11 +15,8 @@ const MAX_TITLE_LENGTH = 100;
 
 const getGoodBrewTitle = (text)=>{
 	const tokens = Markdown.marked.lexer(text);
- 	let title = (tokens.find((token)=>token.type == 'heading' || token.type == 'paragraph') || { text: 'No Title' }).text;
-	if(title.length > MAX_TITLE_LENGTH) {
-		title = title.substr(0, MAX_TITLE_LENGTH);
-	}
-	return title;
+ 	return (tokens.find((token)=>token.type == 'heading' ||	token.type == 'paragraph')?.text || 'No Title')
+				 .slice(0, MAX_TITLE_LENGTH);
 };
 
 const newBrew = (req, res)=>{


### PR DESCRIPTION
This change sets the maximum title length to 100 characters. This value is set in the constant `MAX_TITLE_LENGTH` in the `homebrew.api.js` file, although it likely could be moved to a config file if desired.

Merging this PR should close Issue #1250, or at least minimize the issue so a deeper investigation can take place at a later date.