### PR TITLE
[Editor] Prevent unfolding code in Editor when adding a Snippet

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -80,19 +80,7 @@ const Editor = createClass({
 	},
 
 	handleInject : function(injectText){
-		let text;
-		if(this.isText())  text = this.props.brew.text;
-		if(this.isStyle()) text = this.props.brew.style ?? DEFAULT_STYLE_TEXT;
-
-		const lines = text.split('\n');
-		const cursorPos = this.refs.codeEditor.getCursorPosition();
-		lines[cursorPos.line] = splice(lines[cursorPos.line], cursorPos.ch, injectText);
-
-		const injectLines = injectText.split('\n');
-		this.refs.codeEditor.setCursorPosition(cursorPos.line + injectLines.length, cursorPos.ch  + injectLines[injectLines.length - 1].length);
-
-		if(this.isText())  this.props.onTextChange(lines.join('\n'));
-		if(this.isStyle()) this.props.onStyleChange(lines.join('\n'));
+		this.refs.codeEditor?.injectText(injectText);
 	},
 
 	handleViewChange : function(newView){

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -75,7 +75,7 @@ const Editor = createClass({
 	},
 
 	handleInject : function(injectText){
-		this.refs.codeEditor?.injectText(injectText);
+		this.refs.codeEditor?.injectText(injectText, false);
 	},
 
 	handleViewChange : function(newView){

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -19,11 +19,6 @@ const DEFAULT_STYLE_TEXT = dedent`
 					color: black;
 				}`;
 
-const splice = function(str, index, inject){
-	return str.slice(0, index) + inject + str.slice(index);
-};
-
-
 
 const Editor = createClass({
 	displayName     : 'Editor',

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -234,7 +234,7 @@ const CodeEditor = createClass({
 		if(!overwrite) {
 			cm.setCursor(cm.getCursor('from'));
 		}
-		cm.replaceSelection(injectText, 'around');
+		cm.replaceSelection(injectText, 'end');
 	},
 
 	makeUnderline : function() {

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -229,6 +229,10 @@ const CodeEditor = createClass({
 		this.codeMirror.replaceSelection('\n\\page\n\n', 'end');
 	},
 
+	injectText : function(injectText) {
+		this.codeMirror.replaceSelection(injectText, 'around');
+	},
+
 	makeUnderline : function() {
 		const selection = this.codeMirror.getSelection(), t = selection.slice(0, 3) === '<u>' && selection.slice(-4) === '</u>';
 		this.codeMirror.replaceSelection(t ? selection.slice(3, -4) : `<u>${selection}</u>`, 'around');

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -235,6 +235,7 @@ const CodeEditor = createClass({
 			cm.setCursor(cm.getCursor('from'));
 		}
 		cm.replaceSelection(injectText, 'end');
+		cm.focus();
 	},
 
 	makeUnderline : function() {

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -229,8 +229,12 @@ const CodeEditor = createClass({
 		this.codeMirror.replaceSelection('\n\\page\n\n', 'end');
 	},
 
-	injectText : function(injectText) {
-		this.codeMirror.replaceSelection(injectText, 'around');
+	injectText : function(injectText, overwrite=true) {
+		const cm = this.codeMirror;
+		if(!overwrite) {
+			cm.setCursor(cm.getCursor('from'));
+		}
+		cm.replaceSelection(injectText, 'around');
 	},
 
 	makeUnderline : function() {


### PR DESCRIPTION
This PR resolves #2135.

After investigating Gazook89's draft PR  #2391, I was unable to automate the re-folding of previously folded code blocks in the Editor. However, on comparing the `handleInject` function to the shortcuts for page and column breaks, I realized that the `handleInject` function was operating in a very different fashion, causing the document to effectively be regenerated, losing the folded marks.
By moving this function out of the `editor.jsx` to `codeEditor.jsx` and using the same method (`replaceSelection`) as the shortcut keys, folded code segments are no longer unfolded when a snippet is injected.

At this stage, I have included an optional `overwrite` parameter to overwrite the existing selection, but the `handleInject` function is currently called with this set to `false` in order to mimic the previous functionality.