### PR TITLE
Change MongoDB address from localhost to 127.0.0.1

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -10,7 +10,7 @@ const Mongoose = require('mongoose');
 const getMongoDBURL = (config)=>{
 	return config.get('mongodb_uri') ||
            config.get('mongolab_uri') ||
-           'mongodb://localhost/homebrewery';
+		   'mongodb://127.0.0.1/homebrewery';  // changed from mongodb://localhost/homebrewery to accommodate versions 16+ of node.
 };
 
 const handleConnectionError = (error)=>{


### PR DESCRIPTION
I was running into an issue with not connecting to the Mongo database for a long time, and @calculuschild found [this thread with a solution](https://www.mongodb.com/community/forums/t/mongooseserverselectionerror-connect-econnrefused-127-0-0-1-27017/123421)-- changing the mongo address to mongodb://127.0.01/homebrewery.  This is supposedly a change with node v17+ on MacOS.  The change continues to work on Windows as well.

[From Mongo's documentation for MacOS](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/#localhost-binding-by-default):
> Localhost Binding by Default
> 
> By default, MongoDB launches with [bindIp](https://www.mongodb.com/docs/manual/reference/configuration-options/#mongodb-setting-net.bindIp) set to 127.0.0.1, which binds to the localhost network interface. This means that the mongod can only accept connections from clients that are running on the same machine. Remote clients will not be able to connect to the mongod, and the mongod will not be able to initialize a [replica set](https://www.mongodb.com/docs/manual/reference/glossary/#std-term-replica-set) unless this value is set to a valid network interface.

This PR just makes that small change and includes a comment.