### PR TITLE
Add `.pages` container div to printPage.jsx

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -188,7 +188,6 @@ const BrewRenderer = createClass({
 	        : null}
 
 				<Frame initialContent={this.state.initialContent}
-					head = <link href={`${this.props.renderer == 'legacy' ? '/themes/5ePhbLegacy.style.css' : '/themes/5ePhb.style.css'}`} rel='stylesheet'/>
 					style={{ width: '100%', height: '100%', visibility: this.state.visibility }}
 					contentDidMount={this.frameDidMount}>
 					<div className={'brewRenderer'}
@@ -200,17 +199,17 @@ const BrewRenderer = createClass({
 							<RenderWarnings />
 							<NotificationPopup />
 						</div>
-
-						<div className='pages' ref='pages'>
-							{/* Apply CSS from Style tab and render pages from Markdown tab */}
-							{this.state.isMounted
-								&&
-								<>
-									{this.renderStyle()}
+						<link href={`${this.props.renderer == 'legacy' ? '/themes/5ePhbLegacy.style.css' : '/themes/5ePhb.style.css'}`} rel='stylesheet'/>
+						{/* Apply CSS from Style tab and render pages from Markdown tab */}
+						{this.state.isMounted
+							&&
+							<>
+								{this.renderStyle()}
+								<div className='pages' ref='pages'>
 									{this.renderPages()}
-								</>
-							}
-						</div>
+								</div>
+							</>
+						}
 					</div>
 				</Frame>
 				{this.renderPageInfo()}

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -35,6 +35,11 @@ const PrintPage = createClass({
 		if(this.props.query.dialog) window.print();
 	},
 
+	renderStyle : function() {
+		if(!this.props.brew.style) return;
+		return <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `<style> ${this.props.brew.style} </style>` }} />;
+	},
+
 	renderPages : function(){
 		if(this.props.brew.renderer == 'legacy') {
 			return _.map(this.state.brewText.split('\\page'), (pageText, index)=>{
@@ -62,8 +67,8 @@ const PrintPage = createClass({
 			<Meta name='robots' content='noindex, nofollow' />
 			<link href={`${this.props.brew.renderer == 'legacy' ? '/themes/5ePhbLegacy.style.css' : '/themes/5ePhb.style.css'}`} rel='stylesheet'/>
 			{/* Apply CSS from Style tab */}
-			<div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `<style> ${this.props.brew.style} </style>` }} />
-			<div className='pages'>
+			{this.renderStyle()}
+			<div className='pages' ref='pages'>
 				{this.renderPages()}
 			</div>
 		</div>;

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -63,7 +63,9 @@ const PrintPage = createClass({
 			<link href={`${this.props.brew.renderer == 'legacy' ? '/themes/5ePhbLegacy.style.css' : '/themes/5ePhb.style.css'}`} rel='stylesheet'/>
 			{/* Apply CSS from Style tab */}
 			<div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `<style> ${this.props.brew.style} </style>` }} />
-			{this.renderPages()}
+			<div className='pages'>
+				{this.renderPages()}
+			</div>
 		</div>;
 	}
 });


### PR DESCRIPTION
Fixes #1612 where the page footer is getting reversed on alternate pages when sending to the /print/ page.  Wraps the `.page` divs in a `.pages` container so that the :nth-child selector isn't getting mixed up.