### PR TITLE
Prevent Unfolding of Code after Injection (of snippets)

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -80,9 +80,13 @@ const Editor = createClass({
 	},
 
 	handleInject : function(injectText){
+		const cm = this.refs.codeEditor.codeMirror;
 		let text;
 		if(this.isText())  text = this.props.brew.text;
 		if(this.isStyle()) text = this.props.brew.style ?? DEFAULT_STYLE_TEXT;
+		const foldedMarkIDs = cm.getAllMarks()
+			.filter((mark)=>{ return mark.__isFold; })
+			.map((mark)=>mark.id);
 
 		const lines = text.split('\n');
 		const cursorPos = this.refs.codeEditor.getCursorPosition();
@@ -93,6 +97,13 @@ const Editor = createClass({
 
 		if(this.isText())  this.props.onTextChange(lines.join('\n'));
 		if(this.isStyle()) this.props.onStyleChange(lines.join('\n'));
+		console.log(foldedMarkIDs);
+
+		const allMarks = cm.getAllMarks().filter(mark=>foldedMarkIDs.includes(mark.id));
+		allMarks.forEach((mark)=>{
+			console.log(mark.find().from.line);
+			cm.foldCode(mark.find().from.line);
+		})
 	},
 
 	handleViewChange : function(newView){


### PR DESCRIPTION
This PR fixes #2135 (*actually doesn't yet*), or at least get the ball rolling.  Basically the method I am pursuing is to:

1. Get a list of ID's for all codemirror **marks** that have `__isFold: true` before injection
2. Let the injection code run
3. After injection, get a new list of all marks with their updated line positions and filter by those previously gather ID's
4. Run foldCode() on that new set of marks.

I am stuck on getting it to actually *fold*, though...I think `foldCode()` needs additional info passed into it besides just a line number, and I'm not sure what that is.  According to docs it is either a rangefinder or options object, but I'm just sort of scratching my head on how to pass that info in.  I assume it relates to the foldOptions setup for \page....

Ideas?

----
PS:  I think the folded text that appears when something is folded should not be bright blue and bolded...if it's folded, it shouldn't be emphasized....switching it to regular weight and gray would be good, IMHO.  