### PR TITLE
Add ability to toggle the Auto Save

### DIFF
--- a/client/homebrew/navbar/navbar.less
+++ b/client/homebrew/navbar/navbar.less
@@ -55,6 +55,13 @@
 		text-align     : center;
 		text-transform : initial;
 	}
+	.save-menu .navItem i.fa-power-off {
+		color : red;
+		&.active {
+			color : rgb(0, 182, 52);
+			filter : drop-shadow(0 0 2px rgba(0, 182, 52, 0.765))
+		}
+	}
 	.patreon.navItem{
 		border-left  : 1px solid #666;
 		border-right : 1px solid #666;

--- a/client/homebrew/navbar/navbar.less
+++ b/client/homebrew/navbar/navbar.less
@@ -55,11 +55,16 @@
 		text-align     : center;
 		text-transform : initial;
 	}
-	.save-menu .navItem i.fa-power-off {
-		color : red;
-		&.active {
-			color : rgb(0, 182, 52);
-			filter : drop-shadow(0 0 2px rgba(0, 182, 52, 0.765))
+	.save-menu {
+		.dropdown {
+			z-index: 1000;
+		}
+		.navItem i.fa-power-off {
+			color : red;
+			&.active {
+				color : rgb(0, 182, 52);
+				filter : drop-shadow(0 0 2px rgba(0, 182, 52, 0.765))
+			}
 		}
 	}
 	.patreon.navItem{

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -64,7 +64,8 @@ const EditPage = createClass({
 			htmlErrors             : Markdown.validate(this.props.brew.text),
 			url                    : '',
 			autoSave               : true,
-			autoSaveWarning        : false
+			autoSaveWarning        : false,
+			unsavedTime            : new Date()
 		};
 	},
 	savedBrew : null,
@@ -73,6 +74,7 @@ const EditPage = createClass({
 		this.setState({
 			url : window.location.href
 		});
+
 
 		this.savedBrew = JSON.parse(JSON.stringify(this.props.brew)); //Deep copy
 
@@ -230,8 +232,9 @@ const EditPage = createClass({
 				editId 	 : this.savedBrew.editId,
 				shareId  : this.savedBrew.shareId
 			},
-			isPending : false,
-			isSaving  : false,
+			isPending   : false,
+			isSaving    : false,
+			unsavedTime : new Date()
 		}));
 	},
 
@@ -339,13 +342,14 @@ const EditPage = createClass({
 		}
 
 		if(this.state.autoSaveWarning){
+			console.log(this.state.unsavedTime);
 			setTimeout(()=>this.setState({ autoSaveWarning: false }), 4000);
 			this.setAutosaveWarning();
 
 			return <Nav.item className='save error' icon='fas fa-exclamation-circle'>
 			Reminder...
 				<div className='errorContainer'>
-					Autosave has been turned off, and you haven't saved for {Math.round((new Date() - new Date(this.props.brew.updatedAt)) / 1000 / 60)} minutes.
+					Autosave has been turned off, and you haven't saved for {Math.round((new Date() - this.state.unsavedTime) / 1000 / 60)} minutes.
 				</div>
 			</Nav.item>;
 		}

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -62,7 +62,8 @@ const EditPage = createClass({
 			confirmGoogleTransfer  : false,
 			errors                 : null,
 			htmlErrors             : Markdown.validate(this.props.brew.text),
-			url                    : ''
+			url                    : '',
+			autoSave               : true
 		};
 	},
 	savedBrew : null,
@@ -142,7 +143,12 @@ const EditPage = createClass({
 		return !_.isEqual(this.state.brew, this.savedBrew);
 	},
 
+	toggleAutoSave : function(){
+		this.setState((prevState)=>({ autoSave: !prevState.autoSave }));
+	},
+
 	trySave : function(){
+		if(!this.state.autoSave){ console.log('Auto-save is now off.'); return };
 		if(!this.debounceSave) this.debounceSave = _.debounce(this.save, SAVE_TIMEOUT);
 		if(this.hasChanges()){
 			this.debounceSave();
@@ -336,7 +342,7 @@ const EditPage = createClass({
 			return <Nav.item className='save' onClick={this.save} color='blue' icon='fas fa-save'>Save Now</Nav.item>;
 		}
 		if(!this.state.isPending && !this.state.isSaving){
-			return <Nav.item className='save saved'>saved.</Nav.item>;
+			return <Nav.item className='save saved' onClick={this.toggleAutoSave}>{this.state.autoSave ? `saved.` : `auto-save off`}</Nav.item>;
 		}
 	},
 

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -341,7 +341,7 @@ const EditPage = createClass({
 			</Nav.item>;
 		}
 
-		if(this.state.autoSaveWarning){
+		if(this.state.autoSaveWarning && this.hasChanges()){
 			this.setAutosaveWarning();
 			const elapsedTime = Math.round((new Date() - this.state.unsavedTime) / 1000 / 60);
 			const text = elapsedTime == 0 ? 'Autosave is OFF.' : `Autosave has been turned off, and you haven't saved for ${elapsedTime} minutes.`;

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -143,12 +143,8 @@ const EditPage = createClass({
 		return !_.isEqual(this.state.brew, this.savedBrew);
 	},
 
-	toggleAutoSave : function(){
-		this.setState((prevState)=>({ autoSave: !prevState.autoSave }));
-	},
-
 	trySave : function(){
-		if(!this.state.autoSave){ console.log('Auto-save is off.'); return };
+		if(!this.state.autoSave){return;};
 		if(!this.debounceSave) this.debounceSave = _.debounce(this.save, SAVE_TIMEOUT);
 		if(this.hasChanges()){
 			this.debounceSave();
@@ -342,7 +338,7 @@ const EditPage = createClass({
 			return <Nav.item className='save' onClick={this.save} color='blue' icon='fas fa-save'>Save Now</Nav.item>;
 		}
 		if(!this.state.isPending && !this.state.isSaving){
-			return <Nav.item className='save saved' onClick={this.toggleAutoSave}>{this.state.autoSave ? `saved.` : `auto-save off`}</Nav.item>;
+			return <Nav.item className='save saved'>saved.</Nav.item>;
 		}
 	},
 
@@ -384,7 +380,13 @@ const EditPage = createClass({
 
 			<Nav.section>
 				{this.renderGoogleDriveIcon()}
-				{this.renderSaveButton()}
+				<Nav.dropdown className='save-menu'>
+					{this.renderSaveButton()}
+					<Nav.item onClick={()=>{ this.setState((prevState)=>({ autoSave: !prevState.autoSave }));}}>
+						Autosave <i className={this.state.autoSave ? 'fas fa-power-off active' : 'fas fa-power-off'}></i>
+
+					</Nav.item>
+				</Nav.dropdown>
 				<NewBrew />
 				<HelpNavItem/>
 				<Nav.dropdown>

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -63,12 +63,14 @@ const EditPage = createClass({
 			errors                 : null,
 			htmlErrors             : Markdown.validate(this.props.brew.text),
 			url                    : '',
-			autoSave               : true
+			autoSave               : null
 		};
 	},
 	savedBrew : null,
 
 	componentDidMount : function(){
+		this.setState({ autoSave: JSON.parse(localStorage.getItem('AUTOSAVE_ON')) });
+
 		this.setState({
 			url : window.location.href
 		});
@@ -382,7 +384,12 @@ const EditPage = createClass({
 				{this.renderGoogleDriveIcon()}
 				<Nav.dropdown className='save-menu'>
 					{this.renderSaveButton()}
-					<Nav.item onClick={()=>{ this.setState((prevState)=>({ autoSave: !prevState.autoSave }));}}>
+					<Nav.item onClick={()=>{
+						this.setState((prevState)=>({
+							autoSave : !prevState.autoSave
+						}));
+						localStorage.setItem('AUTOSAVE_ON', JSON.stringify(!this.state.autoSave));
+					}}>
 						Autosave <i className={this.state.autoSave ? 'fas fa-power-off active' : 'fas fa-power-off'}></i>
 
 					</Nav.item>

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -25,6 +25,7 @@ const googleDriveActive = require('../../googleDrive.png');
 const googleDriveInactive = require('../../googleDriveMono.png');
 
 const SAVE_TIMEOUT = 3000;
+const AUTOSAVE_TIMEOUT = 10000;
 
 const EditPage = createClass({
 	displayName     : 'EditPage',
@@ -120,14 +121,14 @@ const EditPage = createClass({
 			brew       : { ...prevState.brew, text: text },
 			isPending  : true,
 			htmlErrors : htmlErrors
-		}), ()=>this.trySave());
+		}), ()=>{if(this.state.autoSave) this.trySave();});
 	},
 
 	handleStyleChange : function(style){
 		this.setState((prevState)=>({
 			brew      : { ...prevState.brew, style: style },
 			isPending : true
-		}), ()=>this.trySave());
+		}), ()=>{if(this.state.autoSave) this.trySave();});
 	},
 
 	handleMetaChange : function(metadata){
@@ -137,7 +138,7 @@ const EditPage = createClass({
 				...metadata
 			},
 			isPending : true,
-		}), ()=>this.trySave());
+		}), ()=>{if(this.state.autoSave) this.trySave();});
 
 	},
 
@@ -146,7 +147,13 @@ const EditPage = createClass({
 	},
 
 	trySave : function(){
-		if(!this.state.autoSave){return;};
+		// if(!this.state.autoSave){
+		// 	if(this.autoSaveInterval){
+		// 		clearInterval(this.autoSaveInterval);
+		// 	}
+		// 	this.autoSaveInterval = setInterval(this.trySave, 10000);
+		// 	return;
+		// };
 		if(!this.debounceSave) this.debounceSave = _.debounce(this.save, SAVE_TIMEOUT);
 		if(this.hasChanges()){
 			this.debounceSave();
@@ -351,7 +358,7 @@ const EditPage = createClass({
 		this.setState((prevState)=>({
 			autoSave : !prevState.autoSave
 		}), ()=>{
-			this.trySave();
+			if(this.state.autoSave) this.trySave();
 			localStorage.setItem('AUTOSAVE_ON', JSON.stringify(this.state.autoSave));
 		});
 	},

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -63,7 +63,7 @@ const EditPage = createClass({
 			errors                 : null,
 			htmlErrors             : Markdown.validate(this.props.brew.text),
 			url                    : '',
-			autoSave               : null
+			autoSave               : true
 		};
 	},
 	savedBrew : null,
@@ -339,6 +339,9 @@ const EditPage = createClass({
 		if(this.state.isPending && this.hasChanges()){
 			return <Nav.item className='save' onClick={this.save} color='blue' icon='fas fa-save'>Save Now</Nav.item>;
 		}
+		if(!this.state.isPending && !this.state.isSaving && this.state.autoSave){
+			return <Nav.item className='save saved'>auto-saved.</Nav.item>;
+		}
 		if(!this.state.isPending && !this.state.isSaving){
 			return <Nav.item className='save saved'>saved.</Nav.item>;
 		}
@@ -347,8 +350,10 @@ const EditPage = createClass({
 	handleAutoSave : function(){
 		this.setState((prevState)=>({
 			autoSave : !prevState.autoSave
-		}));
-		localStorage.setItem('AUTOSAVE_ON', JSON.stringify(!this.state.autoSave));
+		}), ()=>{
+			this.trySave();
+			localStorage.setItem('AUTOSAVE_ON', JSON.stringify(this.state.autoSave));
+		});
 	},
 
 	renderAutoSaveButton : function(){

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -342,14 +342,14 @@ const EditPage = createClass({
 		}
 
 		if(this.state.autoSaveWarning){
-			console.log(this.state.unsavedTime);
-			setTimeout(()=>this.setState({ autoSaveWarning: false }), 4000);
 			this.setAutosaveWarning();
+			const elapsedTime = Math.round((new Date() - this.state.unsavedTime) / 1000 / 60);
+			const text = elapsedTime == 0 ? 'Autosave is OFF.' : `Autosave has been turned off, and you haven't saved for ${elapsedTime} minutes.`;
 
 			return <Nav.item className='save error' icon='fas fa-exclamation-circle'>
 			Reminder...
 				<div className='errorContainer'>
-					Autosave has been turned off, and you haven't saved for {Math.round((new Date() - this.state.unsavedTime) / 1000 / 60)} minutes.
+					{text}
 				</div>
 			</Nav.item>;
 		}
@@ -379,6 +379,7 @@ const EditPage = createClass({
 	},
 
 	setAutosaveWarning : function(){
+		setTimeout(()=>this.setState({ autoSaveWarning: false }), 4000);
 		this.warningTimer = setTimeout(()=>{this.setState({ autoSaveWarning: true });}, 15000);
 		this.warningTimer;
 	},

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -344,7 +344,7 @@ const EditPage = createClass({
 		if(this.state.autoSaveWarning && this.hasChanges()){
 			this.setAutosaveWarning();
 			const elapsedTime = Math.round((new Date() - this.state.unsavedTime) / 1000 / 60);
-			const text = elapsedTime == 0 ? 'Autosave is OFF.' : `Autosave has been turned off, and you haven't saved for ${elapsedTime} minutes.`;
+			const text = elapsedTime == 0 ? 'Autosave is OFF.' : `Autosave is OFF, and you haven't saved for ${elapsedTime} minutes.`;
 
 			return <Nav.item className='save error' icon='fas fa-exclamation-circle'>
 			Reminder...

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -148,7 +148,7 @@ const EditPage = createClass({
 	},
 
 	trySave : function(){
-		if(!this.state.autoSave){ console.log('Auto-save is now off.'); return };
+		if(!this.state.autoSave){ console.log('Auto-save is off.'); return };
 		if(!this.debounceSave) this.debounceSave = _.debounce(this.save, SAVE_TIMEOUT);
 		if(this.hasChanges()){
 			this.debounceSave();

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -344,6 +344,19 @@ const EditPage = createClass({
 		}
 	},
 
+	handleAutoSave : function(){
+		this.setState((prevState)=>({
+			autoSave : !prevState.autoSave
+		}));
+		localStorage.setItem('AUTOSAVE_ON', JSON.stringify(!this.state.autoSave));
+	},
+
+	renderAutoSaveButton : function(){
+		return <Nav.item onClick={this.handleAutoSave}>
+			Autosave <i className={this.state.autoSave ? 'fas fa-power-off active' : 'fas fa-power-off'}></i>
+		</Nav.item>;
+	},
+
 	processShareId : function() {
 		return this.state.brew.googleId && !this.state.brew.stubbed ?
 					 this.state.brew.googleId + this.state.brew.shareId :
@@ -384,15 +397,7 @@ const EditPage = createClass({
 				{this.renderGoogleDriveIcon()}
 				<Nav.dropdown className='save-menu'>
 					{this.renderSaveButton()}
-					<Nav.item onClick={()=>{
-						this.setState((prevState)=>({
-							autoSave : !prevState.autoSave
-						}));
-						localStorage.setItem('AUTOSAVE_ON', JSON.stringify(!this.state.autoSave));
-					}}>
-						Autosave <i className={this.state.autoSave ? 'fas fa-power-off active' : 'fas fa-power-off'}></i>
-
-					</Nav.item>
+					{this.renderAutoSaveButton()}
 				</Nav.dropdown>
 				<NewBrew />
 				<HelpNavItem/>

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -379,8 +379,8 @@ const EditPage = createClass({
 	},
 
 	setAutosaveWarning : function(){
-		setTimeout(()=>this.setState({ autoSaveWarning: false }), 4000);
-		this.warningTimer = setTimeout(()=>{this.setState({ autoSaveWarning: true });}, 15000);
+		setTimeout(()=>this.setState({ autoSaveWarning: false }), 4000);                           // 4 seconds to display
+		this.warningTimer = setTimeout(()=>{this.setState({ autoSaveWarning: true });}, 900000);   // 15 minutes between warnings
 		this.warningTimer;
 	},
 

--- a/client/homebrew/pages/editPage/editPage.less
+++ b/client/homebrew/pages/editPage/editPage.less
@@ -32,7 +32,7 @@
 		position         : absolute;
 		top              : 100%;
 		left             : 50%;
-		z-index          : 100000;
+		z-index          : 500;
 		width            : 140px;
 		padding          : 3px;
 		color            : white;


### PR DESCRIPTION
This PR resolves #1546 , adding an ability to turn the auto-save off.   Setting this as a DRAFT for now since it doesn't quite hit every box in the task list.   

1. There is no visual indicator of how to do this toggle, yet.  Right now, you just click on that section of the navbar.  I'm all for ideas here.
2. Possibly occasional pop-ups are needed to remind folks that auto-save is off.
3. Also, a decision about whether this setting should persist across sessions in localStorage.  If it does persist, I need to do something so that it still tries to save when the window closes.

The different states:

### Brew is Saved, auto-save is on:
<img width="221" alt="image" src="https://user-images.githubusercontent.com/58999374/191422424-07ea8f59-d3bd-48d1-b74e-ae2849c50e09.png">

### Brew is Saved, auto-save is off:
<img width="221" alt="image" src="https://user-images.githubusercontent.com/58999374/191422477-3c77c818-08f5-4010-9a0b-7b5af3db23e1.png">

### Brew is *not* Saved, auto-save is off:
<img width="221" alt="image" src="https://user-images.githubusercontent.com/58999374/191422560-ca82e83d-5094-4573-8199-07c2ae606a07.png">

And then there are the normal 'brew is not saved, auto-save is on' which looks the same as above, and the 'saving...' which flashes by too fast for me to screenshot.