### PR TITLE
Make Reddit Issue Template a List

### DIFF
--- a/client/homebrew/navbar/help.navitem.jsx
+++ b/client/homebrew/navbar/help.navitem.jsx
@@ -12,10 +12,10 @@ module.exports = function(props){
 		</Nav.item>
 		<Nav.item color='red' icon='fas fa-fw fa-bug'
 			href={`https://www.reddit.com/r/homebrewery/submit?selftext=true&text=${encodeURIComponent(dedent`
-			**Browser(s)** :
-			**Operating System** :  
-			**Legacy or v3 Renderer** :
-			**Issue** :  `)}`}
+			- **Browser(s)** :
+			- **Operating System** :  
+			- **Legacy or v3 Renderer** :
+			- **Issue** :  `)}`}
 			newTab={true}
 			rel='noopener noreferrer'>
 			report issue


### PR DESCRIPTION
Currently, issues sent to reddit from HB look like this:

<img width="794" alt="image" src="https://user-images.githubusercontent.com/58999374/191149193-767a1e18-746a-41fa-84ff-3c29987732c1.png">

This PR changes this to a list, so each item is on it's own line.  I fudged this when we originally added a reddit template.

I also thought about trying to get the renderer to auto-populate into the template, but that's pretty much specific to just the editPage and probably not worth it at this point.