### PR TITLE
Change User Page search bar to Divs

### DIFF
--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -96,7 +96,7 @@ const BrewItem = createClass({
 	render : function(){
 		const brew = this.props.brew;
 		if(Array.isArray(brew.tags)) {               // temporary fix until dud tags are cleaned
-			brew.tags = brew.tags?.filter(tag => tag); //remove tags that are empty strings
+			brew.tags = brew.tags?.filter((tag)=>tag); //remove tags that are empty strings
 		}
 		const dateFormatString = 'YYYY-MM-DD HH:mm:ss';
 
@@ -112,7 +112,7 @@ const BrewItem = createClass({
 					<div className='brewTags' title={`Tags:\n${brew.tags.join('\n')}`}>
 						<i className='fas fa-tags'/>
 						{brew.tags.map((tag, idx)=>{
-							let matches = tag.match(/^(?:([^:]+):)?([^:]+)$/);
+							const matches = tag.match(/^(?:([^:]+):)?([^:]+)$/);
 							return <span className={matches[1]}>{matches[2]}</span>;
 						})}
 					</div>

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -121,14 +121,8 @@ const ListPage = createClass({
 			>
 				{`${sortTitle}`}
 			</button>
-			{this.state.sortType == sortValue ? 
-				<button
-					onClick={this.handleSortDirChange}
-					className='sortDir'
-				>
-					{this.state.sortDir == 'asc' ? <i className='fas fa-sort-up'></i> : <i className='fas fa-sort-down'></i>}
-				</button>
-				: ''
+			{this.state.sortType == sortValue &&
+				<i className={`sortDir fas ${this.state.sortDir == 'asc' ? 'fa-sort-up' : 'fa-sort-down'}`}></i>
 			}
 		  </div>;
 	},

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -114,14 +114,23 @@ const ListPage = createClass({
 	},
 
 	renderSortOption : function(sortTitle, sortValue){
-		return <div>
-				  <button
-					  value={`${sortValue}`}
-					  onClick={this.handleSortOptionChange}
-					  className={`${(this.state.sortType == sortValue ? 'active' : '')}`}
-				  >
-  					{`${sortTitle}`}
-		 		  </button>
+		return <div className='sort-option'>
+			<button
+				value={`${sortValue}`}
+				onClick={this.handleSortOptionChange}
+				className={`${(this.state.sortType == sortValue ? 'active' : '')}`}
+			>
+				{`${sortTitle}`}
+			</button>
+			{this.state.sortType == sortValue ? 
+				<button
+					onClick={this.handleSortDirChange}
+					className='sortDir'
+				>
+					{this.state.sortDir == 'asc' ? <i className='fas fa-sort-amount-up'></i> : <i className='fas fa-sort-amount-down'></i>}
+				</button>
+				: ''
+			}
 		  </div>;
 	},
 
@@ -165,26 +174,17 @@ const ListPage = createClass({
 
 	renderSortOptions : function(){
 		return <div className='sort-container'>
-							<h6>Sort by :</h6>
-						{this.renderSortOption('Title', 'alpha')}
-						{this.renderSortOption('Created Date', 'created')}
-						{this.renderSortOption('Updated Date', 'updated')}
-						{this.renderSortOption('Views', 'views')}
-						{/* {this.renderSortOption('Latest', 'latest')} */}
+			<h6>Sort by :</h6>
+			{this.renderSortOption('Title', 'alpha')}
+			{this.renderSortOption('Created Date', 'created')}
+			{this.renderSortOption('Updated Date', 'updated')}
+			{this.renderSortOption('Views', 'views')}
+			{/* {this.renderSortOption('Latest', 'latest')} */}
 
-							<h6>Direction :</h6>
+			{this.renderFilterOption()}
 
-							<button
-								onClick={this.handleSortDirChange}
-								className='sortDir'
-							>
-								{`${(this.state.sortDir == 'asc' ? '\u25B2 ASC' : '\u25BC DESC')}`}
-							</button>
 
-						{this.renderFilterOption()}
 
-				
-			
 		</div>;
 	},
 

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -126,7 +126,7 @@ const ListPage = createClass({
 					onClick={this.handleSortDirChange}
 					className='sortDir'
 				>
-					{this.state.sortDir == 'asc' ? <i className='fas fa-sort-amount-up'></i> : <i className='fas fa-sort-amount-down'></i>}
+					{this.state.sortDir == 'asc' ? <i className='fas fa-sort-up'></i> : <i className='fas fa-sort-down'></i>}
 				</button>
 				: ''
 			}

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -117,7 +117,7 @@ const ListPage = createClass({
 		return <div className={`sort-option ${(this.state.sortType == sortValue ? 'active' : '')}`}>
 			<button
 				value={`${sortValue}`}
-				onClick={this.handleSortOptionChange}
+				onClick={this.state.sortType == sortValue ? this.handleSortDirChange : this.handleSortOptionChange}
 			>
 				{`${sortTitle}`}
 			</button>

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -114,11 +114,10 @@ const ListPage = createClass({
 	},
 
 	renderSortOption : function(sortTitle, sortValue){
-		return <div className='sort-option'>
+		return <div className={`sort-option ${(this.state.sortType == sortValue ? 'active' : '')}`}>
 			<button
 				value={`${sortValue}`}
 				onClick={this.handleSortOptionChange}
-				className={`${(this.state.sortType == sortValue ? 'active' : '')}`}
 			>
 				{`${sortTitle}`}
 			</button>

--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -114,7 +114,7 @@ const ListPage = createClass({
 	},
 
 	renderSortOption : function(sortTitle, sortValue){
-		return <td>
+		return <div>
 				  <button
 					  value={`${sortValue}`}
 					  onClick={this.handleSortOptionChange}
@@ -122,7 +122,7 @@ const ListPage = createClass({
 				  >
   					{`${sortTitle}`}
 		 		  </button>
-		  </td>;
+		  </div>;
 	},
 
 	handleFilterTextChange : function(e){
@@ -150,7 +150,7 @@ const ListPage = createClass({
 	},
 
 	renderFilterOption : function(){
-		return <td>
+		return <div className='filter-option'>
 			<label>
 				<i className='fas fa-search'></i>
 				<input
@@ -160,37 +160,31 @@ const ListPage = createClass({
 					value={this.state.filterString}
 				/>
 			</label>
-		</td>;
+		</div>;
 	},
 
 	renderSortOptions : function(){
 		return <div className='sort-container'>
-			<table>
-				<tbody>
-					<tr>
-						<td>
 							<h6>Sort by :</h6>
-						</td>
 						{this.renderSortOption('Title', 'alpha')}
 						{this.renderSortOption('Created Date', 'created')}
 						{this.renderSortOption('Updated Date', 'updated')}
 						{this.renderSortOption('Views', 'views')}
 						{/* {this.renderSortOption('Latest', 'latest')} */}
-				    	<td>
+
 							<h6>Direction :</h6>
-						</td>
-						<td>
+
 							<button
 								onClick={this.handleSortDirChange}
 								className='sortDir'
 							>
 								{`${(this.state.sortDir == 'asc' ? '\u25B2 ASC' : '\u25BC DESC')}`}
 							</button>
-						</td>
+
 						{this.renderFilterOption()}
-					</tr>
-				</tbody>
-			</table>
+
+				
+			
 		</div>;
 	},
 
@@ -233,10 +227,10 @@ const ListPage = createClass({
 		return <div className='listPage sitePage'>
 			<link href='/themes/V3/5ePHB/style.css' rel='stylesheet'/>
 			{this.props.navItems}
+			{this.renderSortOptions()}
 
 			<div className='content V3'>
 				<div className='phb page'>
-					{this.renderSortOptions()}
 					{this.renderBrewCollection(this.state.brewCollection)}
 				</div>
 			</div>

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -12,8 +12,8 @@
 	-moz-column-gap      : auto;
 }
 .listPage{
+	height : unset !important;
 	.content{
-		overflow-y : overlay;
 		.phb{
 			.noColumns();
 			height     : auto;
@@ -32,47 +32,49 @@
 	}
 	.sort-container{
 		font-family        : 'Open Sans', sans-serif;
-		position           : fixed;
-		top                : 35px;
-		left               : calc(50vw - 400px);
-		border             : 2px solid #58180D;
-		width              : 800px;
-		background-color   : #EEE5CE;
+		position           : sticky;
+		top                : 0;
+		left               : 0;
+		width              : 100%;
+		background-color   : #555;
+		border-top         : 1px solid #666;
+		color              : white;
 		padding            : 2px;
 		text-align         : center;
-		z-index            : 15;
+		z-index            : 500;
+		display            : flex;
+		justify-content    : center;
+		align-items        : center;
 		h6{
 			text-transform : uppercase;
 			font-family    : 'Open Sans', sans-serif;
 			font-size      : 11px;
 			font-weight    : bold;
-			color          : #58180D;
 		}
-		table{
-			margin : 0px;
-			vertical-align : middle;
-			tbody tr{
-				background-color: transparent !important;
-				i{
-					padding-right : 5px
-				}
-			button{
-					background-color : transparent;
-					color            : #58180D;
-					font-family    : 'Open Sans', sans-serif;
-					font-size      : 11px;
-					text-transform : uppercase;
-					font-weight      : normal;
-					&.active{
-						font-weight : bold;
-						border      : 2px solid #58180D;
-					}
-					&.sortDir{
-						width : 75px;
-					}
-				}
+		.filter-option {
+			background-color: transparent !important;
+			i{
+				padding-right : 5px
 			}
 		}
+		button{
+				background-color : transparent;
+				font-family      : 'Open Sans', sans-serif;
+				font-size        : 11px;
+				text-transform   : uppercase;
+				font-weight      : normal;
+				color            : #888;
+				&.active{
+					font-weight      : bold;
+					text-decoration  : underline;
+					color            : unset;
+				}
+				&.sortDir{
+					width : 75px;
+				}
+			}
+		
+		
 	}
 	h1 {
 		cursor: pointer;

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -74,12 +74,12 @@
 				color: white;
 				font-weight: 800;
 				height: 100%;
-				&.sortDir {
+				& + .sortDir {
 					padding-left: 5px;
 				}
 			}
 		}
-			
+
 		}
 		.filter-option {
 			margin-left: 20px;
@@ -98,7 +98,7 @@
 				color            : #ccc;
 				padding          : 0;
 			}
-		
-		
+
+
 	}
 }

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -45,6 +45,9 @@
 		display            : flex;
 		justify-content    : center;
 		align-items        : center;
+		column-gap         : 15px;
+		row-gap            : 5px;
+		flex-wrap          : wrap;
 		h6{
 			text-transform : uppercase;
 			font-family    : 'Open Sans', sans-serif;
@@ -52,50 +55,35 @@
 			font-weight    : bold;
 		}
 		.filter-option {
-			background-color: transparent !important;
+			margin-left: 20px;
+			background-color : transparent !important;
+			font-size        : 11px;
 			i{
-				padding-right : 5px
+				padding-right : 5px;
 			}
 		}
 		button{
 				background-color : transparent;
 				font-family      : 'Open Sans', sans-serif;
-				font-size        : 11px;
 				text-transform   : uppercase;
 				font-weight      : normal;
+				font-size        : 11px;
 				color            : #888;
+				padding          : 0;
 				&.active{
 					font-weight      : bold;
-					text-decoration  : underline;
-					color            : unset;
+					color            : white;
+					border-bottom : 1px solid white;
 				}
 				&.sortDir{
-					width : 75px;
+					width : auto;
+					padding: 5px;
+					&:hover {
+						color: white;
+					}
 				}
 			}
 		
 		
-	}
-	h1 {
-		cursor: pointer;
-		&.active {
-			color: #58180D;
-		}
-		&.inactive {
-			color: #707070;
-			
-		}
-		&.active::before, &.inactive::before {
-			font-family: 'Font Awesome 5 Free';
-			font-weight: 900;
-			font-size: 0.6cm;
-    			padding-right: 0.5em;
-		}
-		&.active::before {
-			content: '\f107';
-		}
-		&.inactive::before {
-			content: '\f105';
-		}
 	}
 }

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -43,7 +43,7 @@
 		z-index            : 500;
 		display            : flex;
 		justify-content    : center;
-		align-items        : center;
+		align-items        : baseline;
 		column-gap         : 15px;
 		row-gap            : 5px;
 		flex-wrap          : wrap;

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -12,7 +12,6 @@
 	-moz-column-gap      : auto;
 }
 .listPage{
-	height : unset !important;
 	.content{
 		.phb{
 			.noColumns();

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -77,9 +77,7 @@
 				&.sortDir{
 					width : auto;
 					padding: 5px;
-					&:hover {
-						color: white;
-					}
+					color: white;
 				}
 			}
 		

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -35,10 +35,11 @@
 		top                : 0;
 		left               : 0;
 		width              : 100%;
+		height             : 30px;
 		background-color   : #555;
 		border-top         : 1px solid #666;
+		border-bottom         : 1px solid #666;
 		color              : white;
-		padding            : 2px;
 		text-align         : center;
 		z-index            : 500;
 		display            : flex;
@@ -56,19 +57,24 @@
 		.sort-option {
 			display: flex;
 			align-items: center;
-			padding: 0 5px;
+			padding: 0 8px;
+			color: #ccc;
+			height: 100%;
 
+			&:hover{
+				background-color : #444;
+			}
 
 			&.active {
 			font-weight: bold;
-			color: white;
-			border: 1px solid darkcyan;
-			border-radius: 5px;
+			color: #ddd;
+			background-color: #333;
+			
 			button {
 				color: white;
-
+				font-weight: 800;
 				&.sortDir {
-					background-color: darkcyan;
+					padding-left: 5px;
 				}
 			}
 		}
@@ -88,13 +94,8 @@
 				text-transform   : uppercase;
 				font-weight      : normal;
 				font-size        : 11px;
-				color            : #888;
+				color            : #ccc;
 				padding          : 0;
-				&.sortDir{
-					width : auto;
-					padding-left: 5px;
-					color: white;
-				}
 			}
 		
 		

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -69,10 +69,11 @@
 			font-weight: bold;
 			color: #ddd;
 			background-color: #333;
-			
+
 			button {
 				color: white;
 				font-weight: 800;
+				height: 100%;
 				&.sortDir {
 					padding-left: 5px;
 				}

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -53,6 +53,27 @@
 			font-size      : 11px;
 			font-weight    : bold;
 		}
+		.sort-option {
+			display: flex;
+			align-items: center;
+			padding: 0 5px;
+
+
+			&.active {
+			font-weight: bold;
+			color: white;
+			border: 1px solid darkcyan;
+			border-radius: 5px;
+			button {
+				color: white;
+
+				&.sortDir {
+					background-color: darkcyan;
+				}
+			}
+		}
+			
+		}
 		.filter-option {
 			margin-left: 20px;
 			background-color : transparent !important;
@@ -69,14 +90,9 @@
 				font-size        : 11px;
 				color            : #888;
 				padding          : 0;
-				&.active{
-					font-weight      : bold;
-					color            : white;
-					border-bottom : 1px solid white;
-				}
 				&.sortDir{
 					width : auto;
-					padding: 5px;
+					padding-left: 5px;
 					color: white;
 				}
 			}


### PR DESCRIPTION
Currently the User Page search/filter bar is rendered as a table which I think could be improved.  Using divs in a flexbox is a bit more flexible if more options are added later or screen size changes.

Also, as part of the UI, I wanted to change it to feel more cohesive with the existing UI rather than blending with the page content.  Structurally, in the HTML, I also moved the sort bar out of the '.page' div.

<img width="1100" alt="image" src="https://user-images.githubusercontent.com/58999374/191051706-f7c9d7fd-e0f4-4838-b146-cc27150cc146.png">

fixes #1675
