### PR TITLE
Parametrize fillMode for .useColumns

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -34,9 +34,9 @@ body {
 		letter-spacing : -0.02em;
 	}
 }
-.useColumns(@multiplier : 1){
+.useColumns(@multiplier : 1, @fillMode: balance){
 	column-count         : 2;
-	column-fill          : auto;
+	column-fill          : @fillMode;
 	column-gap           : 0.9cm;
 	column-width         : 8cm * @multiplier;
 	-webkit-column-count : 2;
@@ -383,7 +383,7 @@ body {
 
 	//Full Width
 	.monster.wide{
-		.useColumns(0.96);
+		.useColumns(0.96, @fillMode: balance);
 	}
 
 	//*****************************
@@ -629,7 +629,7 @@ body {
 		}
 	}
 	&.wide{
-		.useColumns(0.96);
+		.useColumns(0.96, @fillMode: balance);
 	}
 }
 


### PR DESCRIPTION
A @fillMode parameter for .useColumns9) allows setting 
`column-fill` property to `balance` for wide statblocks (or other
wide column types) instead of relying on Chrome's fallback
behavior that ignores `auto` when there's no set container height.
Set the default for the for `@fillMode` to `auto` to maintain the
current behavior.