### PR TITLE
Fix text wrapping in code blocks

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -512,7 +512,7 @@ body {
 		background-color : #faf7ea;
 		border-radius    : 4px;
 		white-space      : pre-wrap;
-		word-break       : break-word;
+		overflow-wrap    : break-word;
 	}
 
 	pre code{

--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -513,7 +513,8 @@ body {
 		color            : #58180d;
 		background-color : #faf7ea;
 		border-radius    : 4px;
-		white-space      : pre-wrap
+		white-space      : pre-wrap;
+		word-break       : break-word;
 	}
 
 	pre code{


### PR DESCRIPTION
Add `word-break: break-word` to CSS in order to fix code wrapping.

This resolves #1736.