### PR TITLE
Remove backticks from splitTable

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippetsLegacy/snippets.js
@@ -240,30 +240,25 @@ module.exports = [
 			{
 				name : 'Split Table',
 				icon : 'fas fa-th-large',
-				gen  : function(){
-					return [
-						'<div style=\'column-count:2\'>',
-						'| d10 | Damage Type |',
-						'|:---:|:------------|',
-						'|  1  | Acid        |',
-						'|  2  | Cold        |',
-						'|  3  | Fire        |',
-						'|  4  | Force       |',
-						'|  5  | Lightning   |',
-						'',
-						'```',
-						'```',
-						'',
-						'| d10 | Damage Type |',
-						'|:---:|:------------|',
-						'|  6  | Necrotic    |',
-						'|  7  | Poison      |',
-						'|  8  | Psychic     |',
-						'|  9  | Radiant     |',
-						'|  10 | Thunder     |',
-						'</div>\n\n',
-					].join('\n');
-				},
+				gen  : dedent`\n
+					<div style='column-count:2'>
+					| d10 | Damage Type |
+					|:---:|:------------|
+					|  1  | Acid        |
+					|  2  | Cold        |
+					|  3  | Fire        |
+					|  4  | Force       |
+					|  5  | Lightning   |
+
+					| d10 | Damage Type |
+					|:---:|:------------|
+					|  6  | Necrotic    |
+					|  7  | Poison      |
+					|  8  | Psychic     |
+					|  9  | Radiant     |
+					|  10 | Thunder     |
+					</div>
+					\n`
 			}
 		]
 	},


### PR DESCRIPTION
Finishes off the last of #844 by removing the backticks from the Legacy snippet.