### PR TITLE
Modify buildAdmin.js for Node compatibility

### DIFF
--- a/scripts/buildAdmin.js
+++ b/scripts/buildAdmin.js
@@ -18,7 +18,6 @@ const build = async ({ bundle, render, ssr })=>{
 	await fs.outputFile('./build/admin/bundle.css', css);
 	await fs.outputFile('./build/admin/bundle.js', bundle);
 	await fs.outputFile('./build/admin/ssr.js', ssr);
-	//await fs.outputFile('./build/admin/render.js', render);
 };
 
 fs.emptyDirSync('./build/admin');

--- a/scripts/buildAdmin.js
+++ b/scripts/buildAdmin.js
@@ -14,10 +14,11 @@ const transforms = {
 };
 
 const build = async ({ bundle, render, ssr })=>{
-	await fs.outputFile('./build/admin/bundle.css', await lessTransform.generate({ paths: './shared' }));
+	const css = await lessTransform.generate({ paths: './shared' });
+	await fs.outputFile('./build/admin/bundle.css', css);
 	await fs.outputFile('./build/admin/bundle.js', bundle);
 	await fs.outputFile('./build/admin/ssr.js', ssr);
-	await fs.outputFile('./build/admin/render.js', render);
+	//await fs.outputFile('./build/admin/render.js', render);
 };
 
 fs.emptyDirSync('./build/admin');


### PR DESCRIPTION
This PR addresses the issues raised in #1508 - when Node 15 is installed, the build process fails during the `buildAdmin.js` step.

This PR shifts the second `await` call to it's own line, and comments out the `Render` line, which is not used in the current implementation of Homebrewery.

Merging this PR will resolve #1508.