### PR TITLE
Add wrapper to .page to improve `wide` behavior with columns

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -131,7 +131,11 @@ const BrewRenderer = createClass({
 		if(this.props.renderer == 'legacy')
 			return <div className='phb page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(pageText) }} key={index} />;
 		else
-			return <div className='phb3 page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} key={index} />;
+			return (
+				<div className='pageWrapper' id={`p${index + 1}`} key={index} >
+					<div className='page' dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} />
+				</div>
+			);
 	},
 
 	renderPages : function(){

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -130,12 +130,14 @@ const BrewRenderer = createClass({
 	renderPage : function(pageText, index){
 		if(this.props.renderer == 'legacy')
 			return <div className='phb page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(pageText) }} key={index} />;
-		else
+		else {
+			pageText += `\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
 			return (
 				<div className='pageWrapper' id={`p${index + 1}`} key={index} >
 					<div className='page' dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} />
 				</div>
 			);
+		}
 	},
 
 	renderPages : function(){

--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -11,6 +11,12 @@
 			margin-left   : auto;
 			box-shadow    : 1px 4px 14px #000;
 		}
+		&>.pageWrapper{
+			margin-right  : auto;
+			margin-bottom : 30px;
+			margin-left   : auto;
+			box-shadow    : 1px 4px 14px #000;
+		}
 	}
 }
 .pane{

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -59,6 +59,7 @@ body {
 }
 .page{
 	.useColumns();
+	max-height        : 100%;
 	padding           : 1.4cm 1.9cm 1.7cm;
 	font-family       : BookInsanityRemake;
 	font-size         : 0.34cm;

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -46,8 +46,7 @@ body {
 	-webkit-column-gap   : 0.9cm;
 	-moz-column-gap      : 0.9cm;
 }
-.page{
-	.useColumns();
+.pageWrapper{
 	counter-increment : phb-page-numbers;
 	position          : relative;
 	z-index           : 15;
@@ -55,9 +54,12 @@ body {
 	overflow          : hidden;
 	height            : 279.4mm;
 	width             : 215.9mm;
-	padding           : 1.4cm 1.9cm 1.7cm;
 	background-color  : @background;
 	background-image  : @backgroundImage;
+}
+.page{
+	.useColumns();
+	padding           : 1.4cm 1.9cm 1.7cm;
 	font-family       : BookInsanityRemake;
 	font-size         : 0.34cm;
 	text-rendering    : optimizeLegibility;


### PR DESCRIPTION
Fixes #144 for V3.

As a compromise, this forces `column-fill : balance` behavior, which means users will be *required* to use manual `\column` breaks if they want to end a column early. This behavior isn't always predictable however, so I'm working on smoothing out some CSS to make it a bit less clunky for those cases.