### PR TITLE
Confirm `Brew.Title` exists before ordering by it

### DIFF
--- a/client/homebrew/pages/userPage/userPage.jsx
+++ b/client/homebrew/pages/userPage/userPage.jsx
@@ -42,7 +42,7 @@ const UserPage = createClass({
 	renderBrews : function(brews){
 		if(!brews || !brews.length) return <div className='noBrews'>No Brews.</div>;
 
-		const sortedBrews = this.sortBrews(brews, this.state.sortType);
+		const sortedBrews = this.sortBrews(brews);
 
 		return _.map(sortedBrews, (brew, idx)=>{
 			return <BrewItem brew={brew} key={idx}/>;
@@ -50,6 +50,7 @@ const UserPage = createClass({
 	},
 
 	sortBrewOrder : function(brew){
+		if(!brew.title){brew.title = 'No Title';};
 		const mapping = {
 			'alpha'   : _.deburr(brew.title.toLowerCase()),
 			'created' : brew.createdAt,


### PR DESCRIPTION
This PR should resolve #1512.

The ordering logic checks that `brews` exists, then derives `brew` from it. However it does not confirm that the derived `brew` object contains a `title` element before attempting to order the `brews` set by that element.
This PR sets a default value of 'No Title' to any derived `brew` that fails the `(!brew.title)` test.