### PR TITLE
User public url for link gen #2128

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -352,7 +352,7 @@ const EditPage = createClass({
 		const title = `${this.props.brew.title} ${systems}`;
 		const text = `Hey guys! I've been working on this homebrew. I'd love your feedback. Check it out.
 
-**[Homebrewery Link](https://homebrewery.naturalcrit.com/share/${shareLink})**`;
+**[Homebrewery Link](${global.config.publicUrl}/share/${shareLink})**`;
 
 		return `https://www.reddit.com/r/UnearthedArcana/submit?title=${encodeURIComponent(title)}&text=${encodeURIComponent(text)}`;
 	},
@@ -387,7 +387,7 @@ const EditPage = createClass({
 					<Nav.item color='blue' href={`/share/${shareLink}`}>
 						view
 					</Nav.item>
-					<Nav.item color='blue' onClick={()=>{navigator.clipboard.writeText(`https://homebrewery.naturalcrit.com/share/${shareLink}`);}}>
+					<Nav.item color='blue' onClick={()=>{navigator.clipboard.writeText(`${global.config.publicUrl}/share/${shareLink}`);}}>
 						copy url
 					</Nav.item>
 					<Nav.item color='blue' href={this.getRedditLink()} newTab={true} rel='noopener noreferrer'>

--- a/client/template.js
+++ b/client/template.js
@@ -1,5 +1,5 @@
 module.exports = async(name, title = '', props = {})=>{
-	const HOMEBREWERY_PUBLIC_URL=props.publicUrl;
+	const HOMEBREWERY_PUBLIC_URL=props.config.publicUrl;
 
 	return `
 <!DOCTYPE html>

--- a/client/template.js
+++ b/client/template.js
@@ -9,10 +9,10 @@ module.exports = async(name, title = '', props = {})=>{
 		<link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css" />
 		<link href=${`/${name}/bundle.css`} rel='stylesheet' />
 		<link rel="icon" href="/assets/homebrew/favicon.ico" type="image/x-icon" />
-		<meta property="og:title" content="${props.brew?.title ?? 'Homebrewery - Untitled Brew'}">
+		<meta property="og:title" content="${props.brew?.title || 'Homebrewery - Untitled Brew'}">
 		<meta property="og:url" content="${HOMEBREWERY_PUBLIC_URL}/${props.brew?.shareId ? `share/${props.brew.shareId}` : ''}">
-		<meta property="og:image" content="${props.brew?.thumbnail ? props.brew?.thumbnail : `${HOMEBREWERY_PUBLIC_URL}/thumbnail.png`}">
-		<meta property="og:description" content="${props.brew?.description ? props.brew?.description : 'No description.'}">
+		<meta property="og:image" content="${props.brew?.thumbnail || `${HOMEBREWERY_PUBLIC_URL}/thumbnail.png`}">
+		<meta property="og:description" content="${props.brew?.description || 'No description.'}">
 		<meta property="og:site_name" content="The Homebrewery - Make your Homebrew content look legit!">
 		<meta property="og:type" content="article">
 		<meta name="twitter:card" content="summary_large_image">

--- a/server/app.js
+++ b/server/app.js
@@ -281,11 +281,11 @@ app.use((req, res)=>{
 	// Create configuration object
 	const configuration = {
 		local       : isLocalEnvironment,
+		publicUrl   : config.get('publicUrl') ?? '',
 		environment : nodeEnv
 	};
 	const props = {
 		version     : require('./../package.json').version,
-		publicUrl   : config.get('publicUrl') ?? '',
 		url         : req.originalUrl,
 		brew        : req.brew,
 		brews       : req.brews,


### PR DESCRIPTION
- This PR is branched from #2129 and should be applied after that PR.
- This PR resolves #2128.

This PR moves the `publicUrl` prop to the new `global.config` item, making the value available to all pages. It is then used in the EditPage to generate the share links for "COPY URL" and "POST TO REDDIT" nav bar items.
