### PR TITLE
Fix merge of undefined Style data

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -20,10 +20,12 @@ const getGoodBrewTitle = (text)=>{
 };
 
 const mergeBrewText = (text, style)=>{
-	text = `\`\`\`css\n` +
+	if(style || style === '') {
+		text = `\`\`\`css\n` +
 		   	 `${style}\n` +
 				 `\`\`\`\n\n` +
 				 `${text}`;
+	};
 	return text;
 };
 


### PR DESCRIPTION
This only merge `brew.style` with `brew.text` if `brew.style` exists or is an empty string.