### PR TITLE
Small changes to theme swapper

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -151,7 +151,7 @@ const MetadataEditor = createClass({
 			dropdown =
 				<Nav.dropdown className='disabled' trigger='disabled'>
 					<div>
-						{`Themes are not suppdorted in the Legacy Renderer`} <i className='fas fa-caret-down'></i>
+						{`Themes are not supported in the Legacy Renderer`} <i className='fas fa-caret-down'></i>
 					</div>
 				</Nav.dropdown>;
 		} else {

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -118,8 +118,9 @@
 						color: white;
 					}
 					img {
-						mask-image: linear-gradient(90deg, transparent, black 20%);
-						-webkit-mask-image: linear-gradient(90deg, transparent, black 20%);
+						mask-image: linear-gradient(90deg, transparent 150px, black 250px);
+						-webkit-mask-image: linear-gradient(90deg, transparent 150px, black 250px);
+						width: 100%;
 				    position: absolute;
 				    right: 0px;
 				    top: 0px;

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -121,11 +121,10 @@
 						color: white;
 					}
 					img {
-						mask-image: linear-gradient(90deg, transparent 150px, black 250px);
-						-webkit-mask-image: linear-gradient(90deg, transparent 150px, black 250px);
-						width: 100%;
+						mask-image: linear-gradient(90deg, transparent, black 20%);
+						-webkit-mask-image: linear-gradient(90deg, transparent, black 20%);
 				    position: absolute;
-				    right: 0px;
+				    left: ~"max(100px, 100% - 300px)";
 				    top: 0px;
 					}
 				}

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -87,6 +87,7 @@
 		.navDropdownContainer {
 			background-color: white;
 			width: 100%;
+			position: relative;
 			&.disabled {
 				font-style:italic;
 				font-style: italic;
@@ -107,6 +108,8 @@
 			}
 			.navDropdown {
 				box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.3);
+				position:absolute;
+				width:100%;
 				.item {
 					padding: 3px 3px;
 					border-top: 1px solid rgb(118, 118, 118);


### PR DESCRIPTION
Forewarning:  Not sure i've ever opened a PR on another branch that isn't master/main and isn't my own, so let me know if I got this wrong.

I was looking at this branch before jumping in on a theme and a few things caught my eye, addressed in this PR:

1. A simple typo on the theme dropdown when in Legacy
2. The theme texture `mask-image` is applied where it can mask the text of the theme name if metadata panel is small enough (and doesn't even really need to be that small).
3. Opening the dropdown menu pushes the subsequent metadata panel items down, until the dropdown is closed.

Sorry it's 3 different items in one PR, they just seemed small enough to bundle together and seems likely that if you want to accept them, you can just change it on your side without doing a merge.