### PR TITLE
[very minor] Update metadataEditor.less "small" text

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -62,9 +62,6 @@
 			.button(@silver);
 		}
 		small{
-			position   : absolute;
-			bottom     : -15px;
-			left       : 0px;
 			font-size  : 0.6em;
 			font-style : italic;
 		}


### PR DESCRIPTION
This is a quick fix for this:

<img width="284" alt="image" src="https://user-images.githubusercontent.com/58999374/129467282-63917c05-d49c-45f2-bc52-38c70c340d7f.png">

I thought I did this on PR #1480 but I missed it.  