### PR TITLE
Unset `:first-line` small-caps rule with *Remove Drop Cap* snippet

### DIFF
--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -97,7 +97,10 @@ module.exports = [
 				gen  : dedent`/* Removes Drop Caps */
 						.page h1+p:first-letter {
 							all: unset;
-						}\n\n`
+						}\n\n
+						.page h1+p:first-line {
+							all: unset;
+						}`
 			},
 			{
 				name : 'Tweak Drop Cap',

--- a/client/homebrew/editor/snippetbar/snippets/snippets.js
+++ b/client/homebrew/editor/snippetbar/snippets/snippets.js
@@ -98,6 +98,7 @@ module.exports = [
 						.page h1+p:first-letter {
 							all: unset;
 						}\n\n
+						/* Removes Small-Caps in first line */
 						.page h1+p:first-line {
 							all: unset;
 						}`


### PR DESCRIPTION
This PR simply adds a bit to the v3 "Remove Drop Cap" snippet that also removes the `:first-line` rule, so that the small-caps goes away, too.   Questions about the capitalized letters in the first line seem to come up occasionally in the subreddit (some assume it is a glitch). 

And in the DOMT server today they made a pinned post about it, which is what spurred this PR:

<img width="672" alt="image" src="https://user-images.githubusercontent.com/58999374/159399858-50cb1367-818b-402d-ba42-7b6953aca391.png">

If for some reason someone wants no drop-cap, but retain the small-caps, it should be fairly evident how to do that (delete the relevant rule).