### PR TITLE
Fix two css values throwing errors in console

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -238,7 +238,7 @@ body {
 	// ************************************/
 	.descriptive{
 		.useSansSerif();
-		display             : block-inline;
+		display             : inline-block;
 		margin-top          : 1.4em;
 		background-color    : #faf7ea;
 		font-family         : ScalySansRemake;
@@ -335,12 +335,12 @@ body {
 		// Monster Ability table
 		hr + table:first-of-type{
 			margin              : 0;
-			column-span         : 1;
+			column-span         : none;
 			color               : @headerText;
 			background-color    : transparent;
 			border-style        : none;
 			border-image        : none;
-			-webkit-column-span : 1;
+			-webkit-column-span : none;
 			tr {
 				background-color : transparent;
 			}

--- a/themes/5ePhbLegacy.style.less
+++ b/themes/5ePhbLegacy.style.less
@@ -230,11 +230,11 @@ body {
 		// Monster Ability table
 		hr+table{
 			margin              : 0;
-			column-span         : 1;
+			column-span         : none;
 			background-color    : transparent;
 			border-style        : none;
 			border-image        : none;
-			-webkit-column-span : 1;
+			-webkit-column-span : none;
 			tbody{
 				tr:nth-child(odd), tr:nth-child(even){
 					background-color : transparent;
@@ -415,7 +415,7 @@ body {
 // *       DESCRIPTIVE TEXT BOX
 // ************************************/
 .phb .descriptive{
-	display             : block-inline;
+	display             : inline-block;
 	margin-bottom       : 1em;
 	background-color    : #faf7ea;
 	font-family         : ScalySans;


### PR DESCRIPTION
In both Legacy and v3 Stylesheets there are two css properties with invalid values.  Not a big deal, it's not actually impacting anything, but I noticed it in the console when looking for something else.  Using FF.

This updates those values:
- `col-span: 1;`  -->  `col-span:none;`
- `display: block-inline;`  --> `display: inline-block;`

Console also shows a lot of `-moz-column....` properties as invalid.  I don't think we need prefixes on those anymore (for ~94+% of users on the web, according to caniuse.com).  But left those in unless someone wants them out of the console.
