### PR TITLE
change overflow-y behavior to fix navbar

### DIFF
--- a/client/homebrew/homebrew.less
+++ b/client/homebrew/homebrew.less
@@ -6,10 +6,12 @@
 		height           : 100%;
 		background-color : @steel;
 		flex-direction   : column;
+		overflow-y       : hidden;
 		.content{
 			position   : relative;
 			height     : calc(~"100% - 29px"); //Navbar height
 			flex       : auto;
+			overflow-y : scroll;
 		}
 	}
 }


### PR DESCRIPTION
Currently on the live version of the user page, on Firefox, the navbar can be scrolled out of view, and the bottom of the blue background only extends to the height of the window (not of the page).  Also, the scrollbar overlaps the navbar.

I believe the issue is that the scroll region includes the navbar on all pages which doesn't cause an issue on some pages, but it does on the userpage.  It works fine on Chrome because of the use of CSS `overlay` property sets the navbar UI to cover the scroll bar.  But this doesn't work on FF.

This PR changes the scroll region to only include the `.content` portion of the page--- the `.nav` portion sits outside of the scroll, just above it.  This fixes the issue in Firefox and doesn't seem to break it in Chrome. 

Simple fix, so please double check it to make sure I didn't miss something, @G-Ambatte 

fixes #2352 