### PR TITLE
GitHub forms tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,8 +4,7 @@ labels: ["feature request"]
 body:
   - type: markdown
     attributes:
-      value: |
-        "We'd love to hear your idea!  Please be sure to [search the current Issues](https://github.com/naturalcrit/homebrewery/issues) for any duplicate requests."
+      value: "We'd love to hear your idea!  Please be sure to [search the current Issues](https://github.com/naturalcrit/homebrewery/issues) for any duplicate requests."
   - type: textarea
     id: user-request
     attributes:
@@ -15,6 +14,7 @@ body:
       required: true
   - type: checkboxes
     id: terms
-    options:
-      - label: I have searched the Issues tracker for any duplicate requests and found none.
-        required: true
+    attributes:
+      options:
+        - label: I have searched the Issues tracker for any duplicate requests and found none.
+          required: true

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -12,8 +12,8 @@ body:
       options:
         - label: Legacy
         - label: v3
-      validations:
-        required: true
+    validations:
+      required: true
   - type: dropdown
     id: browser
     attributes:
@@ -37,8 +37,8 @@ body:
         - label: MacOS
         - label: Linux
         - label: other
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: user-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -25,8 +25,8 @@ body:
         - label: Edge
         - label: Safari
         - label: other
-      validations:
-        required: true
+    validations:
+      required: true
   - type: dropdown
     id: operating-system
     attributes:

--- a/.github/ISSUE_TEMPLATE/save_issue.yml
+++ b/.github/ISSUE_TEMPLATE/save_issue.yml
@@ -15,6 +15,8 @@ body:
     id: user-description
     attributes:
       label: "Your description of what happened:"
+    validations:
+      required: true
   - type: markdown
     attributes:
       value: |

--- a/.github/ISSUE_TEMPLATE/save_issue.yml
+++ b/.github/ISSUE_TEMPLATE/save_issue.yml
@@ -1,6 +1,5 @@
 name: Saving Issue
 description: Report an issue Saving
-title: "Save Error: "
 labels: ["saving"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/save_issue.yml
+++ b/.github/ISSUE_TEMPLATE/save_issue.yml
@@ -1,6 +1,6 @@
 name: Saving Issue
 description: Report an issue Saving
-labels: ["saving"]
+labels: ["Saving"]
 body:
   - type: markdown
     attributes:

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -322,7 +322,7 @@ const EditPage = createClass({
 				<div className='errorContainer'>
 					Looks like there was a problem saving. <br />
 					Report the issue <a target='_blank' rel='noopener noreferrer'
-						href={`https://github.com/naturalcrit/homebrewery/issues/new?template=save_issue.yaml&error-code=${encodeURIComponent(errMsg)}`}>
+						href={`https://github.com/naturalcrit/homebrewery/issues/new?template=save_issue.yml&error-code=${encodeURIComponent(errMsg)}`}>
 						here
 					</a>.
 				</div>


### PR DESCRIPTION
Here is the PR with the tweaks to fix #2376 


- [x]  "validations" needs to go up one level to be right under "type" instead of under "attributes"
- [x]  Some other required fields are missing from the "Feature Request" template
- [x]  Remove the default value from `title` in the `Save Issue` template. Currently it auto-populates with `Save Error:` which users will probably ignore and we'll end up with every save issue with the same title. Leave it blank so we can require users to put some thought into it with the "validations" setting.
- [x]  Add "validations" to the `Save Issue` template.
- [x]  Link from `editPage.jsx` doesn't quite work.
- [x]  Change `labels` from "saving" to "Saving"
- [x]  Change `template` from "template=save_issue.yaml" to "template=save_issue.**yml**"
