### PR TITLE
Clean up template.js

### DIFF
--- a/client/template.js
+++ b/client/template.js
@@ -5,15 +5,15 @@ module.exports = async(name, title = '', props = {})=>{
 	<head>
 		<link href="//use.fontawesome.com/releases/v5.15.1/css/all.css" rel="stylesheet" />
 		<link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css" />
-		<link href=${`/${name}/bundle.css`} rel='stylesheet'></link>
+		<link href=${`/${name}/bundle.css`} rel='stylesheet' />
 		<link rel="icon" href="/assets/homebrew/favicon.ico" type="image/x-icon" />
 		<title>${title.length ? `${title} - The Homebrewery`: 'The Homebrewery - NaturalCrit'}</title>
 	</head>
 	<body>
 		<main id="reactRoot">${require(`../build/${name}/ssr.js`)(props)}</main>
+		<script src=${`/${name}/bundle.js`}></script>
+		<script>start_app(${JSON.stringify(props)})</script>
 	</body>
-	<script src=${`/${name}/bundle.js`}></script>
-	<script>start_app(${JSON.stringify(props)})</script>
 </html>
 `;
 };


### PR DESCRIPTION
As per comments from Eric Scheid in Gitter chat: 

- [x] `<link href=/homebrew/bundle.css rel='stylesheet'></link>` — don't need that `</link>`
- [x] `</body>↩<script src=/homebrew/bundle.js></script>↩<script>start_app(...` — both of those two script elements should be before the `</body>`

This PR corrects these issues in the `template.js` file.
