### PR TITLE
change legacy box shadows to drop-shadow

### DIFF
--- a/themes/5ePhbLegacy.style.less
+++ b/themes/5ePhbLegacy.style.less
@@ -188,7 +188,7 @@ body {
 		border-width        : 11px;
 		border-image        : @noteBorderImage 11;
 		border-image-outset : 9px 0px;
-		box-shadow          : 1px 4px 14px #888;
+		filter              : drop-shadow(1px 4px 6px #888);
 		p, ul{
 			font-size   : 0.352cm;
 			line-height : 1.1em;
@@ -424,7 +424,7 @@ body {
 	border-width        : 7px;
 	border-image        : @descriptiveBoxImage 12 stretch;
 	border-image-outset : 4px;
-	box-shadow          : 0px 0px 6px #faf7ea;
+	filter              : drop-shadow(0 0 3px #faf7ea);
 	p{
 		display        : block;
 		padding-bottom : 0px;


### PR DESCRIPTION
Closes #1569 

Changes box-shadows to drop-shadows in the Legacy styling.   

Ignore the note in the commit description--- this does change monster stat blocks as well.

Should be good to push through as a minor change.