### PR TITLE
Fix `undefined` inside CSS code fence on /Source/ and /Download/

### DIFF
--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -54,7 +54,7 @@ const NewPage = createClass({
 
 			if(!brew.text || !brew.style){
 				brew.text = brew.text  || (brewStorage  ?? '');
-				brew.style = brew.style || (styleStorage ?? undefined);
+				brew.style = brew.style || (styleStorage ?? '');
 				// brew.title = metaStorage?.title || this.state.brew.title;
 				// brew.description = metaStorage?.description || this.state.brew.description;
 				brew.renderer = metaStorage?.renderer || brew.renderer;


### PR DESCRIPTION
Fixes #1846.  A single tiny change:

```js
	getInitialState : function() {
		const brew = this.props.brew;

		if(typeof window !== 'undefined') { //Load from localStorage if in client browser
			const brewStorage  = localStorage.getItem(BREWKEY);
			const styleStorage = localStorage.getItem(STYLEKEY);
			const metaStorage = JSON.parse(localStorage.getItem(METAKEY));

			if(!brew.text || !brew.style){
				brew.text = brew.text  || (brewStorage  ?? '');
				brew.style = brew.style || (styleStorage ?? '');   //  <--- changed this from undefined to '' (empty string)
				// brew.title = metaStorage?.title || this.state.brew.title;
				// brew.description = metaStorage?.description || this.state.brew.description;
				brew.renderer = metaStorage?.renderer || brew.renderer;
			}
		}
```

This does leave the code fence there, but empty.  I thought leaving the empty code fence would be helpful in showing that there is no additional code, rather than making it uncertain if it exists, but is missing or hidden.  However, possibly in the future there would exist an option to 'hide' the contents of your Style editor from the source?  Though I imagine that "closed source" brews would hide the entire source, rather than just portions.  That's a future discussion in any case.

I am not sure why this only needed a change on the /new/ page, but it works for the tests I did.  I know some unification is going to happen so am not too bothered about it unless someone says something.