### PR TITLE
Handle `brew.style` being `undefined` when injecting snippets.

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -68,7 +68,10 @@ const Editor = createClass({
 	},
 
 	handleInject : function(injectText){
-		const text = (this.isText() ? this.props.brew.text : this.props.brew.style);
+		const text = (
+			this.isText() && this.props.brew.text ||
+			this.isStyle() && (this.props.brew.style || DEFAULT_STYLE_TEXT)
+		);
 
 		const lines = text.split('\n');
 		const cursorPos = this.refs.codeEditor.getCursorPosition();

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -70,7 +70,7 @@ const Editor = createClass({
 	handleInject : function(injectText){
 		const text = (
 			this.isText() && this.props.brew.text ||
-			this.isStyle() && (this.props.brew.style || DEFAULT_STYLE_TEXT)
+			this.isStyle() && (this.props.brew.style ?? DEFAULT_STYLE_TEXT)
 		);
 
 		const lines = text.split('\n');


### PR DESCRIPTION
This PR will resolve #1593.

When `this.props.brew.style` is still in it's default state of `undefined`, attempting to inject a snippet will fail. This PR changes the logic for setting the `text` variable so that if `this.props.brew.style` is `undefined` when it is passed to the `text` variable, it will instead send the value set as `DEFAULT_STYLE_TEXT` - which is what is displayed in the editor at this time anyway.