### PR TITLE
Add Hotkeys for HTML Commenting Selection

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -113,6 +113,13 @@ module.exports = [
 						'  }\n' +
 						'</style>'
 			},
+			{
+				name : 'Add Comment',
+				icon : 'fas fa-comment-code',  /* might need to be fa-solid fa-comment-code --not sure, Gazook */
+				gen  : dedent`\n
+					<!-- Add a comment to your code here without adding it to your live brew. Hotkey Ctrl/Cmd K -->
+					\n`
+			},
 		]
 	},
 

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -117,7 +117,7 @@ module.exports = [
 				name : 'Add Comment',
 				icon : 'fas fa-comment-code',  /* might need to be fa-solid fa-comment-code --not sure, Gazook */
 				gen  : dedent`\n
-					<!-- Add a comment to your code here without adding it to your live brew. Hotkey Ctrl/Cmd K -->
+					<!-- Add a comment to your code here without adding it to your live brew. Hotkey Ctrl/Cmd \\ -->
 					\n`
 			},
 		]

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -100,6 +100,13 @@ module.exports = [
 						'  }\n' +
 						'</style>'
 			},
+			{
+				name : 'Add Comment',
+				icon : 'fas fa-comment-code',  /* might need to be fa-solid fa-comment-code --not sure, Gazook */
+				gen  : dedent`\n
+					<!-- Add a comment to your code here without adding it to your live brew. Hotkey Ctrl/Cmd \\ -->
+					\n`
+			},
 		]
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -47,14 +47,14 @@ const CodeEditor = createClass({
 			indentWithTabs : true,
 			tabSize        : 2,
 			extraKeys      : {
-				'Ctrl-B' : this.makeBold,
-				'Cmd-B'  : this.makeBold,
-				'Ctrl-I' : this.makeItalic,
-				'Cmd-I'  : this.makeItalic,
-				'Ctrl-M' : this.makeSpan,
-				'Cmd-M'  : this.makeSpan,
-				'Ctrl-\\': this.makeComment,
-				'Cmd-\\' : this.makeComment,
+				'Ctrl-B'  : this.makeBold,
+				'Cmd-B'   : this.makeBold,
+				'Ctrl-I'  : this.makeItalic,
+				'Cmd-I'   : this.makeItalic,
+				'Ctrl-M'  : this.makeSpan,
+				'Cmd-M'   : this.makeSpan,
+				'Ctrl-\\' : this.makeComment,
+				'Cmd-\\'  : this.makeComment,
 			}
 		});
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -54,6 +54,7 @@ const CodeEditor = createClass({
 				'Ctrl-M' : this.makeSpan,
 				'Cmd-M'  : this.makeSpan,
 				'Ctrl-K' : this.makeComment,
+				'Cmd-K'  : this.makeComment,
 			}
 		});
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -53,8 +53,8 @@ const CodeEditor = createClass({
 				'Cmd-I'  : this.makeItalic,
 				'Ctrl-M' : this.makeSpan,
 				'Cmd-M'  : this.makeSpan,
-				'Ctrl-\\' : this.makeComment,
-				'Cmd-\\'  : this.makeComment,
+				'Ctrl-\\': this.makeComment,
+				'Cmd-\\' : this.makeComment,
 			}
 		});
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -53,6 +53,7 @@ const CodeEditor = createClass({
 				'Cmd-I'  : this.makeItalic,
 				'Ctrl-M' : this.makeSpan,
 				'Cmd-M'  : this.makeSpan,
+				'Ctrl-K' : this.makeComment,
 			}
 		});
 
@@ -85,6 +86,15 @@ const CodeEditor = createClass({
 		if(selection.length === 0){
 			const cursor = this.codeMirror.getCursor();
 			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 2 });
+		}
+	},
+	
+	makeComment : function() {
+		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 4) === '<!--' && selection.slice(-3) === '-->';
+		this.codeMirror.replaceSelection(t ? selection.slice(4, -3) : `<!-- ${selection}-->`, 'around');
+		if(selection.length === 0){
+			const cursor = this.codeMirror.getCursor();
+			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 3 });
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -53,8 +53,8 @@ const CodeEditor = createClass({
 				'Cmd-I'  : this.makeItalic,
 				'Ctrl-M' : this.makeSpan,
 				'Cmd-M'  : this.makeSpan,
-				'Ctrl-K' : this.makeComment,
-				'Cmd-K'  : this.makeComment,
+				'Ctrl-\\' : this.makeComment,
+				'Cmd-\\'  : this.makeComment,
 			}
 		});
 
@@ -89,7 +89,7 @@ const CodeEditor = createClass({
 			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 2 });
 		}
 	},
-	
+
 	makeComment : function() {
 		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 4) === '<!--' && selection.slice(-3) === '-->';
 		this.codeMirror.replaceSelection(t ? selection.slice(4, -3) : `<!-- ${selection}-->`, 'around');


### PR DESCRIPTION
This addresses #1303 for both macOS/not macOS.  Surrounds selection in `<!-- -->`, and does not check if it needs to be `/*  */` for css.....however, if someone knows how to do that, please do so.  I suspect it is easier to determine if the selection is in the Style Editor vs Brew Editor, and that might be "good enough"?

Please double check my code, though...it was mostly a copy/paste of other hotkeys.