### PR TITLE
update WithRoute to handle query params correctly

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -14,13 +14,17 @@ const PrintPage = require('./pages/printPage/printPage.jsx');
 
 const WithRoute = (props)=>{
 	const params = useParams();
-	const searchParams = useSearchParams();
+	const [searchParams] = useSearchParams();
+	const queryParams = {};
+	for (const [key, value] of searchParams?.entries() || []) {
+		queryParams[key] = value;
+	}
 	const Element = props.el;
 	const allProps = {
 		...props,
 		...params,
-		...searchParams,
-		el : undefined
+		query : queryParams,
+		el    : undefined
 	};
 	return <Element {...allProps} />;
 };


### PR DESCRIPTION
Please test on the brews page by filtering and refreshing -- the search should remain after refresh.
Also test that trying to print will automatically open both the page and dialog.