### PR TITLE
Editor-Specific Snippet Groups, and Print Snippet Menu Changes

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -40,19 +40,9 @@ const Snippetbar = createClass({
 		let snippets = [];
 
 		if(this.props.renderer === 'V3')
-			if(this.props.view === 'text') {
-				snippets = SnippetsV3.filter((SnippetsV3)=>SnippetsV3.view === 'text');
-			} else if(this.props.view === 'style') {
-				snippets = SnippetsV3.filter((SnippetsV3)=>SnippetsV3.view === 'style');
-			} else
-				snippets = null;
+			snippets = SnippetsV3.filter((snippetGroup)=>snippetGroup.view === this.props.view);
 		else
-		if(this.props.view === 'text') {
-			snippets = SnippetsLegacy.filter((SnippetsLegacy)=>SnippetsLegacy.view === 'text');
-		} else if(this.props.view === 'style') {
-			snippets = SnippetsLegacy.filter((SnippetsLegacy)=>SnippetsLegacy.view === 'style');
-		} else
-			snippets = null;
+			snippets = SnippetsLegacy.filter((snippetGroup)=>snippetGroup.view === this.props.view);
 
 		return _.map(snippets, (snippetGroup)=>{
 			return <SnippetGroup

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -39,12 +39,26 @@ const Snippetbar = createClass({
 	renderSnippetGroups : function(){
 		let snippets = [];
 
-		if(this.props.view === 'text') {
-			if(this.props.renderer === 'V3')
-				snippets = SnippetsV3;
+		
+		if(this.props.renderer === 'V3')
+			if(this.props.view === 'text') {
+				snippets = SnippetsV3.filter(SnippetsV3 => SnippetsV3.view === 'text');
+			}
+			else if(this.props.view === 'style') {
+				snippets = SnippetsV3.filter(SnippetsV3 => SnippetsV3.view === 'style');
+			}
 			else
-				snippets = SnippetsLegacy;
-		}
+				snippets = null
+		else
+			if(this.props.view === 'text') {
+				snippets = SnippetsLegacy.filter(SnippetsLegacy => SnippetsLegacy.view === 'text');
+			}
+			else if(this.props.view === 'style') {
+				snippets = SnippetsLegacy.filter(SnippetsLegacy => SnippetsLegacy.view === 'style');
+			}
+			else
+				snippets = null
+		
 
 		return _.map(snippets, (snippetGroup)=>{
 			return <SnippetGroup

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -39,26 +39,20 @@ const Snippetbar = createClass({
 	renderSnippetGroups : function(){
 		let snippets = [];
 
-		
 		if(this.props.renderer === 'V3')
 			if(this.props.view === 'text') {
-				snippets = SnippetsV3.filter(SnippetsV3 => SnippetsV3.view === 'text');
-			}
-			else if(this.props.view === 'style') {
-				snippets = SnippetsV3.filter(SnippetsV3 => SnippetsV3.view === 'style');
-			}
-			else
-				snippets = null
+				snippets = SnippetsV3.filter((SnippetsV3)=>SnippetsV3.view === 'text');
+			} else if(this.props.view === 'style') {
+				snippets = SnippetsV3.filter((SnippetsV3)=>SnippetsV3.view === 'style');
+			} else
+				snippets = null;
 		else
-			if(this.props.view === 'text') {
-				snippets = SnippetsLegacy.filter(SnippetsLegacy => SnippetsLegacy.view === 'text');
-			}
-			else if(this.props.view === 'style') {
-				snippets = SnippetsLegacy.filter(SnippetsLegacy => SnippetsLegacy.view === 'style');
-			}
-			else
-				snippets = null
-		
+		if(this.props.view === 'text') {
+			snippets = SnippetsLegacy.filter((SnippetsLegacy)=>SnippetsLegacy.view === 'text');
+		} else if(this.props.view === 'style') {
+			snippets = SnippetsLegacy.filter((SnippetsLegacy)=>SnippetsLegacy.view === 'style');
+		} else
+			snippets = null;
 
 		return _.map(snippets, (snippetGroup)=>{
 			return <SnippetGroup

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -298,35 +298,39 @@ module.exports = [
 			{
 				name : 'A4 Page Size',
 				icon : 'far fa-file',
-				gen  : ['<style>',
-					'  .phb{',
-					'    width : 210mm;',
-					'    height : 296.8mm;',
-					'  }',
-					'</style>'
+				gen  : ['/* A4 Page Size */',
+					'.phb{',
+					'	width : 210mm;',
+					'	height : 296.8mm;',
+					'}',
+					''
 				].join('\n')
 			},
 			{
 				name : 'Square Page Size',
 				icon : 'far fa-file',
-				gen  : ['<style>',
-					'	.page {',
-					'		width:5.25in;',
-					'		height:5.25in;',
-					'		padding:.5in;',
-					'		columns:unset;',
-					'	}',
-					'</style>'
+				gen  : ['/* Square Page Size */',
+					'.page {',
+					'	width:5.25in;',
+					'	height:5.25in;',
+					'	padding:.5in;',
+					'	columns:unset;',
+					'}',
+					''
 				].join('\n')
 			},
 			{
 				name : 'Ink Friendly',
 				icon : 'fas fa-tint',
-				gen  : ['<style>',
-					'	.pages *:is(.page,.monster,.note,.descriptive) {',
-					'		background:white !important;',
-					'	}',
-					'</style>',
+				gen  : ['/* Ink Friendly */',
+					'.pages *:is(.page,.monster,.note,.descriptive) {',
+					'	background:white !important;',
+					'	box-shadow:0px 0px 3px !important;',
+					'}',
+					'',
+					'.page .note:before {',
+					'	box-shadow:0px 0px 3px;',
+					'}',
 					''
 				].join('\n')
 			},

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -14,6 +14,7 @@ module.exports = [
 	{
 		groupName : 'Editor',
 		icon      : 'fas fa-pencil-alt',
+		editor    : 'text',
 		snippets  : [
 			{
 				name : 'Column Break',
@@ -129,6 +130,7 @@ module.exports = [
 	{
 		groupName : 'PHB',
 		icon      : 'fas fa-book',
+		editor    : 'text',
 		snippets  : [
 			{
 				name : 'Spell',
@@ -208,6 +210,7 @@ module.exports = [
 	{
 		groupName : 'Tables',
 		icon      : 'fas fa-table',
+		editor    : 'text',
 		snippets  : [
 			{
 				name : 'Class Table',
@@ -290,6 +293,7 @@ module.exports = [
 	{
 		groupName : 'Page',
 		icon      : 'fas fa-print',
+		editor    : 'style',
 		snippets  : [
 			{
 				name : 'A4 Page Size',

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -285,20 +285,33 @@ module.exports = [
 
 
 
-	/**************** PRINT *************/
+	/**************** PAGE *************/
 
 	{
-		groupName : 'Print',
+		groupName : 'Page',
 		icon      : 'fas fa-print',
 		snippets  : [
 			{
-				name : 'A4 PageSize',
+				name : 'A4 Page Size',
 				icon : 'far fa-file',
 				gen  : ['<style>',
 					'  .phb{',
 					'    width : 210mm;',
 					'    height : 296.8mm;',
 					'  }',
+					'</style>'
+				].join('\n')
+			},
+			{
+				name : 'Square Page Size',
+				icon : 'far fa-file',
+				gen  : ['<style>',
+					'	.page {',
+					'		width:5.25in;',
+					'		height:5.25in;',
+					'		padding:.5in;',
+					'		columns:unset;',
+					'	}',
 					'</style>'
 				].join('\n')
 			},

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -291,7 +291,7 @@ module.exports = [
 	/**************** PAGE *************/
 
 	{
-		groupName : 'Page',
+		groupName : 'Print',
 		icon      : 'fas fa-print',
 		view      : 'style',
 		snippets  : [
@@ -299,8 +299,8 @@ module.exports = [
 				name : 'A4 Page Size',
 				icon : 'far fa-file',
 				gen  : ['/* A4 Page Size */',
-					'.phb{',
-					'	width : 210mm;',
+					'.page{',
+					'	width  : 210mm;',
 					'	height : 296.8mm;',
 					'}',
 					''
@@ -311,10 +311,10 @@ module.exports = [
 				icon : 'far fa-file',
 				gen  : ['/* Square Page Size */',
 					'.page {',
-					'	width:5.25in;',
-					'	height:5.25in;',
-					'	padding:.5in;',
-					'	columns:unset;',
+					'	width   : 125mm;',
+					'	height  : 125mm;',
+					'	padding : 12.5mm;',
+					'	columns : unset;',
 					'}',
 					''
 				].join('\n')
@@ -322,17 +322,20 @@ module.exports = [
 			{
 				name : 'Ink Friendly',
 				icon : 'fas fa-tint',
-				gen  : ['/* Ink Friendly */',
-					'.pages *:is(.page,.monster,.note,.descriptive) {',
-					'	background:white !important;',
-					'	box-shadow:0px 0px 3px !important;',
-					'}',
-					'',
-					'.page .note:before {',
-					'	box-shadow:0px 0px 3px;',
-					'}',
-					''
-				].join('\n')
+				gen  : dedent`
+					/* Ink Friendly */
+					.pages *:is(.page,.monster,.note,.descriptive) {
+						background : white !important;
+						box-shadow : 0px 0px 3px !important;
+					}
+
+					.page .note:before {
+						box-shadow : 0px 0px 3px;
+					}
+
+					.page img {
+						visibility : hidden;
+					}`
 			},
 		]
 	},

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -319,9 +319,9 @@ module.exports = [
 				name : 'Ink Friendly',
 				icon : 'fas fa-tint',
 				gen  : ['<style>',
-					'  .phb{ background : white;}',
-					'  .phb img{ display : none;}',
-					'  .phb hr+blockquote{background : white;}',
+					'	.pages *:is(.page,.monster,.note,.descriptive) {',
+					'		background:white !important;',
+					'	}',
 					'</style>',
 					''
 				].join('\n')

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -14,7 +14,7 @@ module.exports = [
 	{
 		groupName : 'Editor',
 		icon      : 'fas fa-pencil-alt',
-		view    : 'text',
+		view      : 'text',
 		snippets  : [
 			{
 				name : 'Column Break',
@@ -130,7 +130,7 @@ module.exports = [
 	{
 		groupName : 'PHB',
 		icon      : 'fas fa-book',
-		view    : 'text',
+		view      : 'text',
 		snippets  : [
 			{
 				name : 'Spell',
@@ -210,7 +210,7 @@ module.exports = [
 	{
 		groupName : 'Tables',
 		icon      : 'fas fa-table',
-		view    : 'text',
+		view      : 'text',
 		snippets  : [
 			{
 				name : 'Class Table',
@@ -293,7 +293,7 @@ module.exports = [
 	{
 		groupName : 'Page',
 		icon      : 'fas fa-print',
-		view    : 'style',
+		view      : 'style',
 		snippets  : [
 			{
 				name : 'A4 Page Size',

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -14,7 +14,7 @@ module.exports = [
 	{
 		groupName : 'Editor',
 		icon      : 'fas fa-pencil-alt',
-		editor    : 'text',
+		view    : 'text',
 		snippets  : [
 			{
 				name : 'Column Break',
@@ -130,7 +130,7 @@ module.exports = [
 	{
 		groupName : 'PHB',
 		icon      : 'fas fa-book',
-		editor    : 'text',
+		view    : 'text',
 		snippets  : [
 			{
 				name : 'Spell',
@@ -210,7 +210,7 @@ module.exports = [
 	{
 		groupName : 'Tables',
 		icon      : 'fas fa-table',
-		editor    : 'text',
+		view    : 'text',
 		snippets  : [
 			{
 				name : 'Class Table',
@@ -293,7 +293,7 @@ module.exports = [
 	{
 		groupName : 'Page',
 		icon      : 'fas fa-print',
-		editor    : 'style',
+		view    : 'style',
 		snippets  : [
 			{
 				name : 'A4 Page Size',

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -6,7 +6,7 @@ const MonsterBlockGen = require('./monsterblock.gen.js');
 const ClassFeatureGen = require('./classfeature.gen.js');
 const CoverPageGen = require('./coverpage.gen.js');
 const TableOfContentsGen = require('./tableOfContents.gen.js');
-
+const dedent = require('dedent-tabs').default;
 
 module.exports = [
 
@@ -266,7 +266,7 @@ module.exports = [
 	/**************** PRINT *************/
 
 	{
-		groupName : 'Page',
+		groupName : 'Print',
 		icon      : 'fas fa-print',
 		view      : 'style',
 		snippets  : [
@@ -275,8 +275,8 @@ module.exports = [
 				icon : 'far fa-file',
 				gen  : ['/* A4 Page Size */',
 					'.phb {',
-					'    width : 210mm;',
-					'    height : 296.8mm;',
+					'	width  : 210mm;',
+					'	height : 296.8mm;',
 					'}'
 				].join('\n')
 			},
@@ -285,10 +285,10 @@ module.exports = [
 				icon : 'far fa-file',
 				gen  : ['/* Square Page Size */',
 					'.phb {',
-					'	width:5.25in;',
-					'	height:5.25in;',
-					'	padding:.5in;',
-					'	columns:unset;',
+					'	width   : 125mm;',
+					'	height  : 125mm;',
+					'	padding : 12.5mm;',
+					'	columns : unset;',
 					'}',
 					''
 				].join('\n')
@@ -296,13 +296,16 @@ module.exports = [
 			{
 				name : 'Ink Friendly',
 				icon : 'fas fa-tint',
-				gen  : ['/* Ink Friendly */',
-					'.phb, .phb blockquote, .phb hr+blockquote {',
-					'	background : white;',
-					'	box-shadow : 0px 0px 3px;',
-					'}',
-					''
-				].join('\n')
+				gen  : dedent`
+					/* Ink Friendly */',
+					.phb, .phb blockquote, .phb hr+blockquote {
+						background : white;
+						box-shadow : 0px 0px 3px;
+					}
+
+					.phb img {
+						visibility : hidden;
+					}`
 			},
 		]
 	},

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -266,7 +266,7 @@ module.exports = [
 	/**************** PRINT *************/
 
 	{
-		groupName : 'Print',
+		groupName : 'Page',
 		icon      : 'fas fa-print',
 		view    : 'style',
 		snippets  : [

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -271,24 +271,36 @@ module.exports = [
 		view    : 'style',
 		snippets  : [
 			{
-				name : 'A4 PageSize',
+				name : 'A4 Page Size',
 				icon : 'far fa-file',
-				gen  : ['<style>',
-					'  .phb{',
+				gen  : ['/* A4 Page Size */',
+					'.phb {',
 					'    width : 210mm;',
 					'    height : 296.8mm;',
-					'  }',
-					'</style>'
+					'}'
+				].join('\n')
+			},
+			{
+				name : 'Square Page Size',
+				icon : 'far fa-file',
+				gen  : ['/* Square Page Size */',
+					'.phb {',
+					'	width:5.25in;',
+					'	height:5.25in;',
+					'	padding:.5in;',
+					'	columns:unset;',
+					'}',
+					''
 				].join('\n')
 			},
 			{
 				name : 'Ink Friendly',
 				icon : 'fas fa-tint',
-				gen  : ['<style>',
-					'  .phb{ background : white;}',
-					'  .phb img{ display : none;}',
-					'  .phb hr+blockquote{background : white;}',
-					'</style>',
+				gen  : ['/* Ink Friendly */',
+					'.phb, .phb blockquote, .phb hr+blockquote {',
+					'	background : white;',
+					'	box-shadow : 0px 0px 3px;',
+					'}',
 					''
 				].join('\n')
 			},

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -13,7 +13,7 @@ module.exports = [
 	{
 		groupName : 'Editor',
 		icon      : 'fas fa-pencil-alt',
-		view    : 'text',
+		view      : 'text',
 		snippets  : [
 			{
 				name : 'Column Break',
@@ -115,7 +115,7 @@ module.exports = [
 	{
 		groupName : 'PHB',
 		icon      : 'fas fa-book',
-		view    : 'text',
+		view      : 'text',
 		snippets  : [
 			{
 				name : 'Spell',
@@ -183,7 +183,7 @@ module.exports = [
 	{
 		groupName : 'Tables',
 		icon      : 'fas fa-table',
-		view    : 'text',
+		view      : 'text',
 		snippets  : [
 			{
 				name : 'Class Table',
@@ -268,7 +268,7 @@ module.exports = [
 	{
 		groupName : 'Page',
 		icon      : 'fas fa-print',
-		view    : 'style',
+		view      : 'style',
 		snippets  : [
 			{
 				name : 'A4 Page Size',

--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -13,6 +13,7 @@ module.exports = [
 	{
 		groupName : 'Editor',
 		icon      : 'fas fa-pencil-alt',
+		view    : 'text',
 		snippets  : [
 			{
 				name : 'Column Break',
@@ -114,6 +115,7 @@ module.exports = [
 	{
 		groupName : 'PHB',
 		icon      : 'fas fa-book',
+		view    : 'text',
 		snippets  : [
 			{
 				name : 'Spell',
@@ -181,6 +183,7 @@ module.exports = [
 	{
 		groupName : 'Tables',
 		icon      : 'fas fa-table',
+		view    : 'text',
 		snippets  : [
 			{
 				name : 'Class Table',
@@ -265,6 +268,7 @@ module.exports = [
 	{
 		groupName : 'Print',
 		icon      : 'fas fa-print',
+		view    : 'style',
 		snippets  : [
 			{
 				name : 'A4 PageSize',


### PR DESCRIPTION
The main thrust of this PR is to make changes to the current "Print" snippet menu.  The initial changes were a new "square" dimension page snippet similar to the A4 option, but scope grew...

### New/Updated Snippets
- Renaming "Print" to "Page":  IMO, "Print" menu should actually have the option to print a brew, so it's a bit misleading as-is.  Snippets in the menu affect the display of the page itself.
- Square Page:   Change page width & height to be square, for users who would like to share brews on sites like instagram.  Sets dimensions, reduces page padding, and reverts column count to 1.
  - <details><summary>Example Image</summary><img width="540" alt="image" src="https://user-images.githubusercontent.com/58999374/129131078-bf63a4c6-5ff9-44fb-8da5-aedd7054c814.png"></details>
- Updated Ink-Friendly snippet:   updated for v3 so that is using selectors `.monster`, `.note` etc rather than the old selectors `hr + blockquote`.  Also removes background colors from monster blocks and notes to be even more printer friendly.

### Editor Specific Snippet Groups
When making the above changes to the Print menu, it occurred to me that I could try to display the Print/Page snippet menu only when viewing the Style editor, so they are all css specific.  As is, they utilize `<style>` tags, which is something we want to get away from...especially they are making changes across the entire brew.

### Help needed
~~So in snippets.js  (v3) I added a "editor" property in the snippet groups, with values either 'text' or 'style'.   Then each snippet group could be sorted to the right editor....except, for now, I've reached the limit of my nascent JS skills after staring at snippetbar.jsx for several hours. Just wanted to get a PR out there in case this is an easy thing.~~