### PR TITLE
Add fields to Mongoose brew query

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -194,7 +194,18 @@ app.get('/download/:id', asyncHandler(async (req, res)=>{
 app.get('/user/:username', async (req, res, next)=>{
 	const ownAccount = req.account && (req.account.username == req.params.username);
 
-	const fields = 'title pageCount description authors views shareId editId createdAt updatedAt lastViewed';
+	const fields = [
+		'title',
+		'pageCount',
+		'description',
+		'authors',
+		'views',
+		'shareId',
+		'editId',
+		'createdAt',
+		'updatedAt',
+		'lastViewed'
+	];
 
 	let brews = await HomebrewModel.getByUser(req.params.username, ownAccount, fields)
 	.catch((err)=>{

--- a/server/app.js
+++ b/server/app.js
@@ -194,7 +194,9 @@ app.get('/download/:id', asyncHandler(async (req, res)=>{
 app.get('/user/:username', async (req, res, next)=>{
 	const ownAccount = req.account && (req.account.username == req.params.username);
 
-	let brews = await HomebrewModel.getByUser(req.params.username, ownAccount)
+	const fields = 'title pageCount description authors views shareId editId createdAt updatedAt lastViewed';
+
+	let brews = await HomebrewModel.getByUser(req.params.username, ownAccount, fields)
 	.catch((err)=>{
 		console.log(err);
 	});

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -37,9 +37,9 @@ HomebrewSchema.statics.increaseView = async function(query) {
 	return brew;
 };
 
-HomebrewSchema.statics.get = function(query){
+HomebrewSchema.statics.get = function(query, fields=null){
 	return new Promise((resolve, reject)=>{
-		Homebrew.find(query, (err, brews)=>{
+		Homebrew.find(query, fields, null, (err, brews)=>{
 			if(err || !brews.length) return reject('Can not find brew');
 			if(!_.isNil(brews[0].textBin)) {			// Uncompress zipped text field
 				unzipped = zlib.inflateRawSync(brews[0].textBin);
@@ -52,13 +52,13 @@ HomebrewSchema.statics.get = function(query){
 	});
 };
 
-HomebrewSchema.statics.getByUser = function(username, allowAccess=false){
+HomebrewSchema.statics.getByUser = function(username, allowAccess=false, fields=null){
 	return new Promise((resolve, reject)=>{
 		const query = { authors: username, published: true };
 		if(allowAccess){
 			delete query.published;
 		}
-		Homebrew.find(query).lean().exec((err, brews)=>{ //lean() converts results to JSObjects
+		Homebrew.find(query, fields).lean().exec((err, brews)=>{ //lean() converts results to JSObjects
 			if(err) return reject('Can not find brew');
 			return resolve(brews);
 		});

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -39,7 +39,7 @@ HomebrewSchema.statics.increaseView = async function(query) {
 
 HomebrewSchema.statics.get = function(query, fields=null){
 	return new Promise((resolve, reject)=>{
-		Homebrew.find(query, (err, brews)=>{
+		Homebrew.find(query, fields, null, (err, brews)=>{
 			if(err || !brews.length) return reject('Can not find brew');
 			if(!_.isNil(brews[0].textBin)) {			// Uncompress zipped text field
 				unzipped = zlib.inflateRawSync(brews[0].textBin);
@@ -48,7 +48,7 @@ HomebrewSchema.statics.get = function(query, fields=null){
 			if(!brews[0].renderer)
 				brews[0].renderer = 'legacy';
 			return resolve(brews[0]);
-		}).select(fields);
+		});
 	});
 };
 
@@ -58,7 +58,7 @@ HomebrewSchema.statics.getByUser = function(username, allowAccess=false, fields=
 		if(allowAccess){
 			delete query.published;
 		}
-		Homebrew.find(query).select(fields).lean().exec((err, brews)=>{ //lean() converts results to JSObjects
+		Homebrew.find(query, fields).lean().exec((err, brews)=>{ //lean() converts results to JSObjects
 			if(err) return reject('Can not find brew');
 			return resolve(brews);
 		});

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -39,7 +39,7 @@ HomebrewSchema.statics.increaseView = async function(query) {
 
 HomebrewSchema.statics.get = function(query, fields=null){
 	return new Promise((resolve, reject)=>{
-		Homebrew.find(query, fields, null, (err, brews)=>{
+		Homebrew.find(query, (err, brews)=>{
 			if(err || !brews.length) return reject('Can not find brew');
 			if(!_.isNil(brews[0].textBin)) {			// Uncompress zipped text field
 				unzipped = zlib.inflateRawSync(brews[0].textBin);
@@ -48,7 +48,7 @@ HomebrewSchema.statics.get = function(query, fields=null){
 			if(!brews[0].renderer)
 				brews[0].renderer = 'legacy';
 			return resolve(brews[0]);
-		});
+		}).select(fields);
 	});
 };
 
@@ -58,7 +58,7 @@ HomebrewSchema.statics.getByUser = function(username, allowAccess=false, fields=
 		if(allowAccess){
 			delete query.published;
 		}
-		Homebrew.find(query, fields).lean().exec((err, brews)=>{ //lean() converts results to JSObjects
+		Homebrew.find(query).select(fields).lean().exec((err, brews)=>{ //lean() converts results to JSObjects
 			if(err) return reject('Can not find brew');
 			return resolve(brews);
 		});


### PR DESCRIPTION
This PR adds a `fields` parameter to the `get` and `getByUser` methods, allowing only specific fields to be returned. This defaults to NULL, meaning that all fields are returned.

It also adds a `fields` parameter to the function call in `app.js` for UserPage, which limits the returned data to exclude the `text` and `textBin` fields from the returned data.

This will resolve #2147.