### PR TITLE
(WIP) Color Picker

### DIFF
--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -47,5 +47,16 @@
 		bottom   : 10px;
 		right    : 10px;
 		z-index  : 9;
+		button{
+			position         : absolute;
+			background-color : black;
+			width            : 50px;
+			height           : 30px;
+			bottom           : 5px;
+			right            : 5px;
+			z-index          : 15;
+			border           : 2px solid black;
+			padding          : 0px;
+		}
 	}
 }

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -42,4 +42,10 @@
 		.tooltipLeft("Jump to brew page");
 	}
 
+	.sketchPicker{
+		position : absolute;
+		bottom   : 10px;
+		right    : 10px;
+		z-index  : 9;
+	}
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "prop-types": "15.7.2",
     "query-string": "7.0.1",
     "react": "^16.14.0",
+    "react-color": "^2.19.3",
     "react-dom": "^16.14.0",
     "react-frame-component": "4.1.3",
     "react-router-dom": "5.2.0",

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -112,6 +112,12 @@ const CodeEditor = createClass({
 	updateSize : function(){
 		this.codeMirror.refresh();
 	},
+	replaceSelection : function(text, select=''){
+		return this.codeMirror.replaceSelection(text, select);
+	},
+	getSelection : function(lineSeparator=undefined){
+		return this.codeMirror.getSelection(lineSeparator);
+	},
 	//----------------------//
 
 	render : function(){


### PR DESCRIPTION
This draft PR is an initial pass at adding a color picker tool to the Text and Style tabs. As of this commit, the color picker is functional and updates the text in the editor:
- If text is selected, any color values in the selection are replaced with the picked color (identified as "#" followed by 3, 4, 6, or 8 hexadecimal values).
- If no text is selected, the hex value of the picked color is injected at the current cursor position.

---

Once completed, this PR will resolve issue #1422.
