### PR TITLE
Remove prop-types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "homebrewery",
       "version": "3.0.6",
       "hasInstallScript": true,
       "license": "MIT",
@@ -36,7 +35,6 @@
         "mongoose": "^6.1.8",
         "nanoid": "3.2.0",
         "nconf": "^0.11.3",
-        "prop-types": "15.8.0",
         "query-string": "7.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
       "mode_modules",
       "shared",
       "server"
-    ] 
+    ]
   },
   "babel": {
     "presets": [
@@ -73,7 +73,6 @@
     "mongoose": "^6.1.8",
     "nanoid": "3.2.0",
     "nconf": "^0.11.3",
-    "prop-types": "15.8.0",
     "query-string": "7.1.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",


### PR DESCRIPTION
This is a sub-dependency we probably updated manually for a security reason, but this is now handled by dependabot and doesn't need to be included in our direct dependencies.