### PR TITLE
Fix crash caused by Recent Brews NavItem

### DIFF
--- a/client/homebrew/navbar/recent.navitem.jsx
+++ b/client/homebrew/navbar/recent.navitem.jsx
@@ -80,7 +80,8 @@ const RecentItems = createClass({
 
 	componentDidUpdate : function(prevProps) {
 		if(prevProps.brew && this.props.brew.editId !== prevProps.brew.editId) {
-	 		if(this.props.storageKey == 'edit') {
+	 		let edited = JSON.parse(localStorage.getItem(EDIT_KEY) || '[]');
+			if(this.props.storageKey == 'edit') {
 				let prevEditId = prevProps.brew.editId;
 				if(prevProps.brew.googleId){
 					prevEditId = `${prevProps.brew.googleId}${prevProps.brew.editId}`;


### PR DESCRIPTION
Fix for white screen issue when transferring Brews between Storage options.

The error reports 'edited' is an undeclared variable in `componentDidUpdate`. This variable only appears in that function in `recent.navitem.jsx`; it is declared previously in `componentDidMount` but it appears that this declaration is no longer in scope - this might be related to the update of the Babel package.