### PR TITLE
Fix conflicts on /new

### DIFF
--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -30,10 +30,10 @@ const ListPage = createClass({
 		});
 
 		return {
-			filterString : this.props.query?.filter || '',
-			sortType     : this.props.query?.sort || 'alpha',
-			sortDir      : this.props.query?.dir || 'asc',
-			query        : this.props.query,
+			filterString   : this.props.query?.filter || '',
+			sortType       : this.props.query?.sort || 'alpha',
+			sortDir        : this.props.query?.dir || 'asc',
+			query          : this.props.query,
 			brewCollection : brewCollection
 		};
 	},

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -27,41 +27,30 @@ const NewPage = createClass({
 	getDefaultProps : function() {
 		return {
 			brew : {
-				text      : '',
-				style     : undefined,
-				shareId   : null,
-				editId    : null,
-				createdAt : null,
-				updatedAt : null,
-				gDrive    : false,
-
+				text        : '',
+				style       : undefined,
 				title       : '',
 				description : '',
-				tags        : '',
-				published   : false,
-				authors     : [],
-				systems     : []
+				renderer    : 'V3'
 			}
 		};
 	},
 
 	getInitialState : function() {
-		const brew = this.props.brew;
+		let brew = this.props.brew;
+
+		if(this.props.brew.shareId) {
+			brew = {
+				text        : brew.text        ?? '',
+				style       : brew.style       ?? undefined,
+				title       : brew.title       ?? '',
+				description : brew.description ?? '',
+				renderer    : brew.renderer    ?? 'legacy'
+			};
+		}
 
 		return {
-			brew : {
-				text        : brew.text || '',
-				style       : brew.style || undefined,
-				gDrive      : false,
-				title       : brew.title || '',
-				description : brew.description || '',
-				tags        : brew.tags || '',
-				published   : false,
-				authors     : [],
-				systems     : brew.systems || [],
-				renderer    : brew.renderer || 'V3'
-			},
-
+			brew       : brew,
 			isSaving   : false,
 			saveGoogle : (global.account && global.account.googleId ? true : false),
 			errors     : null,
@@ -74,27 +63,25 @@ const NewPage = createClass({
 
 		const brew = this.state.brew;
 
-		if(typeof window !== 'undefined') { //Load from localStorage if in client browser
+		if(!this.props.brew.shareId && typeof window !== 'undefined') { //Load from localStorage if in client browser
 			const brewStorage  = localStorage.getItem(BREWKEY);
 			const styleStorage = localStorage.getItem(STYLEKEY);
 			const metaStorage = JSON.parse(localStorage.getItem(METAKEY));
 
-			if(!brew.text || !brew.style){
-				brew.text = brew.text  || (brewStorage  ?? '');
-				brew.style = brew.style || (styleStorage ?? undefined);
-				// brew.title = metaStorage?.title || this.state.brew.title;
-				// brew.description = metaStorage?.description || this.state.brew.description;
-				brew.renderer = brew.renderer || metaStorage?.renderer;
+			brew.text  = brewStorage  ?? brew.text;
+			brew.style = styleStorage ?? brew.style;
+			// brew.title = metaStorage?.title || this.state.brew.title;
+			// brew.description = metaStorage?.description || this.state.brew.description;
+			brew.renderer = metaStorage?.renderer ?? brew.renderer;
 
-				this.setState({
-					brew : brew
-				});
-			}
+			this.setState({
+				brew : brew
+			});
 		}
 
 		localStorage.setItem(BREWKEY, brew.text);
 		localStorage.setItem(STYLEKEY, brew.style);
-		localStorage.setItem(METAKEY, JSON.stringify({'renderer' : brew.renderer}));
+		localStorage.setItem(METAKEY, JSON.stringify({ 'renderer': brew.renderer }));
 	},
 	componentWillUnmount : function() {
 		document.removeEventListener('keydown', this.handleControlKeys);


### PR DESCRIPTION
Hopefully fix any remaining conflicts on `/new` between:

1) New empty brews
2) Localstorage
3) Cloned brews

Expected behavior is:

- If we are cloning a brew, do not load localstorage
- Else, generate a blank brew that uses V3
  - If there is any localstorage, apply it on top of the blank brew
- Save the results into localstorage (the cloned brew, the blank brew, or the applied-localstorage brew)