### PR TITLE
Fix for Issue #1438 - style data not cloning to `/new`

### DIFF
--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -26,6 +26,7 @@ const NewPage = createClass({
 		return {
 			brew : {
 				text      : '',
+				style     : undefined,
 				shareId   : null,
 				editId    : null,
 				createdAt : null,
@@ -46,6 +47,7 @@ const NewPage = createClass({
 		return {
 			brew : {
 				text        : this.props.brew.text || '',
+				style       : this.props.brew.style || undefined,
 				gDrive      : false,
 				title       : this.props.brew.title || '',
 				description : this.props.brew.description || '',


### PR DESCRIPTION
Pull request to correct issue where Style tab information is not cloned to a new brew when cloning via `/new/:id` functionality, as recently exposed to users via the Source dropdown menu.