### PR TITLE
Ignore Docker config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ storage
 *.log
 build/*
 config/local.*
+config/docker.*
 
 todo.md
 startDB.bat


### PR DESCRIPTION
Add `config/docker.*` to `.gitignore` to prevent Docker config files from being staged to the project.