### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:14.15
 
 ENV NODE_ENV=docker
 


### PR DESCRIPTION
If a user were to execute the current README.DOCKER.md file as written, they would encounter an error along the lines of "node.js installed is incompatibe".

This is because the current Dockerfile is pulling node:8. But from package.json it seems that homebrewery is expecting something more like node:14.15.