### PR TITLE
[UserPage] Remove autofocus from filter textbox

### DIFF
--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -100,7 +100,6 @@ const ListPage = createClass({
 				<i className='fas fa-search'></i>
 				<input
 					type='search'
-					autoFocus={true}
 					placeholder='filter title/description'
 					onChange={this.handleFilterTextChange}
 					value={this.state.filterString}


### PR DESCRIPTION
This PR resolves #2121.

This PR removes the `autofocus=true` from the UserPage filter textbox.