### PR TITLE
[UserPage] Fix sort container position when scroll bar absent

### DIFF
--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -13,7 +13,7 @@
 }
 .listPage{
 	.content{
-		overflow-y : scroll;
+		overflow-y : overlay;
 		.phb{
 			.noColumns();
 			height     : auto;
@@ -34,7 +34,7 @@
 		font-family        : 'Open Sans', sans-serif;
 		position           : fixed;
 		top                : 35px;
-		left               : calc(50vw - 408px);
+		left               : calc(50vw - 400px);
 		border             : 2px solid #58180D;
 		width              : 800px;
 		background-color   : #EEE5CE;


### PR DESCRIPTION
This PR resolves #2303.

This PR changes the UserPage `content-y` setting to `overlay`, which prevents the scrollbar from adjusting the viewport width when it is present. It also nudges the Sort Container eight pixels to the right to adjust for this change.