### PR TITLE
Add Windows batch scripts to simplify running Homebrewery

### DIFF
--- a/windows/install.bat
+++ b/windows/install.bat
@@ -1,0 +1,37 @@
+@ECHO OFF
+
+ECHO This process requires that the following items are already installed:
+ECHO - node
+ECHO - npm
+ECHO - MongoDB
+ECHO.
+ECHO =====================================================================
+ECHO.
+
+ECHO ACTION: Set current working directory
+cd %~dp0/..
+ECHO.
+
+ECHO ACTION: Set environment variables
+SETX HOMEBREWERY_DIR %cd%
+SETX NODE_ENV local
+ECHO.
+
+ECHO ACTION: NPM Installation
+CALL npm clean-install --no-audit
+ECHO.
+
+ECHO ACTION: NPM Vulnerabilty Check
+CALL npm audit fix
+ECHO.
+
+ECHO ACTION: NPM Post-Install
+CALL npm run postinstall
+ECHO.
+
+ECHO =====================================================================
+ECHO.
+ECHO Process complete.
+ECHO Error Level: %ERRORLEVEL%
+
+PAUSE

--- a/windows/launch.bat
+++ b/windows/launch.bat
@@ -1,0 +1,10 @@
+@ECHO OFF
+
+ECHO Launching Homebrewery...
+ECHO.
+ECHO =====================================================================
+ECHO.
+
+node %HOMEBREWERY_DIR%\server.js
+
+PAUSE


### PR DESCRIPTION
I have created Windows batch scripts to simplify launching Homebrewery.

Currently the requirements are:
- the user has installed node, npm, and MongoDB,
- may require Administrator privileges.

Two files are added in a new `windows` directory.
- **INSTALL.BAT:** Sets permanent environment variables for NODE_ENV and HOMEBREWERY_DIR, then runs `npm clean-install --no-audit`, `npm audit fix`, and `npm run postinstall`.
-  **LAUNCH.BAT:** Runs `node %HOMEBREWERY_DIR%\server.js` to launch the local Homebrewery webserver.

*To do:*
- [ ] create `README.md` for Windows.