### PR TITLE
Add browser-based Spell Check

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -45,6 +45,8 @@ const CodeEditor = createClass({
 			lineWrapping   : this.props.wrap,
 			mode           : this.props.language, //TODO: CSS MODE DOESN'T SEEM TO LOAD PROPERLY
 			indentWithTabs : true,
+			inputStyle     : 'contenteditable',
+			spellcheck     : true,
 			tabSize        : 2,
 			extraKeys      : {
 				'Ctrl-B' : this.makeBold,


### PR DESCRIPTION
Looking for options to cover spell checking, as mentioned in #611, #312, and #517. 

### Some options to address this:
- [x] Option used in this PR:  set the codeMirror options `inputStyle : contentEditable, spellcheck : true,`  [from this SO answer](https://stackoverflow.com/a/66641365).  Seems to work for both FF and Chrome.  From the CodeMirror 5 manual: 

> inputStyle: string
>    Selects the way CodeMirror handles input and focus. The core library defines the "textarea" and "contenteditable" input models. On mobile browsers, the default is "contenteditable". On desktop browsers, the default is "textarea". Support for IME and screen readers is better in the "contenteditable" model. The intention is to make it the default on modern desktop browsers in the future.

> spellcheck: boolean
>    Specifies whether or not spellcheck will be enabled on the input.

#### Minor complaint
- I think it is annoying that the words are highlighted as typos as they are being typed, but I'm not sure what can be done about that using a browser spell checker. 

----

- [ ] Use typo.js as suggested a few places, [here](https://gist.github.com/kofifus/4b2f79cadc871a29439d919692099406) but it seems this might have issues outside a few languages.

