### PR TITLE
Remove post title when opening issue on Reddit; add leading questions

### DIFF
--- a/client/homebrew/navbar/help.navitem.jsx
+++ b/client/homebrew/navbar/help.navitem.jsx
@@ -1,6 +1,7 @@
 const React = require('react');
 const createClass = require('create-react-class');
 const _ = require('lodash');
+const dedent = require('dedent-tabs').default;
 
 const Nav = require('naturalcrit/nav/nav.jsx');
 
@@ -10,7 +11,11 @@ module.exports = function(props){
 			need help?
 		</Nav.item>
 		<Nav.item color='red' icon='fas fa-fw fa-bug'
-			href={`https://www.reddit.com/r/homebrewery/submit?selftext=true&text=Browser%28s%29%3A++%0D%0AOperating+System%3A++%0D%0ALegacy+or+v3+renderer%3F%3A++%0D%0AIssue%3A++`}
+			href={`https://www.reddit.com/r/homebrewery/submit?selftext=true&text=${encodeURIComponent(dedent`
+			Browser(s):  
+			Operating System:  
+			Legacy or v3 Renderer:  
+			Issue:  `)}`}
 			newTab={true}
 			rel='noopener noreferrer'>
 			report issue

--- a/client/homebrew/navbar/help.navitem.jsx
+++ b/client/homebrew/navbar/help.navitem.jsx
@@ -10,7 +10,7 @@ module.exports = function(props){
 			need help?
 		</Nav.item>
 		<Nav.item color='red' icon='fas fa-fw fa-bug'
-			href={`https://www.reddit.com/r/homebrewery/submit?selftext=true&title=${encodeURIComponent('[Issue] Describe Your Issue Here')}`}
+			href={`https://www.reddit.com/r/homebrewery/submit?selftext=true&text=Browser%28s%29%3A++%0D%0AOperating+System%3A++%0D%0ALegacy+or+v3+renderer%3F%3A++%0D%0AIssue%3A++`}
 			newTab={true}
 			rel='noopener noreferrer'>
 			report issue

--- a/client/homebrew/navbar/help.navitem.jsx
+++ b/client/homebrew/navbar/help.navitem.jsx
@@ -12,10 +12,10 @@ module.exports = function(props){
 		</Nav.item>
 		<Nav.item color='red' icon='fas fa-fw fa-bug'
 			href={`https://www.reddit.com/r/homebrewery/submit?selftext=true&text=${encodeURIComponent(dedent`
-			Browser(s):  
-			Operating System:  
-			Legacy or v3 Renderer:  
-			Issue:  `)}`}
+			**Browser(s)** :
+			**Operating System** :  
+			**Legacy or v3 Renderer** :
+			**Issue** :  `)}`}
 			newTab={true}
 			rel='noopener noreferrer'>
 			report issue


### PR DESCRIPTION
This PR removes the automatic addition of *[Issue] Describe Your Issue Here* from new reddit posts created from the HB link in the navbar.  Users will need to enter their own title, rather than being able to just click *Submit* without adding a descriptive title since this is a required field on reddit.

This PR also adds default text to the main text area of a post in an effort to get more descriptive issues and anticipate some initial questions:

<img width="771" alt="image" src="https://user-images.githubusercontent.com/58999374/157798172-1102c99e-0c7f-44b2-bdad-a7120e971cd2.png">

I think the first 3 questions are common starting points to helping many users (though not all).  Others questions could be asked up front as well....possibly in such a way that Automod could pickup on the responses and offer some troubleshooting tips right out the gate.  But that might be overkill/annoying.