### PR TITLE
Hotkey for Lists

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -104,8 +104,20 @@ const CodeEditor = createClass({
 	},
 
 	makeUnOrderedList : function() {
-		const selection = this.codeMirror.getSelection()
-	}
+		const isList = /^-\s/gm;
+		const selectionStart = this.codeMirror.getCursor('from');
+		const selectionEnd = this.codeMirror.getCursor('to');
+		const selection = this.codeMirror.setSelection(
+			{ line: selectionStart.line, ch: 0 },
+			{ line: selectionEnd.line, ch: this.codeMirror.getLine(selectionEnd.line).length });
+		console.log(selectionStart, selectionEnd, selection);
+	},
+
+
+	// ordered list:
+	// selection should expand to include the full line even if selection is only part of line
+	// regex should match "- " at beginning of selection
+	// regex should match "- " at beginnign of each line or maybe "\n- "
 
 	//=-- Externally used -==//
 	setCursorPosition : function(line, char){

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -47,14 +47,18 @@ const CodeEditor = createClass({
 			indentWithTabs : true,
 			tabSize        : 2,
 			extraKeys      : {
-				'Ctrl-B' : this.makeBold,
-				'Cmd-B'  : this.makeBold,
-				'Ctrl-I' : this.makeItalic,
-				'Cmd-I'  : this.makeItalic,
-				'Ctrl-M' : this.makeSpan,
-				'Cmd-M'  : this.makeSpan,
-				'Ctrl-/' : this.makeComment,
-				'Cmd-/'  : this.makeComment
+				'Ctrl-B'       : this.makeBold,
+				'Cmd-B'        : this.makeBold,
+				'Ctrl-I'       : this.makeItalic,
+				'Cmd-I'        : this.makeItalic,
+				'Ctrl-M'       : this.makeSpan,
+				'Cmd-M'        : this.makeSpan,
+				'Ctrl-/'       : this.makeComment,
+				'Cmd-/'        : this.makeComment,
+				'Ctrl-L'       : this.makeUnOrderedList,
+				'Cmd-L'        : this.makeUnOrderedList,
+				'Shift-Ctrl-L' : this.makeOrderedList,
+				'Shift-Cmd-L'  : this.makeOrderedList
 			}
 		});
 
@@ -98,6 +102,10 @@ const CodeEditor = createClass({
 			this.codeMirror.setCursor({ line: cursor.line, ch: cursor.ch - 4 });
 		}
 	},
+
+	makeUnOrderedList : function() {
+		const selection = this.codeMirror.getSelection()
+	}
 
 	//=-- Externally used -==//
 	setCursorPosition : function(line, char){

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -112,12 +112,16 @@ const CodeEditor = createClass({
 		const newSelection = this.codeMirror.getSelection();
 
 		const regex = /^\d+\.\s|^-\s/gm;
-		console.log(regex);
 		if(newSelection.match(regex) != null){   	// if selection IS A LIST
 			this.codeMirror.replaceSelection(newSelection.replace(regex, ''), 'around');
 		} else {									// if selection IS NOT A LIST
-			listType == 'UL' ? this.codeMirror.replaceSelection(newSelection.replace(/^/gm, '- '), 'around') :
-				this.codeMirror.replaceSelection(newSelection.replace(/^/gm, '1. '), 'around');
+			listType == 'UL' ? this.codeMirror.replaceSelection(newSelection.replace(/^/gm, `- `), 'around') :
+				this.codeMirror.replaceSelection(newSelection.replace(/^/gm, (()=>{
+					let n = 1;
+					return ()=>{
+						return `${n++}. `;
+					};
+				})()), 'around');
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -55,10 +55,10 @@ const CodeEditor = createClass({
 				'Cmd-M'        : this.makeSpan,
 				'Ctrl-/'       : this.makeComment,
 				'Cmd-/'        : this.makeComment,
-				'Ctrl-L'       : this.makeUnOrderedList,
-				'Cmd-L'        : this.makeUnOrderedList,
-				'Shift-Ctrl-L' : this.makeOrderedList,
-				'Shift-Cmd-L'  : this.makeOrderedList
+				'Ctrl-L'       : ()=>this.makeList('UL'),
+				'Cmd-L'        : ()=>this.makeList('UL'),
+				'Shift-Ctrl-L' : ()=>this.makeList('OL'),
+				'Shift-Cmd-L'  : ()=>this.makeList('OL')
 			}
 		});
 
@@ -103,19 +103,21 @@ const CodeEditor = createClass({
 		}
 	},
 
-	makeUnOrderedList : function() {
-		const selectionStart = this.codeMirror.getCursor('from');
-		const selectionEnd = this.codeMirror.getCursor('to');
+	makeList : function(listType) {
+		const selectionStart = this.codeMirror.getCursor('from'), selectionEnd = this.codeMirror.getCursor('to');
 		this.codeMirror.setSelection(
 			{ line: selectionStart.line, ch: 0 },
 			{ line: selectionEnd.line, ch: this.codeMirror.getLine(selectionEnd.line).length }
 		);
-		const isUL = /^-\s/gm;
 		const newSelection = this.codeMirror.getSelection();
-		if(newSelection.match(isUL) == null){
-			this.codeMirror.replaceSelection(newSelection.replace(/^/gm, '- '), 'around');
-		} else {
-			this.codeMirror.replaceSelection(newSelection.replace(isUL, ''), 'around');
+
+		const regex = /^\d+\.\s|^-\s/gm;
+		console.log(regex);
+		if(newSelection.match(regex) != null){   	// if selection IS A LIST
+			this.codeMirror.replaceSelection(newSelection.replace(regex, ''), 'around');
+		} else {									// if selection IS NOT A LIST
+			listType == 'UL' ? this.codeMirror.replaceSelection(newSelection.replace(/^/gm, '- '), 'around') :
+				this.codeMirror.replaceSelection(newSelection.replace(/^/gm, '1. '), 'around');
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -104,17 +104,18 @@ const CodeEditor = createClass({
 	},
 
 	makeUnOrderedList : function() {
-		const isList = /^-\s/gm;
 		const selectionStart = this.codeMirror.getCursor('from');
 		const selectionEnd = this.codeMirror.getCursor('to');
-		const selection = this.codeMirror.setSelection(
+		this.codeMirror.setSelection(
 			{ line: selectionStart.line, ch: 0 },
-			{ line: selectionEnd.line, ch: this.codeMirror.getLine(selectionEnd.line).length });
-		console.log(selectionStart, selectionEnd, selection);
-		if(isList.test(this.codeMirror.getSelection()) == true){
-			console.log('is list');
+			{ line: selectionEnd.line, ch: this.codeMirror.getLine(selectionEnd.line).length }
+		);
+		const isUL = /^-\s/gm;
+		const newSelection = this.codeMirror.getSelection();
+		if(newSelection.match(isUL) == null){
+			this.codeMirror.replaceSelection(newSelection.replace(/^/gm, '- '), 'around');
 		} else {
-			console.log('is not a list');
+			this.codeMirror.replaceSelection(newSelection.replace(isUL, ''), 'around');
 		}
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -111,6 +111,11 @@ const CodeEditor = createClass({
 			{ line: selectionStart.line, ch: 0 },
 			{ line: selectionEnd.line, ch: this.codeMirror.getLine(selectionEnd.line).length });
 		console.log(selectionStart, selectionEnd, selection);
+		if(isList.test(this.codeMirror.getSelection()) == true){
+			console.log('is list');
+		} else {
+			console.log('is not a list');
+		}
 	},
 
 


### PR DESCRIPTION
Adds a set of hotkeys for the editor to create and remove both Ordered and Unordered Lists.

`Ctrl` `L`  --- Converts lines to unordered list with `- `
`Shift` `Ctrl` `L`  --- Converts lines to ordered list with `n. `  (where *n* is an incrementing digit).

Both commands work in reverse, removing the list, *regardless of what kind of list it is (so Ctrl+L could remove an Ordered list as well)*.

Works on any fully *or* partially selected line, and ends with full lines highlighted/selected.

Same commands on MacOS using Cmd in place of Ctrl.

![gif](https://media4.giphy.com/media/QatF9Ie2juygQWahwu/giphy.gif?cid=790b76115ee4fd707b1999d89556f7fe81ee490d47952e2e&rid=giphy.gif&ct=g)
