### PR TITLE
Small change to 3.0.6 changelog for MacOS

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -61,7 +61,7 @@ For a full record of development, visit our [Github Page](https://github.com/nat
 
 	Fixes issues: [#1736](https://github.com/naturalcrit/homebrewery/issues/1736)
 
-* [x] Code search/replace `CTRL F / CTRL SHIFT F`
+* [x] Code search/replace PC: `CTRL F / CTRL SHIFT F` / Mac: `CMD F / OPTION CMD F`
 
 	Fixes issues: [#1201](https://github.com/naturalcrit/homebrewery/issues/1201)
 


### PR DESCRIPTION
This PR fixes #1948 with a tiny change to the Search/Replace portion by providing the correct hotkeys for MacOS.  

Super super minor, but just finding the easy 'issues' to close.

<img width="337" alt="image" src="https://user-images.githubusercontent.com/58999374/157801685-8ca7861e-a2da-4d59-ae28-4f90c659c014.png">

verified on my mac.