### PR TITLE
Hide Private brew `<div>` if UserPage is not for logged in User

### DIFF
--- a/client/homebrew/pages/userPage/userPage.jsx
+++ b/client/homebrew/pages/userPage/userPage.jsx
@@ -145,10 +145,12 @@ const UserPage = createClass({
 						<h1>{this.getUsernameWithS()} brews</h1>
 						{this.renderBrews(brews.published)}
 					</div>
-					<div className='unpublished'>
-						<h1>{this.getUsernameWithS()} unpublished brews</h1>
-						{this.renderBrews(brews.private)}
-					</div>
+					{this.props?.username == global.account?.username &&
+						<div className='unpublished'>
+							<h1>{this.getUsernameWithS()} unpublished brews</h1>
+							{this.renderBrews(brews.private)}
+						</div>
+					}
 				</div>
 			</div>
 		</div>;

--- a/client/homebrew/pages/userPage/userPage.jsx
+++ b/client/homebrew/pages/userPage/userPage.jsx
@@ -142,10 +142,10 @@ const UserPage = createClass({
 				<div className='phb'>
 					{this.renderSortOptions()}
 					<div className='published'>
-						<h1>{this.getUsernameWithS()} brews</h1>
+						<h1>{this.getUsernameWithS()} published brews</h1>
 						{this.renderBrews(brews.published)}
 					</div>
-					{this.props?.username == global.account?.username &&
+					{this.props.username == global.account?.username &&
 						<div className='unpublished'>
 							<h1>{this.getUsernameWithS()} unpublished brews</h1>
 							{this.renderBrews(brews.private)}


### PR DESCRIPTION
This PR should hide the `Private Brews` header and content from the UserPage when the currently logged in user is not the owner of the User Page.