### PR TITLE
Add different Issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: /r/Homebrewery Subreddit
+    url: https://www.reddit.com/r/homebrewery
+    about: The Homebrewery community on Reddit!
+  - name: Discord of Many Things
+    url: https://discord.gg/domt
+    about: "Join the conversation in the #formatting channel on DoMT!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        We'd love to hear your idea!  Please be sure to search the current Issues for any duplicate requests.
+        "We'd love to hear your idea!  Please be sure to [search the current Issues](https://github.com/naturalcrit/homebrewery/issues) for any duplicate requests."
   - type: textarea
     id: user-request
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,20 @@
+name: Feature Request
+description: Have an idea to improve the Homebrewery? Let us know!
+labels: ["feature request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We'd love to hear your idea!  Please be sure to search the current Issues for any duplicate requests.
+  - type: textarea
+    id: user-request
+    attributes:
+      label: "Your idea:"
+      description: The best feature requests provide an explanation of the current issue and then an explanation of how it could be improved.  Screenshots/images can be pasted right in as well!
+    validations:
+      required: true
+  - type: checkboxes
+    id: terms
+    options:
+      - label: I have searched the Issues tracker for any duplicate requests and found none.
+        required: true

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -3,8 +3,7 @@ description: Report an issue unrelated to Saving
 body:
   - type: markdown
     attributes:
-      value: |
-        Please include as much information as possible.
+      value: Please include as much information as possible.
   - type: checkboxes
     id: renderer
     attributes:
@@ -16,17 +15,30 @@ body:
       validations:
         required: true
   - type: dropdown
-  id: operating-system
-  attributes:
-    label: Operating System
-    description: Which OS were you using when the issue occurred?
-    options:
-      - label: Windows
-      - label: MacOS
-      - label: Linux
-      - label: other
-    validations:
-      required: true
+    id: browser
+    attributes:
+      label: Browser
+      description: Which browser were you using when the issue occurred?
+      options:
+        - label: Chrome
+        - label: Firefox
+        - label: Edge
+        - label: Safari
+        - label: other
+      validations:
+        required: true
+  - type: dropdown
+    id: operating-system
+    attributes:
+      label: Operating System
+      description: Which OS were you using when the issue occurred?
+      options:
+        - label: Windows
+        - label: MacOS
+        - label: Linux
+        - label: other
+      validations:
+        required: true
   - type: textarea
     id: user-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -1,0 +1,42 @@
+name: General Issue
+description: Report an issue unrelated to Saving
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please include as much information as possible.
+  - type: checkboxes
+    id: renderer
+    attributes:
+      label: Renderer
+      description: Which renderer does this issue occur on?  If you are unsure, you can check the renderer in the Metadata Editor.
+      options:
+        - label: Legacy
+        - label: v3
+      validations:
+        required: true
+  - type: dropdown
+  id: operating-system
+  attributes:
+    label: Operating System
+    description: Which OS were you using when the issue occurred?
+    options:
+      - label: Windows
+      - label: MacOS
+      - label: Linux
+      - label: other
+    validations:
+      required: true
+  - type: textarea
+    id: user-description
+    attributes:
+      label: "What happened?"
+      description: Please include any steps you took leading up to the issue and if you can reproduce it.  Let us know what you expected to happen, and what did happen.
+    validations:
+      required: true
+  - type: textarea
+    id: code
+    attributes:
+      label: Code
+      description: Paste in any relevant code snippet below.
+      render: gfm

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -9,7 +9,7 @@ body:
     id: renderer
     attributes:
       label: Renderer
-      description: Which renderer does this issue occur on?  If you are unsure, you can check the renderer in the Metadata Editor.
+      description: Which renderer does this issue occur on?  If you are unsure, you can check the renderer in the Properties Editor (click the "i" in the Snippet Menu bar above the editor).
       options:
         - label: Legacy
         - label: v3

--- a/.github/ISSUE_TEMPLATE/save_issue.yml
+++ b/.github/ISSUE_TEMPLATE/save_issue.yml
@@ -1,0 +1,22 @@
+name: Saving Issue
+description: Report an issue Saving
+title: "Save Error: "
+labels: ["saving"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Woops, sorry there was an issue Saving.  Here are some possible quick solutions to try:
+        1. Refreshing your Google credentials in Homebrewery by signing out, and back in (they expire after one year).
+        2. Waiting a few minutes and trying again
+        3. Checking the Issues in Github or the /r/homebrewery subreddit for answers to similar issues
+        If none of the above helps, please fill out an Issue!
+  - type: textarea
+    id: error-code
+    attributes:
+      label: Error Code
+      render: shell
+  - type: textarea
+    id: user-description
+    attributes:
+      label: "Your description of what happened:"

--- a/.github/ISSUE_TEMPLATE/save_issue.yml
+++ b/.github/ISSUE_TEMPLATE/save_issue.yml
@@ -6,11 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Woops, sorry there was an issue Saving.  Here are some possible quick solutions to try:
-        1. Refreshing your Google credentials in Homebrewery by signing out, and back in (they expire after one year).
-        2. Waiting a few minutes and trying again
-        3. Checking the Issues in Github or the /r/homebrewery subreddit for answers to similar issues
-        If none of the above helps, please fill out an Issue!
+        Woops, sorry there was an issue Saving.  Please add any detail you can to this report and check back soon!
   - type: textarea
     id: error-code
     attributes:
@@ -20,3 +16,10 @@ body:
     id: user-description
     attributes:
       label: "Your description of what happened:"
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report.  Here are some steps that may help in the meantime:
+        1. Refreshing your Google credentials in Homebrewery by signing out, and back in (they expire after one year).
+        2. Waiting a few minutes and trying again - sometimes there is just a momentary blip in the server.
+        3. Check the Issues in Github or the /r/homebrewery subreddit to see if others are experiencing the same issue.

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -322,7 +322,7 @@ const EditPage = createClass({
 				<div className='errorContainer'>
 					Looks like there was a problem saving. <br />
 					Report the issue <a target='_blank' rel='noopener noreferrer'
-						href={`https://github.com/naturalcrit/homebrewery/issues/new?body=${encodeURIComponent(errMsg)}`}>
+						href={`https://github.com/naturalcrit/homebrewery/issues/new?template=save_issue.yaml&error-code=${encodeURIComponent(errMsg)}`}>
 						here
 					</a>.
 				</div>


### PR DESCRIPTION
Probably jumping the gun here, but here is my take on utilizing Github Issue Forms.   Issue Forms are detailed [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser), and here is a generic example:

![image](https://user-images.githubusercontent.com/58999374/190299988-4db698d4-74f1-463a-b0ae-1eed5b7a6c0e.png)

This is all meant to address the large number of "saving" issues that get reported.  Obviously it's best to just not have those issues, but when they do come up they seem to come in droves.  Also, they are typically reported by first-time github users with little additional information or follow-up.  This form automatically applies a "saving" label to the issue, which could be used in further automation with Github Actions (such as auto-closing with comment after a certain number of days of no activity).

But further, this PR includes the Saving Issue Form, Generic Issue Form, and a Feature Request Form.  Additionally, when creating a new Issue there will be a step that asks which type of Issue you need to create **AND** it will offer links to the subreddit and Discord of Many Things.  This may help direct users to better places for simple questions/answers.   Finally, as currently set in this PR, a normal Issue can be opened as well (with the current markdown template).

One thing I didn't include but might be helpful are dropdown menus (multiple selections are possible) that let a user indicate which page the issue occurred on, or what *category* of feature request they have.

Another thing we can do is add another option in the Issue Form chooser  (config.yml) that opens a reddit DM to calculuschild if seeking password help.