### PR TITLE
Incorporate HTML "lang" attribute

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -18,7 +18,8 @@ const MetadataEditor = createClass({
 				published   : false,
 				authors     : [],
 				systems     : [],
-				renderer    : 'legacy'
+				renderer    : 'legacy',
+				language	: 'en'
 			},
 			onChange : ()=>{}
 		};

--- a/client/template.js
+++ b/client/template.js
@@ -1,7 +1,9 @@
 module.exports = async(name, title = '', props = {})=>{
+	const lang = this.props.metadata.language ? this.props.metadata.language : 'en';
+	
 	return `
 <!DOCTYPE html>
-<html>
+<html lang="${lang}">
 	<head>
 		<link href="//use.fontawesome.com/releases/v5.15.1/css/all.css" rel="stylesheet" />
 		<link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
First pass at incorporating the HTML language attribute (`html lang='brew.metadata.language'`).

- [ ] Add functionality to set the brew language in the Metadata Editor.