### PR TITLE
[v3] Better Paragraph formatting in Monster blocks

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -117,7 +117,7 @@ const BrewRenderer = createClass({
 	},
 
 	renderDummyPage : function(index){
-		return <div className='phb' id={`p${index + 1}`} key={index}>
+		return <div className='phb page' id={`p${index + 1}`} key={index}>
 			<i className='fas fa-spinner fa-spin' />
 		</div>;
 	},

--- a/client/homebrew/editor/snippetbar/snippets/monsterblock.gen.js
+++ b/client/homebrew/editor/snippetbar/snippets/monsterblock.gen.js
@@ -105,6 +105,20 @@ const genAbilities = function(){
 	]);
 };
 
+const genLongAbilities = function(){
+	return _.sample([
+		dedent`***Pack Tactics.*** These guys work together like peanut butter and jelly. Jelly and peanut butter.
+
+		When one of these guys attacks, the target is covered with, well, peanut butter and jelly.`,
+		dedent`***Hangriness.*** This creature is angry, and hungry. It will refuse to do anything with you until its hunger is satisfied.
+
+		When in visual contact with this creature, you must purchase an extra order of fries, even if they say they aren't hungry.`,
+		dedent`***Full of Detergent.*** This creature has swallowed an entire bottle of dish detergent and is actually having a pretty good time.
+
+		While walking near this creature, you must make a dexterity check or become "a soapy mess" for three hours, after which your skin will get all dry and itchy.`
+	]);
+};
+
 const genAction = function(){
 	const name = _.sample([
 		'Abdominal Drop',
@@ -146,24 +160,22 @@ module.exports = {
 			## ${getMonsterName()}
 			*${getType()}, ${getAlignment()}*
 			___
-			**Armor Class** :: ${_.random(10, 20)} (chain mail, shield)
-			**Hit Points**  :: ${_.random(1, 150)}(1d4 + 5)
-			**Speed**       :: ${_.random(0, 50)}ft.
+
 			___
 			|  STR  |  DEX  |  CON  |  INT  |  WIS  |  CHA  |
 			|:-----:|:-----:|:-----:|:-----:|:-----:|:-----:|
 			${getStats()}
 			___
 			**Condition Immunities** :: ${genList(['groggy', 'swagged', 'weak-kneed', 'buzzed', 'groovy', 'melancholy', 'drunk'], 3)}
-			**Senses**               :: darkvision 60 ft., passive Perception ${_.random(3, 20)}
+
 			**Languages**            :: ${genList(['Common', 'Pottymouth', 'Gibberish', 'Latin', 'Jive'], 2)}
-			**Challenge**            :: ${_.random(0, 15)} (${_.random(10, 10000)} XP)
+
 			___
+			${_.times(_.random(genLines, genLines + 2), function(){return genAbilities();}).join('\n:\n')}
 			:
-			${_.times(_.random(genLines, genLines + 2), function(){return genAbilities();}).join('\n\t\t\t\n\t\t\t')}
-			:
+			${genLongAbilities()}
 			### Actions
-			${_.times(_.random(genLines, genLines + 2), function(){return genAction();}).join('\n\t\t\t\n\t\t\t')}
+			${_.times(_.random(genLines, genLines + 2), function(){return genAction();}).join('\n:\n')}
 			}}
 			\n`;
 	}

--- a/client/homebrew/editor/snippetbar/snippets/tableOfContents.gen.js
+++ b/client/homebrew/editor/snippetbar/snippets/tableOfContents.gen.js
@@ -53,19 +53,19 @@ module.exports = function(brew){
 	const TOC = getTOC(pages);
 	const markdown = _.reduce(TOC, (r, g1, idx1)=>{
 		if(g1.title !== null) {
-			r.push(`\t\t- ### [{{ ${g1.title}}}{{ ${g1.page}}}](#p${g1.page})`);
+			r.push(`- ### [{{ ${g1.title}}}{{ ${g1.page}}}](#p${g1.page})`);
 		}
 		if(g1.children.length){
 			_.each(g1.children, (g2, idx2)=>{
 				if(g2.title !== null) {
-					r.push(`\t\t  - #### [{{ ${g2.title}}}{{ ${g2.page}}}](#p${g2.page})`);
+					r.push(`  - #### [{{ ${g2.title}}}{{ ${g2.page}}}](#p${g2.page})`);
 				}
 				if(g2.children.length){
 					_.each(g2.children, (g3, idx3)=>{
 						if(g2.title !== null) {
-							r.push(`\t\t    - [{{ ${g3.title}}}{{ ${g3.page}}}](#p${g3.page})`);
+							r.push(`    - [{{ ${g3.title}}}{{ ${g3.page}}}](#p${g3.page})`);
 						} else { // Don't over-indent if no level-2 parent entry
-							r.push(`\t\t  - [{{ ${g3.title}}}{{ ${g3.page}}}](#p${g3.page})`);
+							r.push(`  - [{{ ${g3.title}}}{{ ${g3.page}}}](#p${g3.page})`);
 						}
 					});
 				}
@@ -78,7 +78,7 @@ module.exports = function(brew){
 		{{toc,wide
 		# Table Of Contents
 
-${markdown}
+		${markdown}
 		}}
 		\n`;
 };

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -385,17 +385,6 @@ body {
 		padding           : 0px;
 		margin-bottom     : 0.325cm;
 
-		p{
-			margin-bottom : 0.3cm;
-		}
-		p+p {
-			margin-top  : 0;	//May not be needed
-			text-indent : 0;
-		}
-		p:last-of-type {
-			margin-bottom: 0;
-		}
-
 		//Headers
 		h2{
 			font-size     : 0.62cm;
@@ -411,7 +400,7 @@ body {
 			font-weight    : 800;
 			font-variant   : small-caps;
 			border-bottom  : 2px solid @headerText;
-			margin-top     : 0.05cm;
+			// margin-top     : 0.05cm;  //Font is misaligned. Shift up slightly
   		padding-bottom : 0.05cm;
 		}
 
@@ -425,12 +414,17 @@ body {
 			border           : none;
 		}
 
-		//Attribute Lists
-		dl {
+		//Attribute Lists - All text between HRs is red
+		hr ~ :is(dl,p) {
 			color : @headerText;
 		}
-		hr:last-of-type~dl{
-			color : inherit; // After the HRs, hanging indents remain black.
+		hr:last-of-type {
+			& ~ :is(dl,p) {
+				color : inherit; // After the HRs, reset text to black
+			}
+			& + * {
+				margin-top : 0.325cm; // Space after last HR
+			}
 		}
 
 		// Monster Ability table
@@ -448,6 +442,10 @@ body {
 			td,th {
 				padding: 0px;
 			}
+		}
+
+		:last-child {
+			margin-bottom : 0;
 		}
 	}
 
@@ -773,10 +771,8 @@ body {
 // *****************************/
 .page {
 	.blank {
-		height: 0.75em;
-	}
-	p + .blank {
-		margin-top: -1em;
+		height     : 1em;
+		margin-top : 0;
 	}
 }
 


### PR DESCRIPTION
Remove the special case CSS for monster blocks and update the snippet to just use Markdown to achieve the same thing. Makes indenting paragraphs at will much easier.

Solves #181

Supersedes #1644

Just awaiting a bug on `dedent-tabs` to be [patched](https://github.com/adrianjost/dedent-tabs/pull/235) (should be soon).