### PR TITLE
Tell CodeMirror to batch custom highlights before updating the browser

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -107,71 +107,69 @@ const Editor = createClass({
 		if(this.state.view === 'text')  {
 			const codeMirror = this.refs.codeEditor.codeMirror;
 
-			codeMirror.startOperation();
+			codeMirror.operation(() => { // Batch CodeMirror styling
+				//reset custom text styles
+				const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
+				for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();
 
-			//reset custom text styles
-			const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
-			for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();
+				let editorPageCount = 2; // start page count from page 2
 
-			let editorPageCount = 2; // start page count from page 2
+				_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 
-			_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
+					//reset custom line styles
+					codeMirror.removeLineClass(lineNumber, 'background');
+					codeMirror.removeLineClass(lineNumber, 'text');
 
-				//reset custom line styles
-				codeMirror.removeLineClass(lineNumber, 'background');
-				codeMirror.removeLineClass(lineNumber, 'text');
+					// Styling for \page breaks
+					if((this.props.renderer == 'legacy' && line.includes('\\page')) ||
+				     (this.props.renderer == 'V3'     && line.match(/^\\page$/))) {
 
-				// Styling for \page breaks
-				if((this.props.renderer == 'legacy' && line.includes('\\page')) ||
-			     (this.props.renderer == 'V3'     && line.match(/^\\page$/))) {
+						// add back the original class 'background' but also add the new class '.pageline'
+						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
+						const pageCountElement = Object.assign(document.createElement('span'), {
+							className   : 'editor-page-count',
+							textContent : editorPageCount
+						});
+						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
 
-					// add back the original class 'background' but also add the new class '.pageline'
-					codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
-					const pageCountElement = Object.assign(document.createElement('span'), {
-						className   : 'editor-page-count',
-						textContent : editorPageCount
-					});
-					codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
+						editorPageCount += 1;
+					};
 
-					editorPageCount += 1;
-				};
-
-				// New Codemirror styling for V3 renderer
-				if(this.props.renderer == 'V3') {
-					if(line.match(/^\\column$/)){
-						codeMirror.addLineClass(lineNumber, 'text', 'columnSplit');
-					}
-
-					// Highlight inline spans {{content}}
-					if(line.includes('{{') && line.includes('}}')){
-						const regex = /{{(?::(?:"[\w,\-()#%. ]*"|[\w\,\-()#%.]*)|[^"'{}\s])*\s*|}}/g;
-						let match;
-						let blockCount = 0;
-						while ((match = regex.exec(line)) != null) {
-							if(match[0].startsWith('{')) {
-								blockCount += 1;
-							} else {
-								blockCount -= 1;
-							}
-							if(blockCount < 0) {
-								blockCount = 0;
-								continue;
-							}
-							codeMirror.markText({ line: lineNumber, ch: match.index }, { line: lineNumber, ch: match.index + match[0].length }, { className: 'inline-block' });
+					// New Codemirror styling for V3 renderer
+					if(this.props.renderer == 'V3') {
+						if(line.match(/^\\column$/)){
+							codeMirror.addLineClass(lineNumber, 'text', 'columnSplit');
 						}
-					} else if(line.trimLeft().startsWith('{{') || line.trimLeft().startsWith('}}')){
-						// Highlight block divs {{\n Content \n}}
-						let endCh = line.length+1;
 
-						const match = line.match(/^ *{{(?::(?:"[\w,\-()#%. ]*"|[\w\,\-()#%.]*)|[^"'{}\s])* *$|^ *}}$/);
-						if(match)
-							endCh = match.index+match[0].length;
-						codeMirror.markText({ line: lineNumber, ch: 0 }, { line: lineNumber, ch: endCh }, { className: 'block' });
+						// Highlight inline spans {{content}}
+						if(line.includes('{{') && line.includes('}}')){
+							const regex = /{{(?::(?:"[\w,\-()#%. ]*"|[\w\,\-()#%.]*)|[^"'{}\s])*\s*|}}/g;
+							let match;
+							let blockCount = 0;
+							while ((match = regex.exec(line)) != null) {
+								if(match[0].startsWith('{')) {
+									blockCount += 1;
+								} else {
+									blockCount -= 1;
+								}
+								if(blockCount < 0) {
+									blockCount = 0;
+									continue;
+								}
+								codeMirror.markText({ line: lineNumber, ch: match.index }, { line: lineNumber, ch: match.index + match[0].length }, { className: 'inline-block' });
+							}
+						} else if(line.trimLeft().startsWith('{{') || line.trimLeft().startsWith('}}')){
+							// Highlight block divs {{\n Content \n}}
+							let endCh = line.length+1;
+
+							const match = line.match(/^ *{{(?::(?:"[\w,\-()#%. ]*"|[\w\,\-()#%.]*)|[^"'{}\s])* *$|^ *}}$/);
+							if(match)
+								endCh = match.index+match[0].length;
+							codeMirror.markText({ line: lineNumber, ch: 0 }, { line: lineNumber, ch: endCh }, { className: 'block' });
+						}
 					}
-				}
+				});
 			});
-
-			codeMirror.endOperation();
 		}
 	},
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -107,7 +107,7 @@ const Editor = createClass({
 		if(this.state.view === 'text')  {
 			const codeMirror = this.refs.codeEditor.codeMirror;
 
-			codeMirror.operation(() => { // Batch CodeMirror styling
+			codeMirror.operation(()=>{ // Batch CodeMirror styling
 				//reset custom text styles
 				const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
 				for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -107,6 +107,8 @@ const Editor = createClass({
 		if(this.state.view === 'text')  {
 			const codeMirror = this.refs.codeEditor.codeMirror;
 
+			codeMirror.startOperation();
+
 			//reset custom text styles
 			const customHighlights = codeMirror.getAllMarks().filter((mark)=>!mark.__isFold); //Don't undo code folding
 			for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();
@@ -168,6 +170,8 @@ const Editor = createClass({
 					}
 				}
 			});
+
+			codeMirror.endOperation();
 		}
 	},
 


### PR DESCRIPTION
Something has changed where CodeMirror is triggering a layout recalculation on every single instance of custom highlighting, causing massive lag when opening the Brew tab. Not sure if it was a CodeMirror update or Chrome or what.

Anyway, we can tell codeMirror to batch all of those operations by just surrounding the commands with startOperation() and endOperation();

See: https://github.com/codemirror/CodeMirror/issues/5766