### PR TITLE
Rearrange BrewItem metadata items - put `authors` first on it's own line

### DIFF
--- a/client/homebrew/pages/userPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.jsx
@@ -110,6 +110,10 @@ const BrewItem = createClass({
 			</div>
 			<hr />
 			<div className='info'>
+				<span title={`Authors:\n${brew.authors.join('\n')}`}>
+					<i className='fas fa-user'/> {brew.authors.join(', ')}
+				</span>
+				<br />
 				<span title={`Last viewed: ${moment(brew.lastViewed).local().format(dateFormatString)}`}>
 					<i className='fas fa-eye'/> {brew.views}
 				</span>
@@ -122,10 +126,6 @@ const BrewItem = createClass({
 					<i className='fas fa-sync-alt' /> {moment(brew.updatedAt).fromNow()}
 				</span>
 				{this.renderGoogleDriveIcon()}
-				<br />
-				<span title={`Authors:\n${brew.authors.join('\n')}`}>
-					<i className='fas fa-user'/> {brew.authors.join(', ')}
-				</span>
 			</div>
 
 			<div className='links'>

--- a/client/homebrew/pages/userPage/brewItem/brewItem.less
+++ b/client/homebrew/pages/userPage/brewItem/brewItem.less
@@ -27,12 +27,11 @@
 	.info{
 		position: initial;
 		bottom: 2px;
-		margin-bottom: 4px;
 		font-family : ScalySans;
 		font-size   : 1.2em;
 		&>span{
-			display      : float;
 			margin-right : 12px;
+			line-height  : 1.5em;
 		}
 	}
 	&:hover{


### PR DESCRIPTION
This PR rearranges the metadata in the BrewItem object on the UserPage to put `authors` before the other metadata, while retaining it's own line in the BrewItem.