### PR TITLE
Turn box shadows to drop shadows

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -199,20 +199,12 @@ body {
 	// *            NOTE
 	// *****************************/
 	.note{
-		&::before{
-			content             : "";
-			box-sizing          : border-box;
-			border-style        : solid;
-			border-width        : 11px;
-			border-image        : @noteBorderImage 12;
-			border-image-outset : 9px 0px;
-			box-shadow          : 1px 4px 14px #888;
-			position            : absolute;
-			width               : 100%;
-			height              : 100%;
-			top                 : 0;
-			left                : 0;
-		}
+		box-sizing          : border-box;
+		border-style        : solid;
+		border-width        : 11px;
+		border-image        : @noteBorderImage 12;
+		border-image-outset : 9px 0px;
+		box-shadow          : 1px 4px 14px #888;
 		.useSansSerif();
 		position            : relative;
 		margin-top          : 1.3em;

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -199,12 +199,20 @@ body {
 	// *            NOTE
 	// *****************************/
 	.note{
-		box-sizing          : border-box;
-		border-style        : solid;
-		border-width        : 11px;
-		border-image        : @noteBorderImage 12;
-		border-image-outset : 9px 0px;
-		filter              : drop-shadow(1px 4px 6px #888);
+		&::before{
+			content             : "";
+			box-sizing          : border-box;
+			border-style        : solid;
+			border-width        : 11px;
+			border-image        : @noteBorderImage 12;
+			border-image-outset : 9px 0px;
+			filter              : drop-shadow(1px 4px 6px #888);
+			position            : absolute;
+			width               : 100%;
+			height              : 100%;
+			top                 : 0;
+			left                : 0;
+		}
 		.useSansSerif();
 		position            : relative;
 		margin-top          : 1.3em;

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -204,7 +204,7 @@ body {
 		border-width        : 11px;
 		border-image        : @noteBorderImage 12;
 		border-image-outset : 9px 0px;
-		box-shadow          : 1px 4px 14px #888;
+		filter              : drop-shadow(1px 4px 6px #888);
 		.useSansSerif();
 		position            : relative;
 		margin-top          : 1.3em;
@@ -239,7 +239,7 @@ body {
 		border-width        : 7px;
 		border-image        : @descriptiveBoxImage 12 stretch;
 		border-image-outset : 4px;
-		box-shadow          : 0px 0px 6px #faf7ea;
+		filter              : drop-shadow(0 0 3px #faf7ea);
 		padding             : 0.1em;
 		& + * {
 			margin-top : 1.4em;
@@ -297,7 +297,7 @@ body {
 			border-image-outset   : 0px 2px;
 			background-blend-mode : overlay;
 			background-attachment : fixed;
-			box-shadow            : 1px 4px 14px #888;
+			filter                : drop-shadow(1px 4px 6px #888);
 			padding               : 4px 2px;
 			margin                : 0px -6px 1em;
 		}


### PR DESCRIPTION
Addresses Issue #1569 by changing "box-shadow" to "drop-shadow" for the Monster, Note, and Descriptive Note blocks.  Nearly identical to the box-shadow, and will solve the macOS Preview issue.

Has a commit and revert of that commit related to .note:before....it's back to what it was before this PR, so can be ignored.