### PR TITLE
Add Textbox with Share Link to Metadata Editor

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -7,6 +7,8 @@ const request = require('superagent');
 
 const SYSTEMS = ['5e', '4e', '3.5e', 'Pathfinder'];
 
+
+
 const MetadataEditor = createClass({
 	getDefaultProps : function() {
 		return {
@@ -69,6 +71,7 @@ const MetadataEditor = createClass({
 		const meta = this.props.metadata;
 
 		const shareLink = (meta.googleId || '') + meta.shareId;
+
 		const title = `${meta.title} [${meta.systems.join(' ')}]`;
 		const text = `Hey guys! I've been working on this homebrew. I'd love your feedback. Check it out.
 

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -134,16 +134,19 @@ const MetadataEditor = createClass({
 
 		return <div className='field share'>
 			<label>share</label>
-			<input type='text' className='value'
-				value={shareURL} readOnly />
-			<button className='clipboard' onClick={()=>{navigator.clipboard.writeText(`${shareURL}`);}}>
-				<i className='far fa-copy' />
-			</button>
-			<a href={this.getRedditLink()} target='_blank' rel='noopener noreferrer'>
-				<button className='reddit'>
-					<i className='fab fa-reddit-alien' />
-				</button>
-			</a>
+			<div className='value'>
+				<div className='hovertext'>
+					<input type='text' value={shareURL} readOnly />
+					<button className='clipboard' onClick={()=>{navigator.clipboard.writeText(`${shareURL}`);}}>
+						<i className='far fa-copy' /> copy
+					</button>
+				</div>
+				<a href={this.getRedditLink()} target='_blank' rel='noopener noreferrer'>
+					<button className='reddit'>
+						<i className='fab fa-reddit-alien' /> share to r/unearthedarcana
+					</button>
+				</a>
+			</div>
 		</div>;
 	},
 

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -130,15 +130,20 @@ const MetadataEditor = createClass({
 	renderShareToReddit : function(){
 		if(!this.props.metadata.shareId) return;
 
-		return <div className='field reddit'>
-			<label>reddit</label>
-			<div className='value'>
-				<a href={this.getRedditLink()} target='_blank' rel='noopener noreferrer'>
-					<button className='publish'>
-						<i className='fab fa-reddit-alien' /> share to reddit
-					</button>
-				</a>
-			</div>
+		const shareURL = `https://homebrewery.naturalcrit.com/share/${this.props.metadata.shareId}`;
+
+		return <div className='field share'>
+			<label>share</label>
+			<input type='text' className='value'
+				value={shareURL} readOnly />
+			<button className='clipboard' onClick={()=>{navigator.clipboard.writeText(`${shareURL}`);}}>
+				<i className='far fa-copy' />
+			</button>
+			<a href={this.getRedditLink()} target='_blank' rel='noopener noreferrer'>
+				<button className='reddit'>
+					<i className='fab fa-reddit-alien' />
+				</button>
+			</a>
 		</div>;
 	},
 

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -77,9 +77,12 @@
 			.button(@red);
 		}
 	}
-	.reddit.field .value{
+	.share.field{
 		button{
-			.button(@purple);
+			.button(@orange);
+			&.clipboard{
+				.button(@purple)
+			}
 		}
 	}
 	.authors.field .value{

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -84,6 +84,47 @@
 				.button(@purple)
 			}
 		}
+		.value{
+			display		: flex;
+			flex-wrap	: wrap;
+			.hovertext{
+				flex			: 1 0 100%;
+				align-items 	: center;
+				position		: relative;
+				padding-bottom 	: 5px;
+				input{
+					width			: 100%;
+					direction 		: rtl;
+					text-align 		: left;
+					text-overflow 	: ellipsis;
+				}
+				button{
+					position			: absolute;
+					right				: 5px;
+					top					: 1px;
+					background-color	: #cdcdcd;
+					height				: unset;
+					width				: unset;
+					border-radius		: 4px;
+					padding 			: 2px;
+					color				: black;
+					opacity 			: 0%;
+					transition			: all .5s ease;
+					font-size 			: .5em;
+					margin 				: 2px;
+				}
+				&:hover button{
+					opacity		: 100%;
+					transition	: all .5s ease;
+				}
+			}
+			a{
+				flex	: 1 0 100%;
+				button{
+					width	: 100%;
+				}
+			}
+		}
 	}
 	.authors.field .value{
 		font-size: 0.8em;

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -408,11 +408,14 @@ const EditPage = createClass({
 	getRedditLink : function(){
 
 		const shareLink = this.processShareId();
-
-		const title = `${this.props.brew.title} [${this.props.brew.systems.join(' ')}]`;
+		const systems = this.props.brew.systems.length > 0 ? ` [${this.props.brew.systems.join(' - ')}]` : '';
+		const title = `${this.props.brew.title} ${systems}`;
+		const description = this.props.brew.description.length > 0 ? `### Description\n${this.props.brew.description}` : '';
 		const text = `Hey guys! I've been working on this homebrew. I'd love your feedback. Check it out.
 
-**[Homebrewery Link](https://homebrewery.naturalcrit.com/share/${shareLink})**`;
+**[Homebrewery Link](https://homebrewery.naturalcrit.com/share/${shareLink})**
+
+${description}`;
 
 		return `https://www.reddit.com/r/UnearthedArcana/submit?title=${encodeURIComponent(title)}&text=${encodeURIComponent(text)}`;
 	},

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -399,6 +399,42 @@ const EditPage = createClass({
 					 this.state.brew.shareId;
 	},
 
+	handleDropdown : function(show){
+		this.setState({
+			showDropdown : show
+		});
+	},
+
+	getRedditLink : function(){
+
+		const shareLink = this.processShareId();
+
+		const title = `${this.props.brew.title} [${this.props.brew.systems.join(' ')}]`;
+		const text = `Hey guys! I've been working on this homebrew. I'd love your feedback. Check it out.
+
+**[Homebrewery Link](https://homebrewery.naturalcrit.com/share/${shareLink})**`;
+
+		return `https://www.reddit.com/r/UnearthedArcana/submit?title=${encodeURIComponent(title)}&text=${encodeURIComponent(text)}`;
+	},
+
+	renderDropdown : function(){
+		if(!this.state.showDropdown) return null;
+
+		const shareLink = this.processShareId();
+
+		return <div className='dropdown'>
+			<a href={`/share/${this.processShareId()}`} className='item'>
+				view
+			</a>
+			<a className='item' onClick={()=>{navigator.clipboard.writeText(`https://homebrewery.naturalcrit.com/share/${shareLink}`);}}>
+				copy url
+			</a>
+			<a href={`${this.getRedditLink()}`} target='_blank' rel='noopener noreferrer' className='item'>
+				post to reddit
+			</a>
+		</div>;
+	},
+
 	renderNavbar : function(){
 		return <Navbar>
 
@@ -420,8 +456,11 @@ const EditPage = createClass({
 				{this.renderSaveButton()}
 				<NewBrew />
 				<ReportIssue />
-				<Nav.item newTab={true} href={`/share/${this.processShareId()}`} color='teal' icon='fas fa-share-alt'>
-					Share
+				<Nav.item color='teal' icon='fas fa-share-alt' className='share'
+					onMouseEnter={()=>this.handleDropdown(true)}
+					onMouseLeave={()=>this.handleDropdown(false)}>
+					share
+					{this.renderDropdown()}
 				</Nav.item>
 				<PrintLink shareId={this.processShareId()} />
 				<RecentNavItem brew={this.state.brew} storageKey='edit' />

--- a/client/homebrew/pages/editPage/editPage.less
+++ b/client/homebrew/pages/editPage/editPage.less
@@ -18,6 +18,51 @@
 			background-color : @red;
 		}
 	}
+	.share.navItem{
+		position : relative;
+		.dropdown{
+			position : absolute;
+			top      : 28px;
+			left     : 0px;
+			z-index  : 10000;
+			width    : 100%;
+			h4{
+				display          : block;
+				box-sizing       : border-box;
+				padding          : 5px 0px;
+				background-color : #333;
+				font-size        : 0.8em;
+				color            : #bbb;
+				text-align       : center;
+				border-top       : 1px solid #888;
+				&:nth-of-type(1){ background-color: darken(@teal, 20%); }
+				&:nth-of-type(2){ background-color: darken(@purple, 30%); }
+			}
+			.item{
+				.animate(background-color);
+				position         : relative;
+				display          : block;
+				width            : 100%;
+				vertical-align   : middle;
+				padding          : 13px 5px;
+				box-sizing       : border-box;
+				background-color : #333;
+				color            : white;
+				text-decoration  : none;
+				border-top       : 1px solid #888;
+				&:hover{
+					background-color : @blue;
+				}
+				.title{
+					display       : inline-block;
+					overflow      : hidden;
+					width         : 100%;
+					text-overflow : ellipsis;
+					white-space   : nowrap;
+				}
+			}
+		}
+	}
 	.googleDriveStorage {
 		position : relative;
 	}


### PR DESCRIPTION
This PR adds a read-only text field that displays the Share URL for a brew.  It also adds a 'copy to clipboard' button.

This removes the need to click through to the Share page to get the share url, which can be tedious.  

<img width="455" alt="image" src="https://user-images.githubusercontent.com/58999374/132081105-bae7d678-4772-4b87-9a29-36790ab4bc94.png">

(my local build doesn't display the icons for some reason I haven't figured out yet).