### PR TITLE
minor fix for ink-friendly legacy snippet

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -305,7 +305,7 @@ module.exports = [
 				name : 'Ink Friendly',
 				icon : 'fas fa-tint',
 				gen  : dedent`
-					/* Ink Friendly */',
+					/* Ink Friendly */
 					.phb, .phb blockquote, .phb hr+blockquote {
 						background : white;
 						box-shadow : 0px 0px 3px;


### PR DESCRIPTION
This PR is to address an [issue raised on reddit](https://old.reddit.com/r/homebrewery/comments/p6jp74/v2134/h9n5l54/).   It is just a left over `',` that was missed when adding dedent. 

Snippet should now work in Legacy.