### PR TITLE
Increase Google pageSize to 1000

### DIFF
--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -96,7 +96,7 @@ GoogleActions = {
 		const drive = google.drive({ version: 'v3', auth: oAuth2Client });
 
 		const obj = await drive.files.list({
-			pageSize : 100,
+			pageSize : 1000,
 			fields   : 'nextPageToken, files(id, name, description, createdTime, modifiedTime, properties)',
 			q        : 'mimeType != \'application/vnd.google-apps.folder\' and trashed = false'
 		})


### PR DESCRIPTION
This PR increases the `pageSize` parameter of the Google Drive list function to return up to 1000 files, rather than the default of 100 - this is affecting some users with large numbers of brews.

This resolves #1943.