### PR TITLE
Stop view count being reduced by an open Edit page

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -51,18 +51,16 @@ const EditPage = createClass({
 	},
 
 	getInitialState : function() {
-		const newBrew = this.props.brew;
-		delete newBrew.views;
 		return {
-			brew                   : newBrew,
+			brew                   : this.props.brew,
 			isSaving               : false,
 			isPending              : false,
-			alertTrashedGoogleBrew : newBrew.trashed,
+			alertTrashedGoogleBrew : this.props.brew.trashed,
 			alertLoginToTransfer   : false,
-			saveGoogle             : newBrew.googleId ? true : false,
+			saveGoogle             : this.props.brew.googleId ? true : false,
 			confirmGoogleTransfer  : false,
 			errors                 : null,
-			htmlErrors             : Markdown.validate(newBrew.text),
+			htmlErrors             : Markdown.validate(this.props.brew.text),
 			url                    : ''
 		};
 	},

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -51,16 +51,18 @@ const EditPage = createClass({
 	},
 
 	getInitialState : function() {
+		const newBrew = this.props.brew;
+		delete newBrew.views;
 		return {
-			brew                   : this.props.brew,
+			brew                   : newBrew,
 			isSaving               : false,
 			isPending              : false,
-			alertTrashedGoogleBrew : this.props.brew.trashed,
+			alertTrashedGoogleBrew : newBrew.trashed,
 			alertLoginToTransfer   : false,
-			saveGoogle             : this.props.brew.googleId ? true : false,
+			saveGoogle             : newBrew.googleId ? true : false,
 			confirmGoogleTransfer  : false,
 			errors                 : null,
-			htmlErrors             : Markdown.validate(this.props.brew.text),
+			htmlErrors             : Markdown.validate(newBrew.text),
 			url                    : ''
 		};
 	},

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -163,7 +163,8 @@ GoogleActions = {
 						version   : brew.version,
 						renderer  : brew.renderer,
 						tags      : brew.tags,
-						systems   : brew.systems.join() }
+						systems   : brew.systems.join()
+					}
 				},
 				media : {
 					mimeType : 'text/plain',

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -154,21 +154,21 @@ GoogleActions = {
 		if(await GoogleActions.existsGoogleBrew(auth, brew.googleId) == true) {
 			await drive.files.update({
 				fileId   : brew.googleId,
-				resource : { name        : `${brew.title}.txt`,
-										 description : `${brew.description}`,
-										 properties  : { title      : brew.title,
-										 							    published  : brew.published,
-																	    lastViewed : brew.lastViewed,
-																	    views      : brew.views,
-																	    version    : brew.version,
-																	    renderer   : brew.renderer,
-																	    tags       : brew.tags,
-																	    systems    : brew.systems.join(),
-																	    pageCount  : brew.pageCount
-																 }
-									 },
-				media : { mimeType : 'text/plain',
-								  body     : brew.text }
+				resource : {
+					name        : `${brew.title}.txt`,
+					description : `${brew.description}`,
+					properties  : {
+						title     : brew.title,
+						published : brew.published,
+						version   : brew.version,
+						renderer  : brew.renderer,
+						tags      : brew.tags,
+						systems   : brew.systems.join() }
+				},
+				media : {
+					mimeType : 'text/plain',
+					body     : brew.text
+				}
 			})
 			.catch((err)=>{
 				console.log('Error saving to google');

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -61,10 +61,20 @@ const newBrew = (req, res)=>{
 	});
 };
 
+const cleanBrew = (brew)=>{
+	// Remove undesired properties
+	const undesiredPropertyNames=['views', 'lastViewed'];
+	for (const undesiredProperty of undesiredPropertyNames) {
+		delete brew[undesiredProperty];
+	};
+	return brew;
+};
+
 const updateBrew = (req, res)=>{
 	HomebrewModel.get({ editId: req.params.id })
 		.then((brew)=>{
-			brew = _.merge(brew, req.body);
+			const updateBrew = cleanBrew(req.body);
+			brew = _.merge(brew, updateBrew);
 			brew.text = mergeBrewText(brew.text, brew.style);
 
 			// Compress brew text to binary before saving
@@ -154,7 +164,7 @@ const updateGoogleBrew = async (req, res, next)=>{
 
 	try {	oAuth2Client = GoogleActions.authCheck(req.account, res); } catch (err) { return res.status(err.status).send(err.message); }
 
-	const brew = req.body;
+	const brew = cleanBrew(req.body);
 	brew.text = mergeBrewText(brew.text, brew.style);
 
 	try {

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -19,6 +19,15 @@ const getGoodBrewTitle = (text)=>{
 				 .slice(0, MAX_TITLE_LENGTH);
 };
 
+const excludePropsFromUpdate = (brew)=>{
+	// Remove undesired properties
+	const propsToExclude = ['views', 'lastViewed'];
+	for (const prop of propsToExclude) {
+		delete brew[prop];
+	};
+	return brew;
+};
+
 const mergeBrewText = (text, style)=>{
 	if(typeof style !== 'undefined') {
 		text = `\`\`\`css\n` +
@@ -61,19 +70,10 @@ const newBrew = (req, res)=>{
 	});
 };
 
-const cleanBrew = (brew)=>{
-	// Remove undesired properties
-	const undesiredPropertyNames=['views', 'lastViewed'];
-	for (const undesiredProperty of undesiredPropertyNames) {
-		delete brew[undesiredProperty];
-	};
-	return brew;
-};
-
 const updateBrew = (req, res)=>{
 	HomebrewModel.get({ editId: req.params.id })
 		.then((brew)=>{
-			const updateBrew = cleanBrew(req.body);
+			const updateBrew = excludePropsFromUpdate(req.body);
 			brew = _.merge(brew, updateBrew);
 			brew.text = mergeBrewText(brew.text, brew.style);
 
@@ -164,7 +164,7 @@ const updateGoogleBrew = async (req, res, next)=>{
 
 	try {	oAuth2Client = GoogleActions.authCheck(req.account, res); } catch (err) { return res.status(err.status).send(err.message); }
 
-	const brew = cleanBrew(req.body);
+	const brew = excludePropsFromUpdate(req.body);
 	brew.text = mergeBrewText(brew.text, brew.style);
 
 	try {


### PR DESCRIPTION
Currently, when an EditPage is opened, the `brew.views` data is loaded into the page. However, this data can and does change while editing is taking place, so it should not overwrite the values in MongoDB/Google Drive when the brew is saved.
This PR simply removes the `brew.views` property from the EditPage at the time that the brew is loaded.

This should resolve #406.