### PR TITLE
Metadata field validation

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -52,7 +52,7 @@ const MetadataEditor = createClass({
 	},
 
 	handleFieldChange : function(name, inputRules, e){
-		console.log(this.state.errs)
+		// check if each field meets the requirements set for that field
 		for (const err of inputRules){
 			if(new RegExp(err.reg).test(e.target.value)){
 				this.setState((prevState)=>({
@@ -68,12 +68,15 @@ const MetadataEditor = createClass({
 			}
 		}
 
+		if(this.state.errs.length == 0){
+			this.props.onChange({
+				...this.props.metadata,
+				[name] : e.target.value
+			});
 
+		}
 
-		this.props.onChange({
-			...this.props.metadata,
-			[name] : e.target.value
-		});
+		console.log(this.props.metadata);
 	},
 
 	handleSystem : function(system, e){

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -244,7 +244,7 @@ const MetadataEditor = createClass({
 	render : function(){
 		return <div className='metadataEditor'>
 
-			{this.renderError()}
+			{this.renderValidationNotice()}
 			<div className='field title'>
 				<label>title</label>
 				<input type='text' className='value'

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -242,7 +242,15 @@ const MetadataEditor = createClass({
 					value={this.props.metadata.thumbnail}
 					placeholder='my.thumbnail.url'
 					className='value'
-					onChange={(e)=>this.handleFieldChange('thumbnail', e)} />
+					onChange={
+						(e)=>{
+							if(e.target.value.length > 5){
+								console.log('too long');
+							} else {
+								this.handleFieldChange('thumbnail', e)
+							}
+						}
+					} />
 				<button className='display' onClick={this.toggleThumbnailDisplay}>
 					<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />
 				</button>

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -28,7 +28,7 @@ const MetadataEditor = createClass({
 				systems     : [],
 				renderer    : 'legacy',
 				theme       : '5ePHB',
-				errors      : '',
+				validation  : [],
 			},
 			onChange : ()=>{}
 		};
@@ -102,19 +102,19 @@ const MetadataEditor = createClass({
 			});
 	},
 
-	handleError : function(msg){
+	handleValidation : function(msg){
 		if(!msg){
-			this.props.metadata.errors = '';
+			this.props.metadata.validation = '';
 			return;
 		}
-		this.props.metadata.errors = msg;
+		this.props.metadata.validation = msg;
 		this.props.onChange(this.props.metadata);
 	},
 
-	renderError : function(){
-		if(!this.props.metadata.errors) return;
+	renderValidationNotice : function(){
+		if(!this.props.metadata.validation) return;
 
-		return <div className='error'>{this.props.metadata.errors}</div>;
+		return <div className='validations'>{this.props.metadata.validation}</div>;
 	},
 
 	renderSystems : function(){
@@ -264,9 +264,9 @@ const MetadataEditor = createClass({
 					className='value'
 					onChange={(e)=>{
 						if(e.target.value.length > 5){
-							this.handleError('URL cannot be longer than 256 characters.  Try uploading to an image hosting service like Imgur.com.');
+							this.handleValidation('URL cannot be longer than 256 characters.  Try uploading to an image hosting service like Imgur.com.');
 						} else {
-							this.handleError();
+							this.handleValidation();
 							this.handleFieldChange('thumbnail', e);
 						}
 					}} />

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -104,14 +104,12 @@ const MetadataEditor = createClass({
 
 	checkValid : function(err, e){
 		if(new RegExp(err.reg).test(e.target.value)){
-			// console.log('matches the requirements');
-			this.setState((prevState)=>({ 
+			this.setState((prevState)=>({
 				errs : prevState.errs.filter(function(o){
-					return o.field !== err.field && o.type !== err.type;
+					return (o.field !== err.field || o.type !== err.type);
 				})
 			}));
 		} else {
-			// console.log('does not match input requirements');
 			if(_.findIndex(this.state.errs, { 'field': err.field, 'type': err.type })){
 				this.setState((prevState)=>({ errs: [...prevState.errs, err] }));
 			}
@@ -266,7 +264,15 @@ const MetadataEditor = createClass({
 			<div className='field description'>
 				<label>description</label>
 				<textarea value={this.props.metadata.description} className='value'
-					onChange={(e)=>this.handleFieldChange('description', e)} />
+					onChange={(e)=>{
+						this.checkValid({
+							field : 'description',
+							type  : 'maxLength',
+							reg   : '^.{0,5}$',
+							msg   : 'Max URL length of 5 characters.'
+						}, e);
+						this.handleFieldChange('description', e);
+					}} />
 			</div>
 			<div className='field thumbnail'>
 				<label>thumbnail</label>
@@ -274,12 +280,15 @@ const MetadataEditor = createClass({
 					value={this.props.metadata.thumbnail}
 					placeholder='my.thumbnail.url'
 					className='value'
-					pattern='^.{0,5}$'
 					onChange={(e)=>{
-							const err = { field: 'thumbnail', type: 'maxLength', reg: '^.{0,5}$', msg: 'Max URL length of 256 characters.'}
-							this.checkValid(err, e);
-							this.handleFieldChange('thumbnail', e);
-						}
+						this.checkValid({
+							field : 'thumbnail',
+							type  : 'maxLength',
+							reg   : '^.{0,5}$',
+							msg   : 'Max URL length of 256 characters.'
+						}, e);
+						this.handleFieldChange('thumbnail', e);
+					}
 					 } />
 				<button className='display' onClick={this.toggleThumbnailDisplay}>
 					<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -27,7 +27,8 @@ const MetadataEditor = createClass({
 				authors     : [],
 				systems     : [],
 				renderer    : 'legacy',
-				theme       : '5ePHB'
+				theme       : '5ePHB',
+				errors      : '',
 			},
 			onChange : ()=>{}
 		};
@@ -99,6 +100,21 @@ const MetadataEditor = createClass({
 			.end(function(err, res){
 				window.location.href = '/';
 			});
+	},
+
+	handleError : function(msg){
+		if(!msg){
+			this.props.metadata.errors = '';
+			return;
+		}
+		this.props.metadata.errors = msg;
+		this.props.onChange(this.props.metadata);
+	},
+
+	renderError : function(){
+		if(!this.props.metadata.errors) return;
+
+		return <div className='error'>{this.props.metadata.errors}</div>;
 	},
 
 	renderSystems : function(){
@@ -223,8 +239,12 @@ const MetadataEditor = createClass({
 		</div>;
 	},
 
+
+
 	render : function(){
 		return <div className='metadataEditor'>
+
+			{this.renderError()}
 			<div className='field title'>
 				<label>title</label>
 				<input type='text' className='value'
@@ -242,15 +262,14 @@ const MetadataEditor = createClass({
 					value={this.props.metadata.thumbnail}
 					placeholder='my.thumbnail.url'
 					className='value'
-					onChange={
-						(e)=>{
-							if(e.target.value.length > 5){
-								console.log('too long');
-							} else {
-								this.handleFieldChange('thumbnail', e)
-							}
+					onChange={(e)=>{
+						if(e.target.value.length > 5){
+							this.handleError('URL cannot be longer than 256 characters.  Try uploading to an image hosting service like Imgur.com.');
+						} else {
+							this.handleError();
+							this.handleFieldChange('thumbnail', e);
 						}
-					} />
+					}} />
 				<button className='display' onClick={this.toggleThumbnailDisplay}>
 					<i className={`fas fa-caret-${this.state.showThumbnail ? 'right' : 'left'}`} />
 				</button>

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -242,10 +242,11 @@
 		}
 	}
 
-	.validations {
+	.errs {
 		position			: absolute;
 		top					: 0;
 		left				: 0;
+		width				: 100%;
 		background-color	: #e59b55EE;
 		padding				: 5px 10px;
 		font-size			: 13px;

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -241,4 +241,14 @@
 			}
 		}
 	}
+
+	.error {
+		background-color: #e59b55;
+		padding: 5px 10px;
+		font-size: 13px;
+		text-align: center;
+		margin-bottom: 10px;
+		font-family: 'Open Sans';
+		line-height: 1.3em;
+	}
 }

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -243,12 +243,15 @@
 	}
 
 	.error {
-		background-color: #e59b55;
-		padding: 5px 10px;
-		font-size: 13px;
-		text-align: center;
-		margin-bottom: 10px;
-		font-family: 'Open Sans';
-		line-height: 1.3em;
+		position			: absolute;
+		top					: 0;
+		left				: 0;
+		background-color	: #e59b55EE;
+		padding				: 5px 10px;
+		font-size			: 13px;
+		text-align			: center;
+		margin-bottom		: 10px;
+		font-family			: 'Open Sans';
+		line-height			: 1.3em;
 	}
 }

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -242,7 +242,7 @@
 		}
 	}
 
-	.error {
+	.validations {
 		position			: absolute;
 		top					: 0;
 		left				: 0;


### PR DESCRIPTION
EDIT::: This is going to be superseded by https://github.com/Gazook89/homebrewery/tree/Field-Validation-System-2 which is just a fresh start using the information gained from the conversation here.

This is to fix #2356 by providing a validation error for too many characters in the thumbnail URL field.  It is setup to provide a regex-based method of setting field requirements that will generate an error bar above the editor.  Hopefully this means it can be used on any text fields with any regex.

Upon review by others, I'm bracing myself for someone to say "*oh, why didn't you just.....*" with a much simpler solution.

\*\*NOTE: with this draft, the PR has silly rules for easy testing:

1. Description field must have no more than 5 characters
2. URL field must have no more than 5 characters
3. URL field must start with "W".

<img width="532" alt="image" src="https://user-images.githubusercontent.com/58999374/190885784-3eee8126-bc38-4930-9b15-d09ee76a9bb6.png">

<img width="532" alt="image" src="https://user-images.githubusercontent.com/58999374/190885797-367c8dec-0700-4090-978d-197839fe32e9.png">

Some issues:

- [ ] This prevents write to the `props.metadata` if errors exist  (even for valid fields)....this doesn't bother me much, let me know what you folks think.
- [ ] I have a max character count set to 5, using regex `/^.{0,5}$/` but it seems like it's allowing 6 characters to write to props.  I'm sure this is some **state** or React thing I don't understand?
- [ ] Should there be a way of minimizing these errors so they are not in the way?  I don't think dismissing them entirely is good, but a button to reduce in size, or after a short period of time?