### PR TITLE
Update 5ePhb.style.less with small tweaks

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -411,12 +411,17 @@ body {
 	// *           CODE BLOCKS
 	// ************************************/
 	code{
-    font-family: "Courier New", Courier, monospace;
-    font-size: 0.325;
-    padding: 2px 4px;
-    color: #58180d;
-    background-color: #faf7ea;
-    border-radius: 4px;
+		font-family		: "Courier New", Courier, monospace;
+		font-size		: 0.325;
+		padding			: 0px 4px;
+		color			: #58180d;
+		background-color	: #faf7ea;
+		border-radius		: 4px;
+		white-space		: pre-wrap
+	}
+	
+	pre{
+		margin-bottom	: 10px;
 	}
 
 	pre code{
@@ -428,6 +433,7 @@ body {
 		border-image-outset : 2px;
 		border-radius       : 12px;
 	}
+	
 	//*****************************
 	// *          EXTRAS
 	// *****************************/
@@ -538,6 +544,8 @@ body {
 	h1 {
 		text-align    : center;
 		margin-bottom : 0.1cm;
+		+ ul{
+			margin-top  : 20px;
 	}
 	a{
 		display         : table;


### PR DESCRIPTION
- add 20px margin between H1 toc header and top of toc list.
- add white-space:pre-wrap; to fix issue of code blocks not wrapping text
- add small margin below pre blocks.
- reduce vertical padding in code spans to 0px...at 2px, code spans blend together across lines.