### PR TITLE
Add UserPage filtering to/from URL

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -46,7 +46,7 @@ const Homebrew = createClass({
 						<Route path='/share/:id' component={(routeProps)=><SharePage id={routeProps.match.params.id} brew={this.props.brew} />}/>
 						<Route path='/new/:id' component={(routeProps)=><NewPage id={routeProps.match.params.id} brew={this.props.brew} />}/>
 						<Route path='/new' exact component={(routeProps)=><NewPage />}/>
-						<Route path='/user/:username' component={(routeProps)=><UserPage username={routeProps.match.params.username} brews={this.props.brews} />}/>
+						<Route path='/user/:username' component={(routeProps)=><UserPage username={routeProps.match.params.username} brews={this.props.brews} query={queryString.parse(routeProps.location.search)}/>}/>
 						<Route path='/print/:id' component={(routeProps)=><PrintPage brew={this.props.brew} query={queryString.parse(routeProps.location.search)} />}/>
 						<Route path='/print' exact component={(routeProps)=><PrintPage query={queryString.parse(routeProps.location.search)} />}/>
 						<Route path='/changelog' exact component={()=><SharePage brew={this.props.brew} />}/>

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -77,13 +77,8 @@ const ListPage = createClass({
 		this.setState({
 			filterString : e.target.value,
 		});
+		this.updateUrl(e.target.value);
 		return;
-	},
-
-	handleKeys : function(e){
-		if(e.key === 'Enter') {
-			this.updateUrl(e.target.value);
-		  }
 	},
 
 	updateUrl : function(filterTerm){
@@ -93,7 +88,7 @@ const ListPage = createClass({
 		urlParams.set('filter', filterTerm);
 		if(!filterTerm) urlParams.delete('filter');
 		url.search = urlParams;
-		window.location.replace(url.href);
+		window.history.replaceState(null, null, url);
 	},
 
 	renderFilterOption : function(){
@@ -105,8 +100,6 @@ const ListPage = createClass({
 					autoFocus={true}
 					placeholder='filter title/description'
 					onChange={this.handleFilterTextChange}
-					onFocus={(e)=>{e.target.select();}}
-					onKeyDown={(e)=>{this.handleKeys(e);}}
 					value={this.state.filterString}
 				/>
 			</label>

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -84,9 +84,12 @@ const ListPage = createClass({
 	updateUrl : function(filterTerm){
 		const url = new URL(window.location.href);
 		const urlParams = new URLSearchParams(url.search);
-		if(urlParams.get('filter') == filterTerm) return;
-		urlParams.set('filter', filterTerm);
-		if(!filterTerm) urlParams.delete('filter');
+		if(urlParams.get('filter') == filterTerm)
+			return;
+		if(!filterTerm)
+			urlParams.delete('filter');
+		else
+			urlParams.set('filter', filterTerm);
 		url.search = urlParams;
 		window.history.replaceState(null, null, url);
 	},

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -103,7 +103,7 @@ const ListPage = createClass({
 				<input
 					type='search'
 					autoFocus={true}
-					placeholder='search title/description'
+					placeholder='filter title/description'
 					onChange={this.handleFilterTextChange}
 					onFocus={(e)=>{e.target.select();}}
 					onKeyDown={(e)=>{this.handleKeys(e);}}

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -24,7 +24,8 @@ const ListPage = createClass({
 		return {
 			sortType     : 'alpha',
 			sortDir      : 'asc',
-			filterString : ''
+			filterString : this.props.query?.filter || '',
+			query        : this.props.query
 		};
 	},
 
@@ -74,9 +75,25 @@ const ListPage = createClass({
 
 	handleFilterTextChange : function(e){
 		this.setState({
-			filterString : e.target.value
+			filterString : e.target.value,
 		});
 		return;
+	},
+
+	handleKeys : function(e){
+		if(e.key === 'Enter') {
+			this.updateUrl(e.target.value);
+		  }
+	},
+
+	updateUrl : function(filterTerm){
+		const url = new URL(window.location.href);
+		const urlParams = new URLSearchParams(url.search);
+		if(urlParams.get('filter') == filterTerm) return;
+		urlParams.set('filter', filterTerm);
+		if(!filterTerm) urlParams.delete('filter');
+		url.search = urlParams;
+		window.location.replace(url.href);
 	},
 
 	renderFilterOption : function(){
@@ -85,8 +102,12 @@ const ListPage = createClass({
 				<i className='fas fa-search'></i>
 				<input
 					type='search'
+					autoFocus={true}
 					placeholder='search title/description'
 					onChange={this.handleFilterTextChange}
+					onFocus={(e)=>{e.target.select();}}
+					onKeyDown={(e)=>{this.handleKeys(e);}}
+					value={this.state.filterString}
 				/>
 			</label>
 		</td>;

--- a/client/homebrew/pages/userPage/userPage.jsx
+++ b/client/homebrew/pages/userPage/userPage.jsx
@@ -19,6 +19,7 @@ const UserPage = createClass({
 		return {
 			username : '',
 			brews    : [],
+			query    : ''
 		};
 	},
 	getInitialState : function() {
@@ -62,7 +63,7 @@ const UserPage = createClass({
 	},
 
 	render : function(){
-		return <ListPage brewCollection={this.state.brewCollection} navItems={this.navItems()}></ListPage>;
+		return <ListPage brewCollection={this.state.brewCollection} navItems={this.navItems()} query={this.props.query}></ListPage>;
 	}
 });
 


### PR DESCRIPTION
This PR adds the ability to specify a `filter` parameter to the `/user` URL, which causes the results to be filtered by the passed parameter.
While typing into the text box does not update the URL, pressing the Enter key causes the browser's current URL to update to reflect the contents of that input field in the filter parameter. Pressing Enter on an empty input field results in the filter parameter being removed from the URL.

These changes will resolve #1858.

---

I also changed one piece of verbiage from "search" to "filter", which resolves #2023. The only place that the term "search" is used is in FontAwesome class names or the names of built-in functions, neither of which we are able to change.

---

EDIT: After feedback from @ericscheid, I have changed the `window.location.replace` to `history.replaceState`. This allowed the URL to update without causing a page reload, so I have removed the URL update on pressing Enter and switched to updating the URL live.