### PR TITLE
Update metadataEditor.less for CSS adjustments

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -18,10 +18,11 @@
 			font-weight    : 800;
 			line-height    : 1.8em;
 			text-transform : uppercase;
-			flex-grow      : 0;
+			flex           : 0 0 auto;
 		}
 		&>.value{
-			flex-grow : 1;
+			flex           : 1 1 auto;
+			min-width      : 200px;
 		}
 	}
 	.description.field textarea.value{
@@ -38,6 +39,8 @@
 			font-size      : 0.7em;
 			font-weight    : 800;
 			user-select    : none;
+			white-space    : nowrap;
+			display        : inline-block;
 		}
 		input{
 			vertical-align : middle;
@@ -47,6 +50,9 @@
 	.publish.field .value{
 		position : relative;
 		margin-bottom: 15px;
+		button{
+			width:100%;
+		}
 		button.publish{
 			.button(@blueLight);
 		}

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -40,11 +40,13 @@
 			font-weight    : 800;
 			user-select    : none;
 			white-space    : nowrap;
-			display        : inline-block;
+			display        : inline-flex;
+			align-items    : center;
 		}
 		input{
 			vertical-align : middle;
 			cursor         : pointer;
+			margin         : 3px;
 		}
 	}
 	.publish.field .value{

--- a/client/homebrew/editor/snippetbar/snippets/magic.gen.js
+++ b/client/homebrew/editor/snippetbar/snippets/magic.gen.js
@@ -57,7 +57,7 @@ const itemNames = [
 module.exports = {
 
 	spellList : function(){
-		const levels = ['Cantrips (0 Level)', '2nd Level', '3rd Level', '4th Level', '5th Level', '6th Level', '7th Level', '8th Level', '9th Level'];
+		const levels = ['Cantrips (0 Level)', '1st Level', '2nd Level', '3rd Level', '4th Level', '5th Level', '6th Level', '7th Level', '8th Level', '9th Level'];
 
 		const content = _.map(levels, (level)=>{
 			const spells = _.map(_.sampleSize(spellNames, _.random(5, 15)), (spell)=>{
@@ -66,7 +66,7 @@ module.exports = {
 			return `##### ${level} \n${spells} \n`;
 		}).join('\n');
 
-		return `<div class='spellList'>\n${content}\n</div>`;
+		return `{{spellList\n${content}\n}}`;
 	},
 
 	spell : function(){


### PR DESCRIPTION
This make some minor tweaks to the stylesheet for the metadata editor.
- vertically centers the checkboxes and radio buttons with their labels
- prevents separation of inputs from labels due to resizing causing wrapping  (keeps them together).
- sets a minimum width of the textbox/textarea so they have the same minimum width.
- fixes #1193.  This text should probably just be updated to no longer mention "searchable" etc unless that is really going to happen?  Overall, I think the clarity of what "publish" does could be improved.  Regardless, whatever is written will fit better.