### PR TITLE
Custom CSS syntax: `recolor: #FFAABB` to auto-calculate hue-rotate, etc.

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 const DB = require('./server/db.js');
 const server = require('./server/app.js');
 
+process.chdir(__dirname);
+
 const config = require('nconf')
 	.argv()
 	.env({ lowerCase: true })

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -372,9 +372,12 @@ const recolor = (target)=>{
 
 	max = Math.max(r, g, b), min = Math.min(r, g, b);
 	let newL= (max + min) / 2;
+	d = max - min;
+	let newS = newL > 0.5 ? d / (2 - max - min) : d / (max + min);
 
 	console.log({newR : r, newG : g, newB: b});
 	console.log({newL :newL});
+	console.log({newS : newS});
 	console.log({l : l})
 
 	l = l * 2; //Set lightness range from 0 to 200%, with 100% = no change (since we start with pure red which is .5 lightness)
@@ -382,11 +385,12 @@ const recolor = (target)=>{
 	console.log({s:s});
 	console.log({l:l});
 	let contrast = 1;
+	console.log({contrast: contrast});
 
 	if(l > 1)
 		contrast = (2-l)/(l);
 
-  return `filter:hue-rotate(${h}turn) contrast(${contrast}) brightness(${l}) saturate(${s});`; // Add  at end
+  return `filter:hue-rotate(${h}turn) saturate(${1/newS}) contrast(${contrast}) brightness(${l}) saturate(${s});`; // Add  at end
 }
 
 const processStyleTags = (string)=>{


### PR DESCRIPTION
Dumb little experiment as part of making custom themes. I know there's not an issue for this, but I don't plan to merge this. Just wanted to share the code so I can get opinions on the idea and come back to it later in a better PR if it seems worth it.

I love the idea of being able to recolor assets for custom themes, but we always have to rely on `hue-rotate` or `brightness` filters to get the color we want, and it's not intuitive at all, especially for inexperienced users who just want to get their CSS to work and don't want to have to calculate what angle to rotate around a color wheel to turn a blue symbol orange.

This PR adds a custom CSS property `recolor` which takes a color (currently just a 6-character hex value) and then calculates the required `filter: hue-rotate() brightness() saturate()` values to turn an asset into that color, assuming the asset starts as mostly red `255, 0, 0`.

Only works in the curly div/span syntax since it was easiest to test there, but this could equally be added as a CSS post-process step to modify the user's style tab before injecting into the DOM.

Then, we simply update any graphics, etc. to be red, apply the filters as required to make them appear as normal in our themes, and then users can recolor them as they wish with `{{monster,frame,recolor:#008800.... }}` to turn the monster frame dark green, for example.