### PR TITLE
Save Renderer data in LocalStorage and GoogleDrive

### DIFF
--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -19,6 +19,7 @@ const BrewRenderer = require('../../brewRenderer/brewRenderer.jsx');
 
 const BREWKEY = 'homebrewery-new';
 const STYLEKEY = 'homebrewery-new-style';
+const METAKEY = 'homebrewery-new-meta';
 
 
 const NewPage = createClass({
@@ -68,12 +69,16 @@ const NewPage = createClass({
 	componentDidMount : function() {
 		const brewStorage  = localStorage.getItem(BREWKEY);
 		const styleStorage = localStorage.getItem(STYLEKEY);
+		const metaStorage = JSON.parse(localStorage.getItem(METAKEY));
 
 		const brew = this.state.brew;
 
-		if(!this.props.brew.text || !this.props.brew.style){
-			brew.text = this.props.brew.text  || (brewStorage  ?? '');
-			brew.style = this.props.brew.style || (styleStorage ?? undefined);
+		if(!this.state.brew.text || !this.state.brew.style){
+			brew.text = this.state.brew.text  || (brewStorage  ?? '');
+			brew.style = this.state.brew.style || (styleStorage ?? undefined);
+			// brew.title = metaStorage?.title || this.state.brew.title;
+			// brew.description = metaStorage?.description || this.state.brew.description;
+			brew.renderer = metaStorage?.renderer || this.state.brew.renderer;
 		}
 
 		this.setState((prevState)=>({
@@ -126,7 +131,11 @@ const NewPage = createClass({
 		this.setState((prevState)=>({
 			brew : _.merge({}, prevState.brew, metadata),
 		}));
-
+		localStorage.setItem(METAKEY, JSON.stringify({
+			// 'title'       : this.state.brew.title,
+			// 'description' : this.state.brew.description,
+			'renderer' : this.state.brew.renderer
+		}));
 	},
 
 	save : async function(){
@@ -159,6 +168,7 @@ const NewPage = createClass({
 			brew = res.body;
 			localStorage.removeItem(BREWKEY);
 			localStorage.removeItem(STYLEKEY);
+			localStorage.removeItem(METAKEY);
 			window.location = `/edit/${brew.googleId}${brew.editId}`;
 		} else {
 			request.post('/api')
@@ -174,6 +184,7 @@ const NewPage = createClass({
 				brew = res.body;
 				localStorage.removeItem(BREWKEY);
 				localStorage.removeItem(STYLEKEY);
+				localStorage.removeItem(METAKEY);
 				window.location = `/edit/${brew.editId}`;
 			});
 		}

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -190,10 +190,11 @@ GoogleActions = {
 			'description' : `${brew.description}`,
 			'parents'     : [folderId],
 			'properties'  : {								//AppProperties is not accessible
-				'shareId' : nanoid(12),
-				'editId'  : nanoid(12),
-				'title'   : brew.title,
-				'views'   : '0'
+				'shareId'  : nanoid(12),
+				'editId'   : nanoid(12),
+				'title'    : brew.title,
+				'views'    : '0',
+				'renderer' : brew.renderer || 'legacy'
 			}
 		};
 


### PR DESCRIPTION
This PR should resolve #1498.

While the original intention was to merely save and retrieve the `renderer` data to/from `localStorage`, during the process of testing it was discovered that while this setting worked on the NewPage, it was lost when saved to Google Drive.
Further investigation revealed that the `renderer` data was not being saved to `file.properties`. Correcting this resulted in correct operation on both NewPage and EditPage after saving to Google Drive.