### PR TITLE
Add Hotkeys for Underline and makeDiv

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -155,12 +155,24 @@ const CodeEditor = createClass({
 	},
 
 	makeComment : function() {
-		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 4) === '<!--' && selection.slice(-3) === '-->';
-		this.codeMirror.replaceSelection(t ? selection.slice(4, -3) : `<!-- ${selection} -->`, 'around');
+		let regex;
+		let cursorPos;
+		let newComment;
+		const selection = this.codeMirror.getSelection();
+		if(this.props.language === 'gfm'){
+			regex = /^\s*(<!--\s?)(.*?)(\s?-->)\s*$/gs;
+			cursorPos = 4;
+			newComment = `<!-- ${selection} -->`;
+		} else {
+			regex = /^\s*(\/\*\s?)(.*?)(\s?\*\/)\s*$/gs;
+			cursorPos = 3;
+			newComment = `/* ${selection} */`;
+		}
+		this.codeMirror.replaceSelection(regex.test(selection) == true ? selection.replace(regex, '$2') : newComment, 'around');
 		if(selection.length === 0){
 			const cursor = this.codeMirror.getCursor();
-			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 4 });
-		}
+			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - cursorPos });
+		};
 	},
 
 	//=-- Externally used -==//

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -51,6 +51,8 @@ const CodeEditor = createClass({
 				'Cmd-B'  : this.makeBold,
 				'Ctrl-I' : this.makeItalic,
 				'Cmd-I'  : this.makeItalic,
+				'Ctrl-U' : this.makeUnderline,
+				'Cmd-U'  : this.makeUnderline,
 				'Ctrl-M' : this.makeSpan,
 				'Cmd-M'  : this.makeSpan,
 				'Ctrl-/' : this.makeComment,
@@ -73,11 +75,20 @@ const CodeEditor = createClass({
 	},
 
 	makeItalic : function() {
-		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 1) === '_' && selection.slice(-1) === '_';
-		this.codeMirror.replaceSelection(t ? selection.slice(1, -1) : `_${selection}_`, 'around');
+		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 1) === '*' && selection.slice(-1) === '*';
+		this.codeMirror.replaceSelection(t ? selection.slice(1, -1) : `*${selection}*`, 'around');
 		if(selection.length === 0){
 			const cursor = this.codeMirror.getCursor();
 			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 1 });
+		}
+	},
+
+	makeUnderline : function() {
+		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 3) === '<u>' && selection.slice(-4) === '</u>';
+		this.codeMirror.replaceSelection(t ? selection.slice(3, -4) : `<u>${selection}</u>`, 'around');
+		if(selection.length === 0){
+			const cursor = this.codeMirror.getCursor();
+			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 4 });
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 require('./codeEditor.less');
 const React = require('react');
 const createClass = require('create-react-class');

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -53,6 +53,12 @@ const CodeEditor = createClass({
 				'Cmd-I'        : this.makeItalic,
 				'Ctrl-U'       : this.makeUnderline,
 				'Cmd-U'        : this.makeUnderline,
+				'Ctrl-.'       : this.makeNbsp,
+				'Cmd-.'        : this.makeNbsp,
+				'Shift-Ctrl-.' : this.makeSpace,
+				'Shift-Cmd-.'  : this.makeSpace,
+				'Shift-Ctrl-,' : this.removeSpace,
+				'Shift-Cmd-,'  : this.removeSpace,
 				'Ctrl-M'       : this.makeSpan,
 				'Cmd-M'        : this.makeSpan,
 				'Shift-Ctrl-M' : this.makeDiv,
@@ -82,6 +88,30 @@ const CodeEditor = createClass({
 		if(selection.length === 0){
 			const cursor = this.codeMirror.getCursor();
 			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 1 });
+		}
+	},
+
+	makeNbsp : function() {
+		this.codeMirror.replaceSelection('&nbsp;', 'end');
+	},
+
+	makeSpace : function() {
+		const selection = this.codeMirror.getSelection();
+		const t = selection.slice(0, 8) === '{{width:' && selection.slice(0 -4) === '% }}';
+		if(t){
+			const percent = parseInt(selection.slice(8, -4)) + 10;
+			this.codeMirror.replaceSelection(percent < 90 ? `{{width:${percent}% }}` : '{{width:100% }}', 'around');
+		} else {
+			this.codeMirror.replaceSelection(`{{width:10% }}`, 'around');
+		}
+	},
+
+	removeSpace : function() {
+		const selection = this.codeMirror.getSelection();
+		const t = selection.slice(0, 8) === '{{width:' && selection.slice(0 -4) === '% }}';
+		if(t){
+			const percent = parseInt(selection.slice(8, -4)) - 10;
+			this.codeMirror.replaceSelection(percent > 10 ? `{{width:${percent}% }}` : '', 'around');
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -47,16 +47,18 @@ const CodeEditor = createClass({
 			indentWithTabs : true,
 			tabSize        : 2,
 			extraKeys      : {
-				'Ctrl-B' : this.makeBold,
-				'Cmd-B'  : this.makeBold,
-				'Ctrl-I' : this.makeItalic,
-				'Cmd-I'  : this.makeItalic,
-				'Ctrl-U' : this.makeUnderline,
-				'Cmd-U'  : this.makeUnderline,
-				'Ctrl-M' : this.makeSpan,
-				'Cmd-M'  : this.makeSpan,
-				'Ctrl-/' : this.makeComment,
-				'Cmd-/'  : this.makeComment
+				'Ctrl-B'       : this.makeBold,
+				'Cmd-B'        : this.makeBold,
+				'Ctrl-I'       : this.makeItalic,
+				'Cmd-I'        : this.makeItalic,
+				'Ctrl-U'       : this.makeUnderline,
+				'Cmd-U'        : this.makeUnderline,
+				'Ctrl-M'       : this.makeSpan,
+				'Cmd-M'        : this.makeSpan,
+				'Shift-Ctrl-M' : this.makeDiv,
+				'Shift-Cmd-M'  : this.makeDiv,
+				'Ctrl-/'       : this.makeComment,
+				'Cmd-/'        : this.makeComment
 			}
 		});
 
@@ -98,6 +100,15 @@ const CodeEditor = createClass({
 		if(selection.length === 0){
 			const cursor = this.codeMirror.getCursor();
 			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 2 });
+		}
+	},
+
+	makeDiv : function() {
+		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 2) === '{{' && selection.slice(-2) === '}}';
+		this.codeMirror.replaceSelection(t ? selection.slice(2, -2) : `{{\n${selection}\n}}`, 'around');
+		if(selection.length === 0){
+			const cursor = this.codeMirror.getCursor();
+			this.codeMirror.setCursor({ line: cursor.line - 1, ch: cursor.ch });  // set to -2? if wanting to enter classes etc.  if so, get rid of first \n when replacing selection
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -47,24 +47,28 @@ const CodeEditor = createClass({
 			indentWithTabs : true,
 			tabSize        : 2,
 			extraKeys      : {
-				'Ctrl-B'       : this.makeBold,
-				'Cmd-B'        : this.makeBold,
-				'Ctrl-I'       : this.makeItalic,
-				'Cmd-I'        : this.makeItalic,
-				'Ctrl-U'       : this.makeUnderline,
-				'Cmd-U'        : this.makeUnderline,
-				'Ctrl-.'       : this.makeNbsp,
-				'Cmd-.'        : this.makeNbsp,
-				'Shift-Ctrl-.' : this.makeSpace,
-				'Shift-Cmd-.'  : this.makeSpace,
-				'Shift-Ctrl-,' : this.removeSpace,
-				'Shift-Cmd-,'  : this.removeSpace,
-				'Ctrl-M'       : this.makeSpan,
-				'Cmd-M'        : this.makeSpan,
-				'Shift-Ctrl-M' : this.makeDiv,
-				'Shift-Cmd-M'  : this.makeDiv,
-				'Ctrl-/'       : this.makeComment,
-				'Cmd-/'        : this.makeComment
+				'Ctrl-B'           : this.makeBold,
+				'Cmd-B'            : this.makeBold,
+				'Ctrl-I'           : this.makeItalic,
+				'Cmd-I'            : this.makeItalic,
+				'Ctrl-U'           : this.makeUnderline,
+				'Cmd-U'            : this.makeUnderline,
+				'Ctrl-.'           : this.makeNbsp,
+				'Cmd-.'            : this.makeNbsp,
+				'Shift-Ctrl-.'     : this.makeSpace,
+				'Shift-Cmd-.'      : this.makeSpace,
+				'Shift-Ctrl-,'     : this.removeSpace,
+				'Shift-Cmd-,'      : this.removeSpace,
+				'Shift-Ctrl-Enter' : this.newColumn,
+				'Shift-Cmd-Enter'  : this.newColumn,
+				'Ctrl-Enter'       : this.newPage,
+				'Cmd-Enter'        : this.newPage,
+				'Ctrl-M'           : this.makeSpan,
+				'Cmd-M'            : this.makeSpan,
+				'Shift-Ctrl-M'     : this.makeDiv,
+				'Shift-Cmd-M'      : this.makeDiv,
+				'Ctrl-/'           : this.makeComment,
+				'Cmd-/'            : this.makeComment
 			}
 		});
 
@@ -113,6 +117,14 @@ const CodeEditor = createClass({
 			const percent = parseInt(selection.slice(8, -4)) - 10;
 			this.codeMirror.replaceSelection(percent > 10 ? `{{width:${percent}% }}` : '', 'around');
 		}
+	},
+
+	newColumn : function() {
+		this.codeMirror.replaceSelection('\n\\column\n\n', 'end');
+	},
+
+	newPage : function() {
+		this.codeMirror.replaceSelection('\n\\page\n\n', 'end');
 	},
 
 	makeUnderline : function() {

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -13,6 +13,13 @@ if(typeof navigator !== 'undefined'){
 	require('codemirror/mode/gfm/gfm.js'); //Github flavoured markdown
 	require('codemirror/mode/css/css.js');
 	require('codemirror/mode/javascript/javascript.js');
+
+	//Addons
+	require('codemirror/addon/fold/foldcode.js');
+	require('codemirror/addon/fold/foldgutter.js');
+
+	const foldCode = require('./fold-code');
+	foldCode.registerHomebreweryHelper(CodeMirror);
 }
 
 const CodeEditor = createClass({
@@ -25,28 +32,48 @@ const CodeEditor = createClass({
 		};
 	},
 
+	getInitialState : function() {
+		return {
+			docs : {}
+		};
+	},
+
 	componentDidMount : function() {
 		this.buildEditor();
+		const newDoc = CodeMirror.Doc(this.props.value, this.props.language);
+		this.codeMirror.swapDoc(newDoc);
 	},
 
 	componentDidUpdate : function(prevProps) {
-		if(prevProps.language !== this.props.language){ //rebuild editor when switching tabs
-			this.buildEditor();
-		}
-		if(this.codeMirror && this.codeMirror.getValue() != this.props.value) { //update editor contents if brew.text is changed from outside
+		if(prevProps.view !== this.props.view){ //view changed; swap documents
+			let newDoc;
+
+			if(!this.state.docs[this.props.view]) {
+				newDoc = CodeMirror.Doc(this.props.value, this.props.language);
+			} else {
+				newDoc = this.state.docs[this.props.view];
+			}
+
+			const oldDoc = { [prevProps.view]: this.codeMirror.swapDoc(newDoc) };
+
+			this.setState((prevState)=>({
+				docs : _.merge({}, prevState.docs, oldDoc)
+			}));
+
+			this.props.rerenderParent();
+		} else if(this.codeMirror?.getValue() != this.props.value) { //update editor contents if brew.text is changed from outside
 			this.codeMirror.setValue(this.props.value);
 		}
 	},
 
 	buildEditor : function() {
 		this.codeMirror = CodeMirror(this.refs.editor, {
-			value          : this.props.value,
-			lineNumbers    : true,
-			lineWrapping   : this.props.wrap,
-			mode           : this.props.language, //TODO: CSS MODE DOESN'T SEEM TO LOAD PROPERLY
-			indentWithTabs : true,
-			tabSize        : 2,
-			extraKeys      : {
+			lineNumbers       : true,
+			lineWrapping      : this.props.wrap,
+			indentWithTabs    : true,
+			tabSize           : 2,
+			historyEventDelay : 250,
+			extraKeys         : {
 				'Ctrl-B'           : this.makeBold,
 				'Cmd-B'            : this.makeBold,
 				'Ctrl-I'           : this.makeItalic,
@@ -59,17 +86,46 @@ const CodeEditor = createClass({
 				'Shift-Cmd-.'      : this.makeSpace,
 				'Shift-Ctrl-,'     : this.removeSpace,
 				'Shift-Cmd-,'      : this.removeSpace,
-				'Shift-Ctrl-Enter' : this.newColumn,
-				'Shift-Cmd-Enter'  : this.newColumn,
-				'Ctrl-Enter'       : this.newPage,
-				'Cmd-Enter'        : this.newPage,
 				'Ctrl-M'           : this.makeSpan,
 				'Cmd-M'            : this.makeSpan,
 				'Shift-Ctrl-M'     : this.makeDiv,
 				'Shift-Cmd-M'      : this.makeDiv,
 				'Ctrl-/'           : this.makeComment,
-				'Cmd-/'            : this.makeComment
-			}
+				'Cmd-/'            : this.makeComment,
+				'Ctrl-K'           : this.makeLink,
+				'Cmd-K'            : this.makeLink,
+				'Shift-Ctrl-Enter' : this.newColumn,
+				'Shift-Cmd-Enter'  : this.newColumn,
+				'Ctrl-Enter'       : this.newPage,
+				'Cmd-Enter'        : this.newPage,
+				'Ctrl-['           : this.foldAllCode,
+				'Cmd-['            : this.foldAllCode,
+				'Ctrl-]'           : this.unfoldAllCode,
+				'Cmd-]'            : this.unfoldAllCode
+			},
+			foldGutter  : true,
+			foldOptions : {
+				scanUp      : true,
+				rangeFinder : CodeMirror.fold.homebrewery,
+				widget      : (from, to)=>{
+					let text = '';
+					let currentLine = from.line;
+					const maxLength = 50;
+					while (currentLine <= to.line && text.length <= maxLength) {
+						text += this.codeMirror.getLine(currentLine);
+						if(currentLine < to.line)
+							text += ' ';
+						currentLine += 1;
+					}
+
+					text = text.trim();
+					if(text.length > maxLength)
+						text = `${text.substr(0, maxLength)}...`;
+
+					return `\u21A4 ${text} \u21A6`;
+				}
+			},
+			gutters : ['CodeMirror-linenumbers', 'CodeMirror-foldgutter']
 		});
 
 		// Note: codeMirror passes a copy of itself in this callback. cm === this.codeMirror. Either one works.
@@ -175,6 +231,31 @@ const CodeEditor = createClass({
 		};
 	},
 
+	makeLink : function() {
+		const isLink = /^\[(.*)\]\((.*)\)$/;
+		const selection = this.codeMirror.getSelection().trim();
+		let match;
+		if(match = isLink.exec(selection)){
+			const altText = match[1];
+			const url     = match[2];
+			this.codeMirror.replaceSelection(`${altText} ${url}`);
+			const cursor = this.codeMirror.getCursor();
+			this.codeMirror.setSelection({ line: cursor.line, ch: cursor.ch - url.length }, { line: cursor.line, ch: cursor.ch });
+		} else {
+			this.codeMirror.replaceSelection(`[${selection || 'alt text'}](url)`);
+			const cursor = this.codeMirror.getCursor();
+			this.codeMirror.setSelection({ line: cursor.line, ch: cursor.ch - 4 }, { line: cursor.line, ch: cursor.ch - 1 });
+		}
+	},
+
+	foldAllCode : function() {
+		this.codeMirror.execCommand('foldAll');
+	},
+
+	unfoldAllCode : function() {
+		this.codeMirror.execCommand('unfoldAll');
+	},
+
 	//=-- Externally used -==//
 	setCursorPosition : function(line, char){
 		setTimeout(()=>{
@@ -188,10 +269,19 @@ const CodeEditor = createClass({
 	updateSize : function(){
 		this.codeMirror.refresh();
 	},
+	redo : function(){
+		return this.codeMirror.redo();
+	},
+	undo : function(){
+		return this.codeMirror.undo();
+	},
+	historySize : function(){
+		return this.codeMirror.doc.historySize();
+	},
 	//----------------------//
 
 	render : function(){
-		return <div className='codeEditor' ref='editor' />;
+		return <div className='codeEditor' ref='editor' style={this.props.style}/>;
 	}
 });
 


### PR DESCRIPTION
Adds hotkeys:

## Underline:  `ctrl`/`cmd` + `u`
<details>
<summary>Click to expand</summary>

```
 <u>|</u>
```
*_pipe indicates final cursor position when no selection_


- I am happy to change this to `++ text ++` --> `<ins> text </ins>` to match the convention in [markdown-it](https://github.com/markdown-it/markdown-it-ins) but I cannot yet figure out how to add custom inline markdown in CodeMirror.  Since html tags will always still work in CodeMirror, it's my opinion it would be fine to add this hotkey as-is and make a change to it later to work with `++`.  
</details>

## makeDiv:   `shift` + `ctrl`/`cmd` + `m` 
<details>
<summary>Click to expand</summary>

```
{{
|
}}
```
*_pipe indicates final cursor position when no selection_

### Considerations
- makeDiv is for v3 only, using curly syntax. 
- I considered setting the final cursor position on makeDiv to be immediately after the opening brackets, to facilitate quickly adding classes etc....
  - but not sure how to find that position when creating from non-empty selection (when using replace)
  - if going ahead with this, likely best to eliminate the empty line between brackets, so that the first "empty" line is created by hitting enter after entering class names etc.
</details>

##  makeNbsp: `ctrl` / `cmd` + `.`
<details>
<summary>Click to expand</summary>

```
&nbsp;
```
Finishes with the cursor at the end.  May look into an additional hotkey (`ctrl` + `,`) to remove as well.
</details>

## makeSpace: `shift` + `ctrl` / `cmd` + `.`
<details>
<summary>Click to expand</summary>

```
{{width:10% }}
```
Finishes with span selected.  Repeated use increases the percentage by 10% increments to a max of 100%.


## removeSpace: `shift` + `ctrl` / `cmd` + `,`
Reduces the above span by 10% increments until 0%, at which point the span is removed entirely.

Overall, these hotkeys should make it easier to work with wrapping text around images, if not using shape-outside etc.  While shape-outside might be the ideal method of wrapping text, it is still difficult to use and doesn't work in every situation.

</details>

## makePage: `ctrl` / `cmd` + `Enter`
<details>
<summary>Click to expand</summary>

```

\page

|
```
*_pipe indicates final cursor position when no selection_

Creates a new page.

</details>

## makeColumn: `shift` + `ctrl` / `cmd` + `Enter`
<details>
<summary>Click to expand</summary>

```
\column

|
```
*_pipe indicates final cursor position when no selection_

Creates a new column

</details>

### Minor Changes
a. This PR does also change the current `makeItalic` hotkey to use `*` instead of `_`.   This is sort of an arbitrary change, but I feel it is more consistent with the syntax used in existing snippets.
b. makeComment() was added in a previous PR/release, but in this PR I just updated it to be responsive to either the GFM editor or CSS editor (commit 3bf5d7a).  It will now comment correctly in either editor.  It also fixes a minor issue where undoing a comment left a leading and trailing space.  This resolves #1303.

### Closes
a. possibly closes #732 
b. resolves #1303

### Related PR's
- #1719:  Lists
- #1568:  Links
 