### PR TITLE
Add snippet for removing drop cap (aka fancy first letter).

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -81,7 +81,7 @@ module.exports = [
 				name : 'Remove Drop Cap',
 				icon : 'fas fa-remove-format',
 				gen  : '<style>\n' +
-						'  .phb h1+p:first-letter {\n' +
+						'  .phb3 h1+p:first-letter {\n' +
 						'    all: unset;\n' +
 						'  }\n' +
 						'</style>'
@@ -91,10 +91,10 @@ module.exports = [
 				icon : 'fas fa-sliders-h',
 				gen  : '<style>\n' +
 						'  /* Drop Cap settings */\n' +
-						'  .phb h1 + p::first-letter {\n' +
+						'  .phb3 h1 + p::first-letter {\n' +
 						'    float: left;\n' +
-						'    font-family: Solberry;\n' +
-						'    font-size: 10em;\n' +
+						'    font-family: SolberaImitationRemake;\n' +
+						'    font-size: 3.5cm;\n' +
 						'    color: #222;\n' +
 						'    line-height: .8em;\n' +
 						'  }\n' +

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -80,7 +80,7 @@ module.exports = [
 			{
 				name : 'Remove Drop Cap',
 				icon : 'fas fa-remove-format',
-				gen  : 	'<style>\n' +
+				gen  : '<style>\n' +
 						'  .phb h1+p:first-letter {\n' +
 						'    all: unset;\n' +
 						'  }\n' +

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -77,6 +77,15 @@ module.exports = [
 				icon : 'fas fa-book',
 				gen  : TableOfContentsGen
 			},
+			{
+				name : 'Remove Drop Cap',
+				icon : 'fas fa-remove-format',
+				gen  : 	'<style>\n' +
+						'  .phb h1+p:first-letter {\n' +
+						'    all: unset;\n' +
+						'  }\n' +
+						'</style>'
+			},
 		]
 	},
 

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -86,6 +86,20 @@ module.exports = [
 						'  }\n' +
 						'</style>'
 			},
+			{
+				name : 'Tweak Drop Cap',
+				icon : 'fas fa-sliders-h',
+				gen  : '<style>\n' +
+						'  /* Drop Cap settings */\n' +
+						'  .phb h1 + p::first-letter {\n' +
+						'    float: left;\n' +
+						'    font-family: Solberry;\n' +
+						'    font-size: 10em;\n' +
+						'    color: #222;\n' +
+						'    line-height: .8em;\n' +
+						'  }\n' +
+						'</style>'
+			},
 		]
 	},
 

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -77,8 +77,15 @@ module.exports = [
 				icon : 'fas fa-book',
 				gen  : TableOfContentsGen
 			},
-
-
+			{
+				name : 'Remove Drop Cap',
+				icon : 'fas fa-remove-format',
+				gen  : 	'<style>\n' +
+						'  .phb h1+p:first-letter {\n' +
+						'    all: unset;\n' +
+						'  }\n' +
+						'</style>'
+			},
 		]
 	},
 

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -80,7 +80,7 @@ module.exports = [
 			{
 				name : 'Remove Drop Cap',
 				icon : 'fas fa-remove-format',
-				gen  : 	'<style>\n' +
+				gen  : '<style>\n' +
 						'  .phb h1+p:first-letter {\n' +
 						'    all: unset;\n' +
 						'  }\n' +

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -86,6 +86,20 @@ module.exports = [
 						'  }\n' +
 						'</style>'
 			},
+			{
+				name : 'Tweak Drop Cap',
+				icon : 'fas fa-sliders-h',
+				gen  : '<style>\n' +
+						'  /* Drop Cap settings */\n' +
+						'  .phb h1 + p::first-letter {\n' +
+						'    float: left;\n' +
+						'    font-family: Solberry;\n' +
+						'    font-size: 10em;\n' +
+						'    color: #222;\n' +
+						'    line-height: .8em;\n' +
+						'  }\n' +
+						'</style>'
+			},
 		]
 	},
 


### PR DESCRIPTION
This PR addresses issue #1285, adding a snippet (to both `snippets` and `snippetsLegacy`) that removes the drop cap from the first paragraph immediately after a big header (h1).