### PR TITLE
Scroll behavior correction

### DIFF
--- a/client/homebrew/homebrew.less
+++ b/client/homebrew/homebrew.less
@@ -16,8 +16,5 @@
 		&.listPage .content {
 			overflow-y : scroll;
 		}
-		// &.editPage .content, &.sharePage .content, &.newPage .content {
-		// 	overflow-y : hidden;
-		// }
 	}
 }

--- a/client/homebrew/homebrew.less
+++ b/client/homebrew/homebrew.less
@@ -11,7 +11,13 @@
 			position   : relative;
 			height     : calc(~"100% - 29px"); //Navbar height
 			flex       : auto;
+			overflow-y : hidden;
+		}
+		&.listPage .content {
 			overflow-y : scroll;
 		}
+		// &.editPage .content, &.sharePage .content, &.newPage .content {
+		// 	overflow-y : hidden;
+		// }
 	}
 }

--- a/client/homebrew/navbar/navbar.less
+++ b/client/homebrew/navbar/navbar.less
@@ -78,6 +78,8 @@
 			width      : 100%;
 			overflow   : hidden auto;
 			max-height : ~"calc(100vh - 28px)";
+			scrollbar-color : #666 #333;
+			scrollbar-width : thin;
 			h4{
 				display          : block;
 				box-sizing       : border-box;

--- a/client/homebrew/pages/basePages/listPage/listPage.less
+++ b/client/homebrew/pages/basePages/listPage/listPage.less
@@ -13,7 +13,6 @@
 }
 .listPage{
 	.content{
-		overflow-y : overlay;
 		.phb{
 			.noColumns();
 			height     : auto;


### PR DESCRIPTION
My last PR #2360  created a problem (i think, please double check if you can) where it doubled up the scrollbars on pages with iframes....so most of them.

This PR attempts to fix that error by narrowing the specificity of the rule.  

There was also a `overflow-y: overlay;` leftover that I could remove as well.

Finally, it sets a scrollbar style on the Recent Items scrollbar.  However, it only does so for firefox.  I read up on the CSS for Chrome scrollbars and just couldn't get it work-- maybe someone else knows what is up:

```css
.dropdown::-webkit-scrollbar-thumb {
  background : #333;
```

I can strip away the styling stuff and just leave the fix for the double scrollbar, too, if desired.  In any case, this should finally close #1881 .