### PR TITLE
Add highlights to div blocks in Code Editor

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -112,7 +112,7 @@ const Editor = createClass({
 			for (let i=0;i<customHighlights.length;i++) customHighlights[i].clear();
 
 			let x = 0;
-			const blockTypes = ['note','descriptive','toc'];
+			const blockTypes = ['note', 'descriptive', 'toc', 'monster'];
 			let blockClass;
 
 			const lineNumbers = _.reduce(this.props.brew.text.split('\n'), (r, line, lineNumber)=>{
@@ -167,15 +167,15 @@ const Editor = createClass({
 							endCh = match.index+match[0].length;
 						codeMirror.markText({ line: lineNumber, ch: 0 }, { line: lineNumber, ch: endCh }, { className: 'block' });
 					};
-					
+
 					if(line.trimLeft().startsWith('{{')){
 						x += 1;
-						blockTypes.forEach(type=>{
+						blockTypes.forEach((type)=>{
 							if(line.includes(type)){   // todo: likely change to "starts with" rather than include to avoid overlapping issues
 								blockClass = type;
-							} 
+							}
 						});
-						if(blockClass === null){ blockClass = 'blockHighlight'}
+						if(blockClass === null){ blockClass = 'blockHighlight'};
 					}
 					if(x>0){
 						codeMirror.addLineClass(lineNumber, 'background', blockClass);
@@ -184,9 +184,6 @@ const Editor = createClass({
 						x -= 1;
 						blockClass = null; // todo:  need to switch back to previous class if nested within another div
 					}
-
-					
-
 				}
 
 				return r;

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -111,6 +111,10 @@ const Editor = createClass({
 			const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
 			for (let i=0;i<customHighlights.length;i++) customHighlights[i].clear();
 
+			let x = 0;
+			const blockTypes = ['note','descriptive','toc'];
+			let blockClass;
+
 			const lineNumbers = _.reduce(this.props.brew.text.split('\n'), (r, line, lineNumber)=>{
 
 				//reset custom line styles
@@ -162,7 +166,27 @@ const Editor = createClass({
 						if(match)
 							endCh = match.index+match[0].length;
 						codeMirror.markText({ line: lineNumber, ch: 0 }, { line: lineNumber, ch: endCh }, { className: 'block' });
+					};
+					
+					if(line.trimLeft().startsWith('{{')){
+						x += 1;
+						blockTypes.forEach(type=>{
+							if(line.includes(type)){   // todo: likely change to "starts with" rather than include to avoid overlapping issues
+								blockClass = type;
+							} 
+						});
+						if(blockClass === null){ blockClass = 'blockHighlight'}
 					}
+					if(x>0){
+						codeMirror.addLineClass(lineNumber, 'background', blockClass);
+					}
+					if(line.trimLeft().startsWith('}}')){
+						x -= 1;
+						blockClass = null; // todo:  need to switch back to previous class if nested within another div
+					}
+
+					
+
 				}
 
 				return r;

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -33,6 +33,17 @@
 			font-weight : bold;
 			//font-style: italic;
 		}
+
+		.blockHighlight {
+			background-color: #fae7fa;
+		}
+		  
+		  .descriptive {
+			background-color: #faf7ea
+		}
+		.note {
+			background-color: #e0e5c1
+		}
 	}
 
 	.brewJump{

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -37,12 +37,17 @@
 		.blockHighlight {
 			background-color: #fae7fa;
 		}
-		  
-		  .descriptive {
+		.descriptive {
 			background-color: #faf7ea
 		}
 		.note {
 			background-color: #e0e5c1
+		}
+		.monster {
+			background-color: #FFECBB;
+		}
+		.toc {
+			background-color: #e4ffdf;
 		}
 	}
 


### PR DESCRIPTION
Attempts to fix #1845, raised originally on reddit, which requests that various elements in the code editor be given further visual distinction beyond just text color.  Adding a light background color behind the lines within divs/blocks was the suggestion solution.

This PR is my attempt at that.  Right now, there are still some parts of it that need work, but I think the bones are there.  It adds to the growing highlightCustomMarkdown() function, and runs a list of defined block types (currently just Note, Descriptive, and ToC) through every line containing `{{` to see if they exist....then if so, applies a matching class name.  The classes are styled in the editor.less stylesheet.  It continues to apply that class until either A) a closing `}}` occurs, or B) another block starts (`{{`).    If a block exists without the defined words, it applies a generic class "blockHighlight".

<img width="1036" alt="image" src="https://user-images.githubusercontent.com/58999374/142801130-904229e3-32b4-4988-b53c-e0c8af861747.png">


Current shortcomings include styles not continuing after the end of a block nested within another.  Also, the defined keywords should likely be matched at the beginning of the string (`{{note...` vs `{{red,note...`) to avoid conflicts as well as give a user some choice about what color is applied to the block in the editor.

I know in the issue #1845 this was possibly backburnered until after editor themes and other higher priority changes, so I'm totally fine with this PR being closed-- I just wanted to try it out, and get it written down.   If it works for the future, it can be reopened (or scrapped for parts).