### PR TITLE
Fix incorrect detection of unclosed <a> tag

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -511,6 +511,12 @@ const tagRegex = new RegExp(`(${
 		return `\\<${type}\\b|\\</${type}>`;
 	}).join('|')})`, 'g');
 
+// Special "void" tags that can be self-closed but don't need to be.
+const voidTags = new Set([
+	'area', 'base', 'br', 'col', 'command', 'hr', 'img',
+	'input', 'keygen', 'link', 'meta', 'param', 'source'
+]);
+
 const processStyleTags = (string)=>{
 	//split tags up. quotes can only occur right after colons.
 	//TODO: can we simplify to just split on commas?
@@ -551,6 +557,13 @@ module.exports = {
 						});
 					}
 					if(match === `</${type}>`){
+						// Closing tag: Check we expect it to be closed.
+						// The accumulator may contain a sequence of voidable opening tags,
+						// over which we skip before checking validity of the close.
+						while (acc.length && voidTags.has(_.last(acc).type) && _.last(acc).type != type) {
+							acc.pop();
+						}
+						// Now check that what remains in the accumulator is valid.
 						if(!acc.length){
 							errors.push({
 								line : lineNumber,

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -508,7 +508,7 @@ const sanatizeScriptTags = (content)=>{
 const tagTypes = ['div', 'span', 'a'];
 const tagRegex = new RegExp(`(${
 	_.map(tagTypes, (type)=>{
-		return `\\<${type}|\\</${type}>`;
+		return `\\<${type}\b|\\</${type}>`;
 	}).join('|')})`, 'g');
 
 const processStyleTags = (string)=>{

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -508,7 +508,7 @@ const sanatizeScriptTags = (content)=>{
 const tagTypes = ['div', 'span', 'a'];
 const tagRegex = new RegExp(`(${
 	_.map(tagTypes, (type)=>{
-		return `\\<${type}\b|\\</${type}>`;
+		return `\\<${type}\\b|\\</${type}>`;
 	}).join('|')})`, 'g');
 
 const processStyleTags = (string)=>{

--- a/shared/naturalcrit/markdownLegacy.js
+++ b/shared/naturalcrit/markdownLegacy.js
@@ -99,8 +99,14 @@ const sanatizeScriptTags = (content)=>{
 const tagTypes = ['div', 'span', 'a'];
 const tagRegex = new RegExp(`(${
 	_.map(tagTypes, (type)=>{
-		return `\\<${type}|\\</${type}>`;
+		return `\\<${type}\\b|\\</${type}>`;
 	}).join('|')})`, 'g');
+
+// Special "void" tags that can be self-closed but don't need to be.
+const voidTags = new Set([
+	'area', 'base', 'br', 'col', 'command', 'hr', 'img',
+	'input', 'keygen', 'link', 'meta', 'param', 'source'
+]);
 
 
 module.exports = {
@@ -128,6 +134,13 @@ module.exports = {
 						});
 					}
 					if(match === `</${type}>`){
+						// Closing tag: Check we expect it to be closed.
+						// The accumulator may contain a sequence of voidable opening tags,
+						// over which we skip before checking validity of the close.
+						while (acc.length && voidTags.has(_.last(acc).type) && _.last(acc).type != type) {
+							acc.pop();
+						}
+						// Now check that what remains in the accumulator is valid.
 						if(!acc.length){
 							errors.push({
 								line : lineNumber,


### PR DESCRIPTION
In the current `master` branch, entering an `<aside>` tag causes the detection of an unclosed `<a>` tag (resolving issue #230).

This PR applies the code changes from #678 to the current `master` branch, rather than attempting to fast forward that PR through ~3 years of changes.

On merging, this should resolve #230 and close #678.