### PR TITLE
Add Route for external tool access

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -45,6 +45,7 @@ const Homebrew = createClass({
 						<Route path='/share/:id' component={(routeProps)=><SharePage id={routeProps.match.params.id} brew={this.props.brew} />}/>
 						<Route path='/new/:id' component={(routeProps)=><NewPage id={routeProps.match.params.id} brew={this.props.brew} />}/>
 						<Route path='/new' exact component={(routeProps)=><NewPage />}/>
+						<Route path='/template' exact component={(routeProps)=><NewPage query={queryString.parse(routeProps.location.search)}/>}/>
 						<Route path='/user/:username' component={(routeProps)=><UserPage username={routeProps.match.params.username} brews={this.props.brews} />}/>
 						<Route path='/print/:id' component={(routeProps)=><PrintPage brew={this.props.brew} query={queryString.parse(routeProps.location.search)} />}/>
 						<Route path='/print' exact component={(routeProps)=><PrintPage query={queryString.parse(routeProps.location.search)} />}/>

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -38,7 +38,8 @@ const NewPage = createClass({
 				tags        : '',
 				published   : false,
 				authors     : [],
-				systems     : []
+				systems     : [],
+				query       : {}
 			}
 		};
 	},
@@ -46,11 +47,11 @@ const NewPage = createClass({
 	getInitialState : function() {
 		return {
 			brew : {
-				text        : this.props.brew.text || '',
-				style       : this.props.brew.style || undefined,
+				text        : this.props.brew.text || this.props.query?.text || '',
+				style       : this.props.brew.style || this.props.query?.style || undefined,
 				gDrive      : false,
-				title       : this.props.brew.title || '',
-				description : this.props.brew.description || '',
+				title       : this.props.brew.title || this.props.query?.title ||  '',
+				description : this.props.brew.description || this.props.query?.description || '',
 				tags        : this.props.brew.tags || '',
 				published   : false,
 				authors     : [],
@@ -71,9 +72,9 @@ const NewPage = createClass({
 
 		const brew = this.state.brew;
 
-		if(!this.props.brew.text || !this.props.brew.style){
-			brew.text = this.props.brew.text  || (brewStorage  ?? '');
-			brew.style = this.props.brew.style || (styleStorage ?? undefined);
+		if(!this.state.brew.text || !this.state.brew.style){
+			brew.text = this.state.brew.text  || (brewStorage  ?? '');
+			brew.style = this.state.brew.style || (styleStorage ?? undefined);
 		}
 
 		this.setState((prevState)=>({
@@ -220,6 +221,7 @@ const NewPage = createClass({
 	},
 
 	render : function(){
+		console.log(this.props.query);
 		return <div className='newPage sitePage'>
 			{this.renderNavbar()}
 			<div className='content'>

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -56,7 +56,7 @@ const NewPage = createClass({
 				published   : false,
 				authors     : [],
 				systems     : this.props.brew.systems || [],
-				renderer    : this.props.brew.renderer || 'legacy'
+				renderer    : this.props.brew.renderer || this.props.query?.renderer || 'legacy'
 			},
 
 			isSaving   : false,

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -221,7 +221,6 @@ const NewPage = createClass({
 	},
 
 	render : function(){
-		console.log(this.props.query);
 		return <div className='newPage sitePage'>
 			{this.renderNavbar()}
 			<div className='content'>


### PR DESCRIPTION
This PR adds a `/template` route, which will allow external apps to create a Homebrewery document via URL. This is achieved by allowing `text`, `style`, `title`, and `description` to be set via parameters in the URL query.

![image](https://user-images.githubusercontent.com/19826659/128653014-4aae5b26-fa97-469f-aa18-6b6b6a99c372.png)

![image](https://user-images.githubusercontent.com/19826659/128653053-d7f5ea3c-2c24-434c-9119-226ed2133314.png)
