### PR TITLE
Fix QR code snippet when `brew.shareId` doesn't exist

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -53,10 +53,10 @@ module.exports = [
 				name : 'QR Code',
 				icon : 'fas fa-qrcode',
 				gen  : (brew)=>{
-					return `![]` +
-							`(https://api.qrserver.com/v1/create-qr-code/?data=` +
-							`https://homebrewery.naturalcrit.com` + `${brew.shareId ? `/share/${brew.shareId}` : ''}` +
-							`&amp;size=100x100) {width:100px;mix-blend-mode:multiply}`;
+					return dedent`![]
+							(https://api.qrserver.com/v1/create-qr-code/?data=
+							https://homebrewery.naturalcrit.com${brew.shareId ? `/share/${brew.shareId}` : ''}
+							&amp;size=100x100) {width:100px;mix-blend-mode:multiply}`;
 				}
 			},
 			{

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -53,10 +53,10 @@ module.exports = [
 				name : 'QR Code',
 				icon : 'fas fa-qrcode',
 				gen  : (brew)=>{
-					return dedent`![]
-							(https://api.qrserver.com/v1/create-qr-code/?data=
-							https://homebrewery.naturalcrit.com${brew.shareId ? `/share/${brew.shareId}` : ''}
-							&amp;size=100x100) {width:100px;mix-blend-mode:multiply}`;
+					return `![]` +
+							`(https://api.qrserver.com/v1/create-qr-code/?data=` +
+							`https://homebrewery.naturalcrit.com` + `${brew.shareId ? `/share/${brew.shareId}` : ''}` +
+							`&amp;size=100x100) {width:100px;mix-blend-mode:multiply}`;
 				}
 			},
 			{

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -55,7 +55,7 @@ module.exports = [
 				gen  : (brew)=>{
 					return `![]` +
 							`(https://api.qrserver.com/v1/create-qr-code/?data=` +
-							`https://homebrewery.naturalcrit.com` + `${brew.shareId ? `/share/${brew.shareId}` : ''}` +
+							`https://homebrewery.naturalcrit.com${brew.shareId ? `/share/${brew.shareId}` : ''}` +
 							`&amp;size=100x100) {width:100px;mix-blend-mode:multiply}`;
 				}
 			},

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -55,7 +55,7 @@ module.exports = [
 				gen  : (brew)=>{
 					return `![]` +
 							`(https://api.qrserver.com/v1/create-qr-code/?data=` +
-							`https://homebrewery.naturalcrit.com/share/${brew.shareId}` +
+							`https://homebrewery.naturalcrit.com` + `${brew.shareId ? `/share/${brew.shareId}` : ''}` +
 							`&amp;size=100x100) {width:100px;mix-blend-mode:multiply}`;
 				}
 			},


### PR DESCRIPTION
This PR modifies the snippet generator for the QR code to use the URL for the Homebrewery home page when a `shareId` does not currently exist.

This resolves #1710.