### PR TITLE
Update Google interactions to prefer the service account where viable

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -25,7 +25,7 @@ const getBrewFromId = asyncHandler(async (id, accessType)=>{
 	if(id.length > 12) {
 		const googleId = id.slice(0, -12);
 		id             = id.slice(-12);
-		brew = await GoogleActions.readFileMetadata(config.get('google_api_key'), googleId, id, accessType);
+		brew = await GoogleActions.readFileMetadata(googleId, id, accessType);
 	} else {
 		brew = await HomebrewModel.get(accessType == 'edit' ? { editId: id } : { shareId: id });
 		brew = brew.toObject(); // Convert MongoDB object to standard Javascript Object

--- a/server/app.js
+++ b/server/app.js
@@ -25,7 +25,7 @@ const getBrewFromId = asyncHandler(async (id, accessType)=>{
 	if(id.length > 12) {
 		const googleId = id.slice(0, -12);
 		id             = id.slice(-12);
-		brew = await GoogleActions.readFileMetadata(googleId, id, accessType);
+		brew = await GoogleActions.getGoogleBrew(googleId, id, accessType);
 	} else {
 		brew = await HomebrewModel.get(accessType == 'edit' ? { editId: id } : { shareId: id });
 		brew = brew.toObject(); // Convert MongoDB object to standard Javascript Object

--- a/server/app.js
+++ b/server/app.js
@@ -200,13 +200,16 @@ app.get('/user/:username', async (req, res, next)=>{
 	});
 
 	if(ownAccount && req?.account?.googleId){
-		const googleBrews = await GoogleActions.listGoogleBrews(req, res)
-		.catch((err)=>{
-			console.error(err);
-		});
+		const auth = await GoogleActions.authCheck(req.account, res);
+		let googleBrews = await GoogleActions.listGoogleBrews(auth)
+			.catch((err)=>{
+				console.error(err);
+			});
 
-		if(googleBrews)
+		if(googleBrews) {
+			googleBrews = googleBrews.map((brew)=>({ ...brew, authors: [req.account.username] }));
 			brews = _.concat(brews, googleBrews);
+		}
 	}
 
 	req.brews = _.map(brews, (brew)=>{

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -233,7 +233,7 @@ const GoogleActions = {
 		return newHomebrew;
 	},
 
-	readFileMetadata : async (id, accessId, accessType)=>{
+	getGoogleBrew : async (id, accessId, accessType)=>{
 		const drive = google.drive({ version: 'v3' });
 
 		const obj = await drive.files.get({

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -16,6 +16,7 @@ try {
 	];
 } catch (err) {
 	console.warn(err);
+	console.log('Please make sure that a Google Service Account is set up properly in your config files.');
 }
 google.options({ auth: serviceAuth || config.get('google_api_key') });
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -185,6 +185,10 @@ router.put('/api/update/:id', updateBrew);
 router.put('/api/updateGoogle/:id', updateGoogleBrew);
 router.delete('/api/:id', deleteBrew);
 router.get('/api/remove/:id', deleteBrew);
-router.get('/api/removeGoogle/:id', (req, res)=>{GoogleActions.deleteGoogleBrew(req, res, req.params.id);});
+router.get('/api/removeGoogle/:id', async (req, res)=>{
+	const auth = await GoogleActions.authCheck(req.account, res);
+	await GoogleActions.deleteGoogleBrew(auth, req.params.id);
+	return res.status(200).send();
+});
 
 module.exports = router;

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -167,15 +167,11 @@ const newGoogleBrew = async (req, res, next)=>{
 };
 
 const updateGoogleBrew = async (req, res, next)=>{
-	let oAuth2Client;
-
-	try {	oAuth2Client = GoogleActions.authCheck(req.account, res); } catch (err) { return res.status(err.status).send(err.message); }
-
 	const brew = excludePropsFromUpdate(req.body);
 	brew.text = mergeBrewText(brew);
 
 	try {
-		const updatedBrew = await GoogleActions.updateGoogleBrew(oAuth2Client, brew);
+		const updatedBrew = await GoogleActions.updateGoogleBrew(brew);
 		return res.status(200).send(updatedBrew);
 	} catch (err) {
 		return res.status(err.response?.status || 500).send(err);


### PR DESCRIPTION
Commits
* update googleActions and related files to use service-level auth where viable

Iterative approach to changes required for Google document stubs, part 1. See issue #1838 

This only changes the GoogleActions so that they will primarily use the google service account loaded by the application for interacting with drive-based documents.

Notes:
* Users who are not the main author will not see the brew on their user page
* Deletion and Creation are the two pieces that still require a valid oauth token