### PR TITLE
Set `.classTable.decoration` to display below text

### DIFF
--- a/themes/5ePhb.style.less
+++ b/themes/5ePhb.style.less
@@ -621,6 +621,8 @@ body {
 	}
 	&.decoration {
 		transform-style : preserve-3d;
+		z-index: -1;
+		position:relative;
 	}
 	&.decoration::before {
 		content           :'';


### PR DESCRIPTION
This PR fixes #1985, where the classTable decoration would overlap elements around it including the base text.  Test with some other non-text elements and this seems to hold up.

<img width="449" alt="image" src="https://user-images.githubusercontent.com/58999374/157799529-f72a6858-b717-4d27-8327-fca0fcb5b489.png">
