### PR TITLE
Update BrewItem tooltips

### DIFF
--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -48,7 +48,7 @@ const BrewItem = createClass({
 		if(!this.props.brew.editId) return;
 
 		return <a onClick={this.deleteBrew}>
-			<i className='fas fa-trash-alt' />
+			<i className='fas fa-trash-alt' title='Delete' />
 		</a>;
 	},
 
@@ -61,7 +61,7 @@ const BrewItem = createClass({
 		}
 
 		return <a href={`/edit/${editLink}`} target='_blank' rel='noopener noreferrer'>
-			<i className='fas fa-pencil-alt' />
+			<i className='fas fa-pencil-alt' title='Edit' />
 		</a>;
 	},
 
@@ -74,7 +74,7 @@ const BrewItem = createClass({
 		}
 
 		return <a href={`/share/${shareLink}`} target='_blank' rel='noopener noreferrer'>
-			<i className='fas fa-share-alt' />
+			<i className='fas fa-share-alt' title='Share' />
 		</a>;
 	},
 
@@ -87,7 +87,7 @@ const BrewItem = createClass({
 		}
 
 		return <a href={`/download/${shareLink}`}>
-			<i className='fas fa-download' />
+			<i className='fas fa-download' title='Download' />
 		</a>;
 	},
 
@@ -101,7 +101,7 @@ const BrewItem = createClass({
 
 	getTooltipData : function(){
 		const dateFormatString = 'YYYY-MM-DD HH:mm:ss';
-		let outputString = `Created: ${this.props.brew.createdAt ? moment(this.props.brew.createdAt).local().format(dateFormatString) : 'UNKNOWN'}\n`;
+		let outputString = `Title: ${this.props.brew.title}\nCreated: ${this.props.brew.createdAt ? moment(this.props.brew.createdAt).local().format(dateFormatString) : 'UNKNOWN'}\n`;
 		outputString +=    `Last updated: ${this.props.brew.updatedAt ? moment(this.props.brew.updatedAt).local().format(dateFormatString) : 'UNKNOWN'}`;
 		return  outputString;
 	},

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -99,29 +99,29 @@ const BrewItem = createClass({
 		</span>;
 	},
 
-	getTooltipData : function(){
-		const dateFormatString = 'YYYY-MM-DD HH:mm:ss';
-		let outputString = `Title: ${this.props.brew.title}\nCreated: ${this.props.brew.createdAt ? moment(this.props.brew.createdAt).local().format(dateFormatString) : 'UNKNOWN'}\n`;
-		outputString +=    `Last updated: ${this.props.brew.updatedAt ? moment(this.props.brew.updatedAt).local().format(dateFormatString) : 'UNKNOWN'}`;
-		return  outputString;
-	},
-
 	render : function(){
 		const brew = this.props.brew;
-		return <div className='brewItem' title={this.getTooltipData()}>
+		const dateFormatString = 'YYYY-MM-DD HH:mm:ss';
+
+		return <div className='brewItem'>
 			<h2>{brew.title}</h2>
 			<p className='description'>{brew.description}</p>
 			<hr />
 
 			<div className='info'>
-				<span>
-					<i className='fas fa-user' /> {brew.authors.join(', ')}
+				<span title={`Authors:\n${brew.authors.join('\n')}`}>
+					<i className='fas fa-user'/> {brew.authors.join(', ')}
 				</span>
-				<span>
-					<i className='fas fa-eye' /> {brew.views}
+				<span title={`Last viewed: ${brew.lastViewed}`}>
+					<i className='fas fa-eye'/> {brew.views}
 				</span>
-				<span>
-					<i className='fas fa-sync-alt' /> {moment(brew.updatedAt).fromNow()}
+				<span
+					title={
+						`Created: ${this.props.brew.createdAt ? moment(this.props.brew.createdAt).local().format(dateFormatString) : 'UNKNOWN'}\n` +
+						`Last updated: ${this.props.brew.updatedAt ? moment(this.props.brew.updatedAt).local().format(dateFormatString) : 'UNKNOWN'}`
+					}>
+					<i className='fas fa-sync-alt'	/>
+					{moment(brew.updatedAt).fromNow()}
 				</span>
 				{this.renderGoogleDriveIcon()}
 			</div>

--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -112,13 +112,13 @@ const BrewItem = createClass({
 				<span title={`Authors:\n${brew.authors.join('\n')}`}>
 					<i className='fas fa-user'/> {brew.authors.join(', ')}
 				</span>
-				<span title={`Last viewed: ${brew.lastViewed}`}>
+				<span title={`Last viewed: ${moment(brew.lastViewed).local().format(dateFormatString)}`}>
 					<i className='fas fa-eye'/> {brew.views}
 				</span>
 				<span
 					title={
-						`Created: ${this.props.brew.createdAt ? moment(this.props.brew.createdAt).local().format(dateFormatString) : 'UNKNOWN'}\n` +
-						`Last updated: ${this.props.brew.updatedAt ? moment(this.props.brew.updatedAt).local().format(dateFormatString) : 'UNKNOWN'}`
+						`Created: ${brew.createdAt ? moment(brew.createdAt).local().format(dateFormatString) : 'UNKNOWN'}\n` +
+						`Last updated: ${brew.updatedAt ? moment(brew.updatedAt).local().format(dateFormatString) : 'UNKNOWN'}`
 					}>
 					<i className='fas fa-sync-alt'	/>
 					{moment(brew.updatedAt).fromNow()}

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -358,8 +358,9 @@ GoogleActions = {
 
 		await drive.files.update({
 			fileId   : brew.googleId,
-			resource : { properties : { views      : brew.views + 1,
-		 															lastViewed : new Date() } }
+			resource : { modifiedTime : brew.updatedAt,
+						 properties   : { views      : brew.views + 1,
+		 							      lastViewed : new Date() } }
 		})
 		.catch((err)=>{
 			console.log('Error updating Google views');

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -358,9 +358,8 @@ GoogleActions = {
 
 		await drive.files.update({
 			fileId   : brew.googleId,
-			resource : { modifiedTime : brew.updatedAt,
-						 properties   : { views      : brew.views + 1,
-		 							      lastViewed : new Date() } }
+			resource : { properties : { views      : brew.views + 1,
+		 															lastViewed : new Date() } }
 		})
 		.catch((err)=>{
 			console.log('Error updating Google views');


### PR DESCRIPTION
PR based on feedback from Gitter:

> the tooltip for created/updated microdata should really only appear when hovering over the refresh item in the `<div class="info">`, not when hovering the `<div class="brewItem">`.  
Also, the items within the `<div class="links">` should have tooltips (e.g. "share", "edit", "download", "delete").

However, as I believe that the `<div class='info'>` is a small un-intuitive target when compared to the entire Brew Item, at this time I have added a line to the start of the tooltip containing "Title: {`brew.title`}" without changing the element that the tooltip is attached to.