### PR TITLE
Allows DL hanging indents in the mosnter stat block that are not red.

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -362,6 +362,9 @@ body {
 		dl {
 			color : @headerText;
 		}
+		hr:last-of-type~dl{
+			color : inherit; // After the HRs, hanging indents remain black.
+		}
 
 		// Monster Ability table
 		hr + table:first-of-type{


### PR DESCRIPTION
Fixes #149 by using `<dl>` via the new `term :: definition` syntax in V3