### PR TITLE
Prevent text selection in editor when dragging splitPane divider.

### DIFF
--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -69,7 +69,8 @@ const SplitPane = createClass({
 		this.setState({ isDragging: false });
 	},
 
-	handleDown : function(){
+	handleDown : function(e){
+		e.preventDefault();
 		this.setState({ isDragging: true });
 		//this.unFocus()
 	},


### PR DESCRIPTION
Hoping this fixes #1632, preventing the selection of text in the editor when the split pane divider is moved.  I've tested it a bunch and haven't seen any selections made, but someone else should try it a bunch to make sure...

Also, I noted that someone else has commented out a `unFocus` method that I think had the same goal.  I uncommented it and tried it, and was still able to get a selection.  I commented it out again and left it in this branch for now, but I can remove it with another commit before this gets merged (if it does).