### PR TITLE
Fix robots.txt route

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -106,7 +106,7 @@ const faqText        = require('fs').readFileSync('./../faq.md', 'utf8');
 
 String.prototype.replaceAll = function(s, r){return this.split(s).join(r);};
 
-const path = require("path");
+const path = require('path');
 
 //Robots.txt
 app.get('/robots.txt', (req, res)=>{

--- a/server/app.js
+++ b/server/app.js
@@ -106,9 +106,11 @@ const faqText        = require('fs').readFileSync('./../faq.md', 'utf8');
 
 String.prototype.replaceAll = function(s, r){return this.split(s).join(r);};
 
+const path = require("path");
+
 //Robots.txt
 app.get('/robots.txt', (req, res)=>{
-	return res.sendFile(`${__dirname}/robots.txt`);
+	return res.sendFile(path.resolve(__dirname, '../robots.txt'));
 });
 
 //Home page

--- a/tests/routes/static-pages.test.js
+++ b/tests/routes/static-pages.test.js
@@ -21,9 +21,7 @@ describe('Tests for static pages', ()=>{
 		return app.get('/faq').expect(200);
 	});
 
-	// FIXME: robots.txt file can't be properly loaded under testing environment,
-	// most likely due to __dirname being different from what is expected
-	it.skip('robots.txt works', ()=>{
+	it('robots.txt works', ()=>{
 		return app.get('/robots.txt').expect(200);
 	});
 });


### PR DESCRIPTION
The route was broken by #1959, because path to `robots.txt` became invalid with that PR.
Tests I added in #1979 were actually highlighting the issue, but I thought that this is a test issue and not a real problem.

This PR fixes that and enables the corresponding test. We can't just use `${__dirname}/../robots.txt`, because `express.js` under the hood checks for malicious strings and going "up" through `..` is considered dangerous - `403 Forbidden` was returned in this case.