### PR TITLE
Add divider reset on window resize #2053

### DIFF
--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -10,7 +10,6 @@ const SplitPane = createClass({
 		return {
 			storageKey   : 'naturalcrit-pane-split',
 			onDragFinish : function(){} //fires when dragging
-
 		};
 	},
 	getInitialState : function() {
@@ -26,6 +25,17 @@ const SplitPane = createClass({
 				size : paneSize
 			});
 		}
+		window.addEventListener('resize', this.resetSize);
+	},
+
+	componentWillUnmount : function() {
+		window.removeEventListener('resize', this.resetSize);
+	},
+
+	resetSize : function() {
+		this.setState({
+			size : window.innerWidth / 2
+		});
 	},
 
 	handleUp : function(){

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -26,6 +26,7 @@ const SplitPane = createClass({
 		if(paneSize){
 			this.setState({
 				size        : paneSize,
+				dividerSize : paneSize,
 				screenWidth : window.innerWidth
 			});
 		}
@@ -37,19 +38,24 @@ const SplitPane = createClass({
 	},
 
 	changeSize : function() {
-		const oldWidth = this.state.screenWidth;
 		const oldLoc = this.state.size;
-		const newLoc = this.limitPosition(window.innerWidth * (oldLoc / oldWidth));
+		const oldWidth = this.state.screenWidth;
+		let newLoc = oldLoc;
+		// Allow divider to increase in size to original position
+		if(window.innerWidth > oldWidth) {
+			newLoc = Math.min(oldLoc * (window.innerWidth / this.state.screenWidth), this.state.dividerSize);
+		}
+		// Limit current position to between 10% and 90% of visible space
+		newLoc = this.limitPosition(newLoc, 0.1*(window.innerWidth-13), 0.9*(window.innerWidth-13));
+
 		this.setState({
 			size        : newLoc,
 			screenWidth : window.innerWidth
 		});
 	},
 
-	limitPosition : function(x) {
-		const minWidth = 1;
-		const maxWidth = window.innerWidth - 13;
-		const result = Math.min(maxWidth, Math.max(minWidth, x));
+	limitPosition : function(x, min = 1, max = window.innerWidth - 13) {
+		const result = Math.round(Math.min(max, Math.max(min, x)));
 		return result;
 	},
 
@@ -71,7 +77,8 @@ const SplitPane = createClass({
 
 		const newSize = this.limitPosition(e.pageX);
 		this.setState({
-			size : newSize
+			size        : newSize,
+			dividerSize : newSize
 		});
 	},
 	/*

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -12,12 +12,14 @@ const SplitPane = createClass({
 			onDragFinish : function(){} //fires when dragging
 		};
 	},
+
 	getInitialState : function() {
 		return {
 			size       : null,
 			isDragging : false
 		};
 	},
+
 	componentDidMount : function() {
 		const paneSize = window.localStorage.getItem(this.props.storageKey);
 		if(paneSize){

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -33,6 +33,7 @@ const SplitPane = createClass({
 	},
 
 	resetSize : function() {
+		window.localStorage.removeItem(this.props.storageKey);
 		this.setState({
 			size : window.innerWidth / 2
 		});

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -15,8 +15,9 @@ const SplitPane = createClass({
 
 	getInitialState : function() {
 		return {
-			size       : null,
-			isDragging : false
+			size        : null,
+			screenWidth : 0,
+			isDragging  : false
 		};
 	},
 
@@ -24,21 +25,32 @@ const SplitPane = createClass({
 		const paneSize = window.localStorage.getItem(this.props.storageKey);
 		if(paneSize){
 			this.setState({
-				size : paneSize
+				size        : paneSize,
+				screenWidth : window.innerWidth
 			});
 		}
-		window.addEventListener('resize', this.resetSize);
+		window.addEventListener('resize', this.changeSize);
 	},
 
 	componentWillUnmount : function() {
-		window.removeEventListener('resize', this.resetSize);
+		window.removeEventListener('resize', this.changeSize);
 	},
 
-	resetSize : function() {
-		window.localStorage.removeItem(this.props.storageKey);
+	changeSize : function() {
+		const oldWidth = this.state.screenWidth;
+		const oldLoc = this.state.size;
+		const newLoc = this.limitPosition(window.innerWidth * (oldLoc / oldWidth));
 		this.setState({
-			size : window.innerWidth / 2
+			size        : newLoc,
+			screenWidth : window.innerWidth
 		});
+	},
+
+	limitPosition : function(x) {
+		const minWidth = 1;
+		const maxWidth = window.innerWidth - 13;
+		const result = Math.min(maxWidth, Math.max(minWidth, x));
+		return result;
 	},
 
 	handleUp : function(){
@@ -48,16 +60,16 @@ const SplitPane = createClass({
 		}
 		this.setState({ isDragging: false });
 	},
+
 	handleDown : function(){
 		this.setState({ isDragging: true });
 		//this.unFocus()
 	},
+
 	handleMove : function(e){
 		if(!this.state.isDragging) return;
 
-		const minWidth = 1;
-		const maxWidth = window.innerWidth - 13;
-		const newSize = Math.min(maxWidth, Math.max(minWidth, e.pageX));
+		const newSize = this.limitPosition(e.pageX);
 		this.setState({
 			size : newSize
 		});


### PR DESCRIPTION
This PR resets the divider position to 50% whenever a browser window resize event is detected.

This should resolve #2053.