### PR TITLE
GMB Compatibility

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -30,7 +30,7 @@ const BrewRenderer = createClass({
 		if(this.props.renderer == 'legacy') {
 			pages = this.props.text.split('\\page');
 		} else {
-			pages = this.props.text.split(/^\\page$/gm);
+			pages = this.props.text.split(/^\\pagebreakNum$|^\\pagebreak$|^\\page$/gm);
 		}
 
 		return {
@@ -62,7 +62,7 @@ const BrewRenderer = createClass({
 			if(this.props.renderer == 'legacy') {
 				pages = this.props.text.split('\\page');
 			} else {
-				pages = this.props.text.split(/^\\page$/gm);
+				pages = this.props.text.split(/^\\pagebreakNum$|^\\pagebreak$|^\\page$/gm);
 			}
 			this.setState({
 				pages  : pages,

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -122,12 +122,12 @@ const Editor = createClass({
 
 				// New Codemirror styling for V3 renderer
 				if(this.props.renderer == 'V3') {
-					if(line.match(/^\\page$/)){
+					if(line.match(/^\\page$|^\\pagebreak$|^\\pagebreakNum$/)){
 						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
 						r.push(lineNumber);
 					}
 
-					if(line.match(/^\\column$/)){
+					if(line.match(/^\\column$|^\\columnbreak$/)){
 						codeMirror.addLineClass(lineNumber, 'text', 'columnSplit');
 						r.push(lineNumber);
 					}

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -197,7 +197,7 @@ const EditPage = createClass({
 		const transfer = this.state.saveGoogle == _.isNil(this.state.brew.googleId);
 
 		const brew = this.state.brew;
-		brew.pageCount = ((brew.renderer=='legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$/gm)) || []).length + 1;
+		brew.pageCount = ((brew.renderer=='legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$|^\\pagebreak$|^\\pagebreakNum$/gm)) || []).length + 1;
 
 		if(this.state.saveGoogle) {
 			if(transfer) {

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -161,7 +161,7 @@ const NewPage = createClass({
 			brew.text = brew.text.slice(index + 5);
 		};
 
-		brew.pageCount=((brew.renderer=='legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$/gm)) || []).length + 1;
+		brew.pageCount=((brew.renderer=='legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$|^\\pagebreak$|^\\pagebreakNum$/gm)) || []).length + 1;
 
 		if(this.state.saveGoogle) {
 			const res = await request

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -45,7 +45,7 @@ const PrintPage = createClass({
 					key={index} />;
 			});
 		} else {
-			return _.map(this.state.brewText.split(/^\\page$/gm), (pageText, index)=>{
+			return _.map(this.state.brewText.split(/^\\page$|^\\pagebreak$|^\\pagebreakNum$/gm), (pageText, index)=>{
 				pageText += `\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
 				return (
 					<div className='page' id={`p${index + 1}`} key={index} >

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -527,7 +527,7 @@ const processStyleTags = (string)=>{
 module.exports = {
 	marked : Markdown,
 	render : (rawBrewText)=>{
-		rawBrewText = rawBrewText.replace(/^\\column$/gm, `\n<div class='columnSplit'></div>\n`)
+		rawBrewText = rawBrewText.replace(/^\\columnbreak$|^\\column$/gm, `\n<div class='columnSplit'></div>\n`)
 														 .replace(/^(:+)$/gm, (match)=>`${`<div class='blank'></div>`.repeat(match.length)}\n`);
 		return Markdown(
 			sanatizeScriptTags(rawBrewText),


### PR DESCRIPTION
Looking to make it as easy as possible to bring GMB documents to Homebrewery (and back again, if there is time).  One goal is to increase user count with easy migration process, but also to help troubleshoot issues occurring in GMB using Homebrewery.

### First Commit
This commit adds `\pagebreak`, `\pagebreakNum`, and `\columnbreak` to the watch words for page and column breaks.

It does nothing further for `\pagebreakNum` (does not add page numbers).

### Further Work
- [ ] apply page numbers using \pagebreakNum
- [ ] identify baked in class names such as "cover-page"
- [ ] more...