### PR TITLE
Add Styling to Tags on userpage

### DIFF
--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -95,6 +95,10 @@ const BrewItem = createClass({
 
 	render : function(){
 		const brew = this.props.brew;
+		if(Array.isArray(brew.tags)) {               // temporary fix until dud tags are cleaned
+			brew.tags = brew.tags?.filter(tag => tag); //remove tags that are empty strings
+			console.log(brew.tags);
+		}
 		const dateFormatString = 'YYYY-MM-DD HH:mm:ss';
 
 		return <div className='brewItem'>
@@ -104,10 +108,14 @@ const BrewItem = createClass({
 			</div>
 			<hr />
 			<div className='info'>
-				{brew.tags ? <>
+
+				{brew.tags?.length ? <>
 					<div className='brewTags' title={`Tags:\n${brew.tags.join('\n')}`}>
 						<i className='fas fa-tags'/>
-						{brew.tags.map((tag, idx)=>{return <span>{tag}</span>;})}
+						{brew.tags.map((tag, idx)=>{
+							let matches = tag.match(/^(?:([^:]+):)?([^:]+)$/);
+							return <span className={matches[1]}>{matches[2]}</span>;
+						})}
 					</div>
 				</> : <></>
 				}

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -105,11 +105,10 @@ const BrewItem = createClass({
 			<hr />
 			<div className='info'>
 				{brew.tags ? <>
-					<span className='brewTags' title={`Tags:\n${brew.tags.join('\n')}`}>
+					<div className='brewTags' title={`Tags:\n${brew.tags.join('\n')}`}>
 						<i className='fas fa-tags'/>
-						{brew.tags.map((tag, idx)=>{return <><span>{tag}</span>{'\n'}</>;})}
-					</span>
-					<br />
+						{brew.tags.map((tag, idx)=>{return <span>{tag}</span>;})}
+					</div>
 				</> : <></>
 				}
 				<span title={`Authors:\n${brew.authors?.join('\n')}`}>

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -97,7 +97,6 @@ const BrewItem = createClass({
 		const brew = this.props.brew;
 		if(Array.isArray(brew.tags)) {               // temporary fix until dud tags are cleaned
 			brew.tags = brew.tags?.filter(tag => tag); //remove tags that are empty strings
-			console.log(brew.tags);
 		}
 		const dateFormatString = 'YYYY-MM-DD HH:mm:ss';
 

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -106,7 +106,8 @@ const BrewItem = createClass({
 			<div className='info'>
 				{brew.tags ? <>
 					<span className='brewTags' title={`Tags:\n${brew.tags.join('\n')}`}>
-						<i className='fas fa-tags'/> {brew.tags.join(', ')}
+						<i className='fas fa-tags'/>
+						{brew.tags.map((tag, idx)=>{return <><span>{tag}</span>{'\n'}</>;})}
 					</span>
 					<br />
 				</> : <></>

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
@@ -29,7 +29,7 @@
 	.info{
 		position: initial;
 		bottom: 2px;
-		font-family : ScalySans;
+		font-family : ScalySansRemake;
 		font-size   : 1.2em;
 		&>span{
 			margin-right : 12px;
@@ -38,11 +38,13 @@
 	}
 	.brewTags span {
 		background-color: #c8ac6e3b;
-		margin-left: 2px;
-		border-radius: 0.5em;
-		padding: 1px 4px;
+		margin: 2px;
+		padding: 2px;
 		border: 1px solid #c8ac6e;
+		border-radius: 4px;
 		white-space: nowrap;
+		display: inline-block;
+		font-weight: bold;
 	}
 	&:hover{
 		.links{

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
@@ -36,6 +36,14 @@
 			line-height  : 1.5em;
 		}
 	}
+	.brewTags span {
+		background-color: #c8ac6e3b;
+		margin-left: 2px;
+		border-radius: 0.5em;
+		padding: 1px 4px;
+		border: 1px solid #c8ac6e;
+		white-space: nowrap;
+	}
 	&:hover{
 		.links{
 			opacity : 1;


### PR DESCRIPTION
Wraps Tags shown on the User page in spans, following the style suggested by @ericscheid in #2334 . Spans are kept from breaking across lines.

Also fixes the `scalySans` font that got lost when updating the user page to use the V3 stylesheet.

![image](https://user-images.githubusercontent.com/5878534/188547035-389562d3-ee26-47a7-8833-16aab12dafaa.png)

