### PR TITLE
[Docker] Shift to Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:16.11
+FROM node:16.11-alpine
+RUN apk --no-cache add git
 
 ENV NODE_ENV=docker
 


### PR DESCRIPTION
Shifting the base image from `16.11` to `16.11-alpine` and adding `git` results in a massive reduction in space - the entire `homebrewery` container is approximately 40% smaller, with no observed reduction in functionality.