### PR TITLE
Fix column-wrapper on print page

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -133,8 +133,8 @@ const BrewRenderer = createClass({
 		else {
 			pageText += `\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
 			return (
-				<div className='pageWrapper' id={`p${index + 1}`} key={index} >
-					<div className='page' dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} />
+				<div className='page' id={`p${index + 1}`} key={index} >
+					<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} />
 				</div>
 			);
 		}

--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -11,12 +11,6 @@
 			margin-left   : auto;
 			box-shadow    : 1px 4px 14px #000;
 		}
-		&>.pageWrapper{
-			margin-right  : auto;
-			margin-bottom : 30px;
-			margin-left   : auto;
-			box-shadow    : 1px 4px 14px #000;
-		}
 	}
 }
 .pane{

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -37,20 +37,21 @@ const PrintPage = createClass({
 
 	renderPages : function(){
 		if(this.props.brew.renderer == 'legacy') {
-			return _.map(this.state.brewText.split('\\page'), (page, index)=>{
+			return _.map(this.state.brewText.split('\\page'), (pageText, index)=>{
 				return <div
 					className='phb page'
 					id={`p${index + 1}`}
-					dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(page) }}
+					dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(pageText) }}
 					key={index} />;
 			});
 		} else {
-			return _.map(this.state.brewText.split(/^\\page/gm), (page, index)=>{
-				return <div
-					className='phb3 page'
-					id={`p${index + 1}`}
-					dangerouslySetInnerHTML={{ __html: Markdown.render(page) }}
-					key={index} />;
+			return _.map(this.state.brewText.split(/^\\page/gm), (pageText, index)=>{
+				pageText += `\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
+				return (
+					<div className='page' id={`p${index + 1}`} key={index} >
+						<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} />
+					</div>
+				);
 			});
 		}
 

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -46,7 +46,11 @@ body {
 	-webkit-column-gap   : 0.9cm;
 	-moz-column-gap      : 0.9cm;
 }
-.pageWrapper{
+.columnWrapper{
+	max-height        : 100%;
+}
+.page{
+	.useColumns();
 	counter-increment : phb-page-numbers;
 	position          : relative;
 	z-index           : 15;
@@ -56,10 +60,6 @@ body {
 	width             : 215.9mm;
 	background-color  : @background;
 	background-image  : @backgroundImage;
-}
-.page{
-	.useColumns();
-	max-height        : 100%;
 	padding           : 1.4cm 1.9cm 1.7cm;
 	font-family       : BookInsanityRemake;
 	font-size         : 0.34cm;
@@ -540,6 +540,7 @@ body {
 	column-span         : all;
 	-webkit-column-span : all;
 	-moz-column-span    : all;
+	display             : block;
 }
 //*****************************
 // *       CLASS TABLE


### PR DESCRIPTION
* /print wasn't emitting the wrapper page
* Changed from `.pageWrapper { .page }` to `.page { .columnWrapper }` so .page is the outermost Div, for consistency with Legacy. Was able to move all properties into .page again so custom CSS should work again without needing special cases for some properties in the wrapper and some not.