### PR TITLE
Set modifiedTime during view count update of Google brews

### DIFF
--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -359,9 +359,13 @@ GoogleActions = {
 
 		await drive.files.update({
 			fileId   : brew.googleId,
-			resource : { modifiedTime : brew.updatedAt,
-						 properties   : { views      : brew.views + 1,
-		 								  lastViewed : new Date() } }
+			resource : {
+				modifiedTime : brew.updatedAt,
+				properties   : {
+					views      : brew.views + 1,
+		 			lastViewed : new Date()
+				}
+			}
 		})
 		.catch((err)=>{
 			console.log('Error updating Google views');

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -359,8 +359,9 @@ GoogleActions = {
 
 		await drive.files.update({
 			fileId   : brew.googleId,
-			resource : { properties : { views      : brew.views + 1,
-		 															lastViewed : new Date() } }
+			resource : { modifiedTime : brew.updatedAt,
+						 properties   : { views      : brew.views + 1,
+		 								  lastViewed : new Date() } }
 		})
 		.catch((err)=>{
 			console.log('Error updating Google views');


### PR DESCRIPTION
This PR sets the `modifiedTime` file attribute to `brew.updatedAt` while performing the update of `brew.views` and `brew.lastViewed`, preventing `brew.updatedAt` from being changed.

This should resolve #1506.