### PR TITLE
Enable Marked SmartyPants option

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 const _ = require('lodash');
-const Markdown = require('marked');
+const Markdown = require('marked').setOptions(MarkedOpts);
 const renderer = new Markdown.Renderer();
 
 //Processes the markdown within an HTML block if it's just a class-wrapper

--- a/shared/naturalcrit/markdownLegacy.js
+++ b/shared/naturalcrit/markdownLegacy.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
-const Markdown = require('markedLegacy');
+const MarkedOpts = require('./markedOpts.json');
+const Markdown = require('markedLegacy').setOptions(MarkedOpts);
 const renderer = new Markdown.Renderer();
 
 //Processes the markdown within an HTML block if it's just a class-wrapper

--- a/shared/naturalcrit/markedOpts.json
+++ b/shared/naturalcrit/markedOpts.json
@@ -1,0 +1,3 @@
+{
+    "smartypants" : true
+}


### PR DESCRIPTION
This PR creates an independent `MarkedOpts.json` file to contain the options for Marked, and sets both `Markdown` and `MarkdownLegacy` to use those options.  
Currently, the only option set in `MarkedOpts.json` is `"smartypants" : true`, but this file can be extended later to set other options for Marked.

This PR addresses issue #849.