### PR TITLE
Remove calls to deprecated `componentWillMount`

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -32,11 +32,14 @@ const Homebrew = createClass({
 			}
 		};
 	},
-	componentDidMount : function() {
-		global.account = this.props.account;
+
+	getInitialState : function(){
 		global.version = this.props.version;
+		global.account = this.props.account;
 		global.enable_v3 = this.props.enable_v3;
+		return {};
 	},
+
 	render : function (){
 		return (
 			<Router location={this.props.url}>

--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -32,7 +32,7 @@ const Homebrew = createClass({
 			}
 		};
 	},
-	componentWillMount : function() {
+	componentDidMount : function() {
 		global.account = this.props.account;
 		global.version = this.props.version;
 		global.enable_v3 = this.props.enable_v3;

--- a/client/homebrew/navbar/navbar.jsx
+++ b/client/homebrew/navbar/navbar.jsx
@@ -14,12 +14,10 @@ const Navbar = createClass({
 		};
 	},
 
-	componentDidMount : function() {
-		//const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
-		this.setState({
-			//showNonChromeWarning : !isChrome,
-			ver : window.version
-		});
+	getInitialState : function() {
+		return {
+			ver : global.version
+		};
 	},
 
 	/*


### PR DESCRIPTION
This PR removes the deprecated `componentWillMount` call from `homebrew.jsx`, shifting the declarations in that function to `getInitialState` instead.

This PR resolves #1936.