### PR TITLE
Page numbers via js

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -140,7 +140,7 @@ const Editor = createClass({
 						editorPageCount = editorPageCount + 1;
 					}
 				}
-			}, []);
+			});
 		}
 	},
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -115,11 +115,6 @@ const Editor = createClass({
 
 			let editorPageCount = 2; // start page count from page 2
 
-			// get top and bottom line numbers currently in editor viewport
-			const viewportRect = codeMirror.getWrapperElement().getBoundingClientRect();
-			const topVisibleLine = codeMirror.lineAtHeight(viewportRect.top, 'window') - 50;
-			const bottomVisibleLine = codeMirror.lineAtHeight(viewportRect.bottom, 'window') + 50;
-
 			_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 
 				//reset custom line styles
@@ -129,17 +124,15 @@ const Editor = createClass({
 				// Legacy Codemirror styling
 				if(this.props.renderer == 'legacy') {
 					if(line.includes('\\page')){
-						// add a check here to see if in current viewport
-						if(lineNumber > topVisibleLine && lineNumber < bottomVisibleLine){
-							// add back the original class 'background' but also add the new class '.pageline'
-							codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-							const pageCountElement = Object.assign(document.createElement('span'), {
-								className   : 'editor-page-count',
-								textContent : editorPageCount
-							});
-							codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
-						}
-						editorPageCount = editorPageCount + 1;
+						// add back the original class 'background' but also add the new class '.pageline'
+						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
+						const pageCountElement = Object.assign(document.createElement('span'), {
+							className   : 'editor-page-count',
+							textContent : editorPageCount
+						});
+						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
+		
+						editorPageCount += 1;
 					};
 
 				}
@@ -147,8 +140,6 @@ const Editor = createClass({
 				// New Codemirror styling for V3 renderer
 				if(this.props.renderer == 'V3') {
 					if(line.match(/^\\page$/)){
-						// add a check here to see if in current viewport,
-						if(lineNumber > topVisibleLine && lineNumber < bottomVisibleLine){
 							// add back the original class 'background' but also add the new class '.pageline'
 							codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
 							const pageCountElement = Object.assign(document.createElement('span'), {
@@ -156,8 +147,8 @@ const Editor = createClass({
 								textContent : editorPageCount
 							});
 							codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
-						}
-						editorPageCount = editorPageCount + 1;
+						
+						editorPageCount += 1;
 					}
 
 					if(line.match(/^\\column$/)){

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -105,22 +105,20 @@ const Editor = createClass({
 	highlightCustomMarkdown : function(){
 		if(!this.refs.codeEditor) return;
 		if(this.state.view === 'text')  {
+			console.log('change');
 			const codeMirror = this.refs.codeEditor.codeMirror;
 
 			//reset custom text styles
 			const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
-			for (let i=0;i<customHighlights.length;i++) customHighlights[i].clear();
+			for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();
 
-			// remove all widgets (page numbers in Editor)
-			const pageCountWidgets = document.getElementsByClassName('editor-page-count');
-			for (let x=pageCountWidgets.length - 1;x>=0;x--) pageCountWidgets[x].remove();
 
 			let editorPageCount = 2; // start page count from page 2
 
 			// get top and bottom line numbers currently in editor viewport
 			const viewportRect = codeMirror.getWrapperElement().getBoundingClientRect();
-			const topVisibleLine = codeMirror.lineAtHeight(viewportRect.top, 'window');
-			const bottomVisibleLine = codeMirror.lineAtHeight(viewportRect.bottom, 'window');
+			const topVisibleLine = codeMirror.lineAtHeight(viewportRect.top, 'window') - 50;
+			const bottomVisibleLine = codeMirror.lineAtHeight(viewportRect.bottom, 'window') + 50;
 
 			_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 
@@ -131,20 +129,16 @@ const Editor = createClass({
 				// Legacy Codemirror styling
 				if(this.props.renderer == 'legacy') {
 					if(line.includes('\\page')){
-						// add back the original class 'background' but also add the new class '.pageline'
-						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-						// add a check here to see if in current viewport, then create widget if true
+						// add a check here to see if in current viewport
 						if(lineNumber > topVisibleLine && lineNumber < bottomVisibleLine){
-							const testElement = Object.assign(document.createElement('div'), {
+							// add back the original class 'background' but also add the new class '.pageline'
+							codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
+							const pageCountElement = Object.assign(document.createElement('span'), {
 								className   : 'editor-page-count',
 								textContent : editorPageCount
 							});
-							codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
-							// addWidget() sets an inline style for 'top' and 'left' by default; the below overrides or removes the default values
-							testElement.style.top = `${parseInt(testElement.style.top) - codeMirror.defaultTextHeight()}px`;
-							testElement.style.left = null;
+							codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
 						}
-						// end createWidget process
 						editorPageCount = editorPageCount + 1;
 					};
 
@@ -153,18 +147,15 @@ const Editor = createClass({
 				// New Codemirror styling for V3 renderer
 				if(this.props.renderer == 'V3') {
 					if(line.match(/^\\page$/)){
-						// add back the original class 'background' but also add the new class '.pageline'
-						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-						// add a check here to see if in current viewport, then create widget if true
+						// add a check here to see if in current viewport,
 						if(lineNumber > topVisibleLine && lineNumber < bottomVisibleLine){
-							const testElement = Object.assign(document.createElement('div'), {
+							// add back the original class 'background' but also add the new class '.pageline'
+							codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
+							const pageCountElement = Object.assign(document.createElement('span'), {
 								className   : 'editor-page-count',
 								textContent : editorPageCount
 							});
-							codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
-							// addWidget() sets an inline style for 'top' and 'left' by default; the below overrides or removes the default values
-							testElement.style.top = `${parseInt(testElement.style.top) - codeMirror.defaultTextHeight()}px`;
-							testElement.style.left = null;
+							codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
 						}
 						editorPageCount = editorPageCount + 1;
 					}

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -140,7 +140,7 @@ const Editor = createClass({
 						editorPageCount = editorPageCount + 1;
 					}
 				}
-			}, [])
+			}, []);
 		}
 	},
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -122,8 +122,9 @@ const Editor = createClass({
 							textContent : editorPageCount
 						});
 						codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
-						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
-						testElement.style.left = 'unset';
+						// testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
+						testElement.style.top = `${parseInt(testElement.style.top) - cm.defaultTextHeight()}px`;
+						testElement.style.left = null;
 						editorPageCount = editorPageCount + 1;
 					}
 				}
@@ -136,7 +137,7 @@ const Editor = createClass({
 						});
 						codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
 						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
-						testElement.style.left = 'unset';
+						testElement.style.left = null;
 						editorPageCount = editorPageCount + 1;
 					}
 				}

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -105,13 +105,11 @@ const Editor = createClass({
 	highlightCustomMarkdown : function(){
 		if(!this.refs.codeEditor) return;
 		if(this.state.view === 'text')  {
-			console.log('change');
 			const codeMirror = this.refs.codeEditor.codeMirror;
 
 			//reset custom text styles
 			const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
 			for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();
-
 
 			let editorPageCount = 2; // start page count from page 2
 
@@ -121,36 +119,23 @@ const Editor = createClass({
 				codeMirror.removeLineClass(lineNumber, 'background');
 				codeMirror.removeLineClass(lineNumber, 'text');
 
-				// Legacy Codemirror styling
-				if(this.props.renderer == 'legacy') {
-					if(line.includes('\\page')){
-						// add back the original class 'background' but also add the new class '.pageline'
-						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-						const pageCountElement = Object.assign(document.createElement('span'), {
-							className   : 'editor-page-count',
-							textContent : editorPageCount
-						});
-						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
+				// Styling for \page breaks
+				if((this.props.renderer == 'legacy' && line.includes('\\page')) ||
+			     (this.props.renderer == 'V3'     && line.match(/^\\page$/))) {
 
-						editorPageCount += 1;
-					};
+					// add back the original class 'background' but also add the new class '.pageline'
+					codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
+					const pageCountElement = Object.assign(document.createElement('span'), {
+						className   : 'editor-page-count',
+						textContent : editorPageCount
+					});
+					codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
 
-				}
+					editorPageCount += 1;
+				};
 
 				// New Codemirror styling for V3 renderer
 				if(this.props.renderer == 'V3') {
-					if(line.match(/^\\page$/)){
-						// add back the original class 'background' but also add the new class '.pageline'
-						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-						const pageCountElement = Object.assign(document.createElement('span'), {
-							className   : 'editor-page-count',
-							textContent : editorPageCount
-						});
-						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
-
-						editorPageCount += 1;
-					}
-
 					if(line.match(/^\\column$/)){
 						codeMirror.addLineClass(lineNumber, 'text', 'columnSplit');
 					}

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -107,39 +107,36 @@ const Editor = createClass({
 	addEditorPageNumbers : function(){
 		if(!this.refs.codeEditor) return;
 		if(this.state.view === 'text')  {
-			let editorPageCount = 2; // start counting from page 2
 			const codeMirror = this.refs.codeEditor.codeMirror;
 
-			const pageCountWidgets = document.getElementsByClassName('editor-page');
-					
-			for(let x=pageCountWidgets.length - 1;x>=0;x--) pageCountWidgets[x].remove();
+			const pageCountWidgets = document.getElementsByClassName('editor-page-count');
+			for (let x=pageCountWidgets.length - 1;x>=0;x--) pageCountWidgets[x].remove();
 
-			
-			console.log(editorPageCount);
+			let editorPageCount = 2; // start counting from page 2
 
 			const lineNumbers = _.reduce(this.props.brew.text.split('\n'), (r, line, lineNumber)=>{
 				if(this.props.renderer == 'legacy') {
 					if(line.includes('\\page')) {
 						const testElement = Object.assign(document.createElement('div'), {
-							className : 'editor-page-count',
+							className   : 'editor-page-count',
 							textContent : editorPageCount
 						});
-						codeMirror.addWidget({ line: lineNumber, ch: 0}, testElement);
-						testElement.style.top = parseInt(testElement.style.top) - 12.5 + 'px';
+						codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
+						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
 						testElement.style.left = 'unset';
 						editorPageCount = editorPageCount + 1;
 						r.push(lineNumber);
 					}
 				}
-				
+
 				if(this.props.renderer == 'V3') {
 					if(line.match(/^\\page$/)){
 						const testElement = Object.assign(document.createElement('div'), {
-							className : 'editor-page-count',
+							className   : 'editor-page-count',
 							textContent : editorPageCount
 						});
-						codeMirror.addWidget({ line: lineNumber, ch: 0}, testElement);
-						testElement.style.top = parseInt(testElement.style.top) - 12.5 + 'px';
+						codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
+						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
 						testElement.style.left = 'unset';
 						editorPageCount = editorPageCount + 1;
 						r.push(lineNumber);

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -116,8 +116,8 @@ const Editor = createClass({
 
 			// get top and bottom line numbers currently in editor viewport
 			const viewportRect = codeMirror.getWrapperElement().getBoundingClientRect();
-			const topVisibleLine = codeMirror.lineAtHeight(viewportRect.top, "window");
-			const bottomVisibleLine = codeMirror.lineAtHeight(viewportRect.bottom, "window");
+			const topVisibleLine = codeMirror.lineAtHeight(viewportRect.top, 'window');
+			const bottomVisibleLine = codeMirror.lineAtHeight(viewportRect.bottom, 'window');
 
 			_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 				if(this.props.renderer == 'legacy') {

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -52,6 +52,7 @@ const Editor = createClass({
 
 	componentDidMount : function() {
 		this.updateEditorSize();
+		this.addEditorPageNumbers();
 		this.highlightCustomMarkdown();
 		window.addEventListener('resize', this.updateEditorSize);
 	},
@@ -61,6 +62,7 @@ const Editor = createClass({
 	},
 
 	componentDidUpdate : function() {
+		this.addEditorPageNumbers();
 		this.highlightCustomMarkdown();
 	},
 
@@ -102,6 +104,53 @@ const Editor = createClass({
 		}, 1);
 	},
 
+	addEditorPageNumbers : function(){
+		if(!this.refs.codeEditor) return;
+		if(this.state.view === 'text')  {
+			let editorPageCount = 2; // start counting from page 2
+			const codeMirror = this.refs.codeEditor.codeMirror;
+
+			const pageCountWidgets = document.getElementsByClassName('editor-page');
+					
+			for(let x=pageCountWidgets.length - 1;x>=0;x--) pageCountWidgets[x].remove();
+
+			
+			console.log(editorPageCount);
+
+			const lineNumbers = _.reduce(this.props.brew.text.split('\n'), (r, line, lineNumber)=>{
+				if(this.props.renderer == 'legacy') {
+					if(line.includes('\\page')) {
+						const testElement = Object.assign(document.createElement('div'), {
+							className : 'editor-page-count',
+							textContent : editorPageCount
+						});
+						codeMirror.addWidget({ line: lineNumber, ch: 0}, testElement);
+						testElement.style.top = parseInt(testElement.style.top) - 12.5 + 'px';
+						testElement.style.left = 'unset';
+						editorPageCount = editorPageCount + 1;
+						r.push(lineNumber);
+					}
+				}
+				
+				if(this.props.renderer == 'V3') {
+					if(line.match(/^\\page$/)){
+						const testElement = Object.assign(document.createElement('div'), {
+							className : 'editor-page-count',
+							textContent : editorPageCount
+						});
+						codeMirror.addWidget({ line: lineNumber, ch: 0}, testElement);
+						testElement.style.top = parseInt(testElement.style.top) - 12.5 + 'px';
+						testElement.style.left = 'unset';
+						editorPageCount = editorPageCount + 1;
+						r.push(lineNumber);
+					}
+				}
+				return r;
+			}, []);
+			return lineNumbers;
+		}
+	},
+
 	highlightCustomMarkdown : function(){
 		if(!this.refs.codeEditor) return;
 		if(this.state.view === 'text')  {
@@ -110,6 +159,7 @@ const Editor = createClass({
 			//reset custom text styles
 			const customHighlights = codeMirror.getAllMarks();
 			for (let i=0;i<customHighlights.length;i++) customHighlights[i].clear();
+
 
 			const lineNumbers = _.reduce(this.props.brew.text.split('\n'), (r, line, lineNumber)=>{
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -114,7 +114,7 @@ const Editor = createClass({
 
 			let editorPageCount = 2; // start counting from page 2
 
-			const lineNumbers = _.reduce(this.props.brew.text.split('\n'), (r, line, lineNumber)=>{
+			_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 				if(this.props.renderer == 'legacy') {
 					if(line.includes('\\page')) {
 						const testElement = Object.assign(document.createElement('div'), {
@@ -125,7 +125,6 @@ const Editor = createClass({
 						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
 						testElement.style.left = 'unset';
 						editorPageCount = editorPageCount + 1;
-						r.push(lineNumber);
 					}
 				}
 
@@ -139,12 +138,9 @@ const Editor = createClass({
 						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
 						testElement.style.left = 'unset';
 						editorPageCount = editorPageCount + 1;
-						r.push(lineNumber);
 					}
 				}
-				return r;
-			}, []);
-			return lineNumbers;
+			}, [])
 		}
 	},
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -114,30 +114,40 @@ const Editor = createClass({
 
 			let editorPageCount = 2; // start counting from page 2
 
+			// get top and bottom line numbers currently in editor viewport
+			const viewportRect = codeMirror.getWrapperElement().getBoundingClientRect();
+			const topVisibleLine = codeMirror.lineAtHeight(viewportRect.top, "window");
+			const bottomVisibleLine = codeMirror.lineAtHeight(viewportRect.bottom, "window");
+
 			_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 				if(this.props.renderer == 'legacy') {
 					if(line.includes('\\page')) {
-						const testElement = Object.assign(document.createElement('div'), {
-							className   : 'editor-page-count',
-							textContent : editorPageCount
-						});
-						codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
-						// testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
-						testElement.style.top = `${parseInt(testElement.style.top) - cm.defaultTextHeight()}px`;
-						testElement.style.left = null;
+						// add a check here to see if in current viewport, then create widget if true
+						if(lineNumber > topVisibleLine && lineNumber < bottomVisibleLine){
+							const testElement = Object.assign(document.createElement('div'), {
+								className   : 'editor-page-count',
+								textContent : editorPageCount
+							});
+							codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
+							testElement.style.top = `${parseInt(testElement.style.top) - codeMirror.defaultTextHeight()}px`;
+							testElement.style.left = null;
+						}
+						// end createWidget process
 						editorPageCount = editorPageCount + 1;
 					}
 				}
 
 				if(this.props.renderer == 'V3') {
 					if(line.match(/^\\page$/)){
-						const testElement = Object.assign(document.createElement('div'), {
-							className   : 'editor-page-count',
-							textContent : editorPageCount
-						});
-						codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
-						testElement.style.top = `${parseInt(testElement.style.top) - 12.5}px`;
-						testElement.style.left = null;
+						if(lineNumber > topVisibleLine && lineNumber < bottomVisibleLine){
+							const testElement = Object.assign(document.createElement('div'), {
+								className   : 'editor-page-count',
+								textContent : editorPageCount
+							});
+							codeMirror.addWidget({ line: lineNumber, ch: 0 }, testElement);
+							testElement.style.top = `${parseInt(testElement.style.top) - codeMirror.defaultTextHeight()}px`;
+							testElement.style.left = null;
+						}
 						editorPageCount = editorPageCount + 1;
 					}
 				}

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -131,7 +131,7 @@ const Editor = createClass({
 							textContent : editorPageCount
 						});
 						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
-		
+
 						editorPageCount += 1;
 					};
 
@@ -140,14 +140,14 @@ const Editor = createClass({
 				// New Codemirror styling for V3 renderer
 				if(this.props.renderer == 'V3') {
 					if(line.match(/^\\page$/)){
-							// add back the original class 'background' but also add the new class '.pageline'
-							codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-							const pageCountElement = Object.assign(document.createElement('span'), {
-								className   : 'editor-page-count',
-								textContent : editorPageCount
-							});
-							codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
-						
+						// add back the original class 'background' but also add the new class '.pageline'
+						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
+						const pageCountElement = Object.assign(document.createElement('span'), {
+							className   : 'editor-page-count',
+							textContent : editorPageCount
+						});
+						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
+
 						editorPageCount += 1;
 					}
 

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -11,7 +11,7 @@
 		}
 		.editor-page-count{
 			color : grey;
-			float: right;
+			float : right;
 		}
 		.columnSplit{
 			font-style 			: italic;

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -11,7 +11,7 @@
 		}
 		.editor-page-count{
 			color : grey;
-			right : 12px;
+			right : 15px;
 		}
 		.columnSplit{
 			font-style 			: italic;

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -5,17 +5,13 @@
 
 	.codeEditor{
 		height            : 100%;
-		counter-reset     : page;
-		counter-increment : page;
 		.pageLine{
 			background : #33333328;
 			border-top : #339 solid 1px;
-			&:after{
-				content           : counter(page);
-				counter-increment : page;
-				float             : right;
-				color             : gray;
-			}
+		}
+		.editor-page-count{
+			color : grey;
+			right : 12px;
 		}
 		.columnSplit{
 			font-style 			: italic;

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -11,7 +11,7 @@
 		}
 		.editor-page-count{
 			color : grey;
-			right : 15px;  // needs to be enough to push past scrollbar.
+			float: right;
 		}
 		.columnSplit{
 			font-style 			: italic;

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -11,7 +11,7 @@
 		}
 		.editor-page-count{
 			color : grey;
-			right : 15px;
+			right : 15px;  // needs to be enough to push past scrollbar.
 		}
 		.columnSplit{
 			font-style 			: italic;

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -80,6 +80,7 @@ const CodeEditor = createClass({
 
 		// Note: codeMirror passes a copy of itself in this callback. cm === this.codeMirror. Either one works.
 		this.codeMirror.on('change', (cm)=>{this.props.onChange(cm.getValue());});
+		this.codeMirror.on('viewportChange', _.debounce((cm)=>{this.props.onChange(cm.getValue());},200));
 		this.updateSize();
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -114,7 +114,6 @@ const CodeEditor = createClass({
 
 		// Note: codeMirror passes a copy of itself in this callback. cm === this.codeMirror. Either one works.
 		this.codeMirror.on('change', (cm)=>{this.props.onChange(cm.getValue());});
-		this.codeMirror.on('viewportChange', _.debounce((cm)=>{this.props.onChange(cm.getValue());}, 200));
 		this.updateSize();
 	},
 

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -80,7 +80,7 @@ const CodeEditor = createClass({
 
 		// Note: codeMirror passes a copy of itself in this callback. cm === this.codeMirror. Either one works.
 		this.codeMirror.on('change', (cm)=>{this.props.onChange(cm.getValue());});
-		this.codeMirror.on('viewportChange', _.debounce((cm)=>{this.props.onChange(cm.getValue());},200));
+		this.codeMirror.on('viewportChange', _.debounce((cm)=>{this.props.onChange(cm.getValue());}, 200));
 		this.updateSize();
 	},
 


### PR DESCRIPTION
This is a fix for an issue (that was never created on Github) where the current page numbers are not reliably updated or consistent.   The current page numbers are done via CSS pseudo-elements-- because CodeMirror doesn't render* the entirety of the editor at a time the css `counter` was not counting the pages correctly.

This PR eliminates the CSS method and adds a new function in Markdown.js similar to `addCustomHighlights()`.   In fact it could likely just be combined with the `addCustomHighlights()` function but I kept it separate for now for clarity.   The function adds an absolutely-positioned `div` for each `\page` line using the CodeMirror addWidget() method.  The div can be styled with CSS using the class `editor-page-count`.

*\*I'm just assuming this is the reason.*

-----

I have tested this with longer brews and seems to work fine, *except* when copy\pasting in some content....it doesn't register that as a "change" and the numbers can get misaligned with their row until typing resumes.  I'm not sure how to fix this, and am not bothered about it.

This is pretty much done with vanilla JS, and I highly suspect that React could get this done better, so I won't be offended if we go another route.....though I do think this would be a good stop-gap between now and then.

------

Further exploration can be done to change these to links which jump to the corresponding page in the preview pane.  I'm not sure how that works across the iframe, though, and seems like a separate future PR if someone wants to explore that.  For now, this fixes an existing bug that was annoyingly close to being a good navigation feature.