### PR TITLE
Reposition Thumbnail Preview in Metadata Editor

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -232,24 +232,26 @@ const MetadataEditor = createClass({
 					onChange={(e)=>this.handleFieldChange('title', e)} />
 			</div>
 			<div className='field-group'>
-				<div className='field description'>
-					<label>description</label>
-					<textarea value={this.props.metadata.description} className='value'
-						onChange={(e)=>this.handleFieldChange('description', e)} />
+				<div className='field-column'>
+					<div className='field description'>
+						<label>description</label>
+						<textarea value={this.props.metadata.description} className='value'
+							onChange={(e)=>this.handleFieldChange('description', e)} />
+					</div>
+					<div className='field thumbnail'>
+						<label>thumbnail</label>
+						<input type='text'
+							value={this.props.metadata.thumbnail}
+							placeholder='my.thumbnail.url'
+							className='value'
+							onChange={(e)=>this.handleFieldChange('thumbnail', e)} />
+						<button className='display' onClick={this.toggleThumbnailDisplay}>
+							<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />
+						</button>
+					</div>
 				</div>
-				<div className='field thumbnail'>
-					<label>thumbnail</label>
-					<input type='text'
-						value={this.props.metadata.thumbnail}
-						placeholder='my.thumbnail.url'
-						className='value'
-						onChange={(e)=>this.handleFieldChange('thumbnail', e)} />
-					<button className='display' onClick={this.toggleThumbnailDisplay}>
-						<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />
-					</button>
-				</div>
+				{this.renderThumbnail()}
 			</div>
-			{this.renderThumbnail()}
 
 			<StringArrayEditor label='tags' valuePatterns={[/^(?:(?:group|meta|system|type):)?[A-Za-z0-9][A-Za-z0-9 \/.\-]{0,40}$/]}
 				placeholder='add tag' unique={true}

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -231,23 +231,25 @@ const MetadataEditor = createClass({
 					value={this.props.metadata.title}
 					onChange={(e)=>this.handleFieldChange('title', e)} />
 			</div>
-			<div className='field description'>
-				<label>description</label>
-				<textarea value={this.props.metadata.description} className='value'
-					onChange={(e)=>this.handleFieldChange('description', e)} />
+			<div className='field-group'>
+				<div className='field description'>
+					<label>description</label>
+					<textarea value={this.props.metadata.description} className='value'
+						onChange={(e)=>this.handleFieldChange('description', e)} />
+				</div>
+				<div className='field thumbnail'>
+					<label>thumbnail</label>
+					<input type='text'
+						value={this.props.metadata.thumbnail}
+						placeholder='my.thumbnail.url'
+						className='value'
+						onChange={(e)=>this.handleFieldChange('thumbnail', e)} />
+					<button className='display' onClick={this.toggleThumbnailDisplay}>
+						<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />
+					</button>
+				</div>
 			</div>
-			<div className='field thumbnail'>
-				<label>thumbnail</label>
-				<input type='text'
-					value={this.props.metadata.thumbnail}
-					placeholder='my.thumbnail.url'
-					className='value'
-					onChange={(e)=>this.handleFieldChange('thumbnail', e)} />
-				<button className='display' onClick={this.toggleThumbnailDisplay}>
-					<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />
-				</button>
-				{this.renderThumbnail()}
-			</div>
+			{this.renderThumbnail()}
 
 			<StringArrayEditor label='tags' valuePatterns={[/^(?:(?:group|meta|system|type):)?[A-Za-z0-9][A-Za-z0-9 \/.\-]{0,40}$/]}
 				placeholder='add tag' unique={true}

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -80,12 +80,11 @@
 		justify-self: center;
 		width: 80px;
 		height: min-content;
-		border: 2px solid white;
 		flex: 1 1;
 		max-height: 115px;
 		aspect-ratio: 1 / 1;
 		object-fit: contain;
-		background-color: cadetblue;
+		background-color: #AAA;
 	}
 
 	.systems.field .value{

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -8,6 +8,7 @@
 	padding          : 25px;
 	background-color : #999;
 	height           : calc(100vh - 54px); // 54px is the height of the navbar + snippet bar.  probably a better way to dynamic get this.
+	overflow-y       : auto;
 
 	& > div {
 		margin-bottom: 10px;

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -9,19 +9,28 @@
 	background-color : #999;
 	height           : calc(100vh - 54px); // 54px is the height of the navbar + snippet bar.  probably a better way to dynamic get this.
 
-	display: flex;
-	flex-wrap: wrap;
-	gap: 10px;
+	& > div {
+		margin-bottom: 10px;
+	}
 
 	.field-group {
 		display: flex;
-		flex-direction: column;
-		flex: 5;
+		width: 100%;
+		flex-wrap: wrap;
 		gap: 10px;
+	}
+
+	.field-column {
+		display: flex;
+		flex-direction: column;
+		flex: 5 0 200px;
+		gap: 10px;
+		
 	}
 	.field{
 		display       : flex;
 		width         : 100%;
+		min-width     : 200px;
 		&>label{
 			display        : inline-block;
 			vertical-align : top;

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -32,14 +32,11 @@
 		width         : 100%;
 		min-width     : 200px;
 		&>label{
-			display        : inline-block;
-			vertical-align : top;
 			width          : 80px;
 			font-size      : 11px;
 			font-weight    : 800;
 			line-height    : 1.8em;
 			text-transform : uppercase;
-			flex           : 0 0 auto;
 		}
 		&>.value{
 			flex           : 1 1 auto;

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -7,10 +7,21 @@
 	width            : 100%;
 	padding          : 25px;
 	background-color : #999;
+	height           : calc(100vh - 54px); // 54px is the height of the navbar + snippet bar.  probably a better way to dynamic get this.
+
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+
+	.field-group {
+		display: flex;
+		flex-direction: column;
+		flex: 5;
+		gap: 10px;
+	}
 	.field{
 		display       : flex;
 		width         : 100%;
-		margin-bottom : 10px;
 		&>label{
 			display        : inline-block;
 			vertical-align : top;
@@ -23,7 +34,7 @@
 		}
 		&>.value{
 			flex           : 1 1 auto;
-			min-width      : 200px;
+			width          : 50px;
 		}
 		&.thumbnail{
 			height      : 1.4em;
@@ -43,22 +54,33 @@
 					background-color: #777;
 				}
 			}
-			.thumbnail-preview{
-				position    : relative;
-				width       : 80px;
-				height      : min-content;
-				border      : 2px solid white;
-				margin-left : 5px;
-				max-height  : 115px;
+		}
+
+		&.description {
+			flex: 1;
+			textarea.value {
+				resize      : none;
+				height      : auto;
+				font-family : 'Open Sans', sans-serif;
+				font-size   : 0.8em;
 			}
 		}
 	}
-	.description.field textarea.value{
-		resize      : none;
-		height      : 5em;
-		font-family : 'Open Sans', sans-serif;
-		font-size   : 0.8em;
+
+
+	.thumbnail-preview {
+		position: relative;
+		justify-self: center;
+		width: 80px;
+		height: min-content;
+		border: 2px solid white;
+		flex: 1 1;
+		max-height: 115px;
+		aspect-ratio: 1 / 1;
+		object-fit: contain;
+		background-color: cadetblue;
 	}
+
 	.systems.field .value{
 		label{
 			vertical-align : middle;


### PR DESCRIPTION
This moves the thumbnail preview to be alongside both the Description and Thumbnail URL inputs.  Currently, alongside the tags, it can obscure the tag badges if enough of them are added.

In this PR the thumbnail also shifts down below the URL input if the width is reduced to a certain point.

If this PR sits for too long unmerged, I may also take another stab at making the labels shift above the fields at a certain breakpoint.

![gif](https://media.giphy.com/media/tjRAbr8UV271t97H7Q/giphy.gif)