### PR TITLE
Added sortLines function (alphabetical)

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -137,7 +137,9 @@ const CodeEditor = createClass({
 				'Ctrl-['           : this.foldAllCode,
 				'Cmd-['            : this.foldAllCode,
 				'Ctrl-]'           : this.unfoldAllCode,
-				'Cmd-]'            : this.unfoldAllCode
+				'Cmd-]'            : this.unfoldAllCode,
+				'Ctrl-F9'          : this.sortLines,
+				'Cmd-F9'           : this.sortLines
 			},
 			foldGutter  : true,
 			foldOptions : {
@@ -178,6 +180,13 @@ const CodeEditor = createClass({
 		// Note: codeMirror passes a copy of itself in this callback. cm === this.codeMirror. Either one works.
 		this.codeMirror.on('change', (cm)=>{this.props.onChange(cm.getValue());});
 		this.updateSize();
+	},
+
+	sortLines : function() {
+		const selections = this.codeMirror.getSelection('\n').split('\n');
+		selections.sort((a, b)=>a.localeCompare(b));
+		const text = selections.join('\n');
+		this.codeMirror.replaceSelection(text, 'around');
 	},
 
 	makeHeader : function (number) {


### PR DESCRIPTION
So, I created a small function to sort text lines alphabetically. It is quite niche, but it can be useful. If someone wants to "upgrade" this feature with a numeric sort, feel free to do so.

It is also "partially blocked" by #1343, because it uses localeCompare to sort, and I'm not sure if localeCompare uses the browser's language or the site's language (couldn't find in the MDN docs). With the language added as a document metadata, we can add it to the sort parameters and it will work well. 