### PR TITLE
remove p + p padding in .note & .descriptive

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -242,9 +242,6 @@ body {
 			display        : block;
 			padding-bottom : 0px;
 		}
-		p + p {
-			padding-top : .8em;
-		}
 		:last-child {
 			margin-bottom : 0;
 		}
@@ -274,9 +271,6 @@ body {
 			display        : block;
 			padding-bottom : 0px;
 			line-height    : 1.5em;
-		}
-		p + p {
-			padding-top : .8em;
 		}
 		:last-child {
 			margin-bottom : 0;


### PR DESCRIPTION
Fixes #1836 by just removing the `p + p` rules on .note and .descriptive.   I did double check the PHB for descriptive notes, too.