### PR TITLE
[Stub] Shift thumbnail url to stub #2351

### DIFF
--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -125,8 +125,7 @@ const GoogleActions = {
 				description : file.description,
 				views       : parseInt(file.properties.views),
 				published   : file.properties.published ? file.properties.published == 'true' : false,
-				systems     : [],
-				thumbnail   : file.properties.thumbnail
+				systems     : []
 			};
 		});
 	  return brews;
@@ -146,8 +145,7 @@ const GoogleActions = {
 					editId    : brew.editId || nanoid(12),
 					pageCount : brew.pageCount,
 					renderer  : brew.renderer || 'legacy',
-					isStubbed : true,
-					thumbnail : brew.thumbnail
+					isStubbed : true
 				}
 			},
 			media : {
@@ -185,8 +183,7 @@ const GoogleActions = {
 				pageCount : brew.pageCount,
 				renderer  : brew.renderer || 'legacy',
 				isStubbed : true,
-				version   : 1,
-				thumbnail : brew.thumbnail || ''
+				version   : 1
 			}
 		};
 
@@ -265,7 +262,6 @@ const GoogleActions = {
 				views      : parseInt(obj.data.properties.views) || 0, //brews with no view parameter will return undefined
 				version    : parseInt(obj.data.properties.version) || 0,
 				renderer   : obj.data.properties.renderer ? obj.data.properties.renderer : 'legacy',
-				thumbnail  : obj.data.properties.thumbnail || '',
 
 				googleId : id
 			};

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -108,7 +108,7 @@ const excludePropsFromUpdate = (brew)=>{
 
 const excludeGoogleProps = (brew)=>{
 	const modified = _.clone(brew);
-	const propsToExclude = ['tags', 'systems', 'published', 'authors', 'owner', 'views'];
+	const propsToExclude = ['tags', 'systems', 'published', 'authors', 'owner', 'views', 'thumbnail'];
 	for (const prop of propsToExclude) {
 		delete modified[prop];
 	}


### PR DESCRIPTION
This PR will resolve #2351.

The thumbnail property is removed from the Google properties and is instead saved in the MongoDB stub.

In the current iteration, any thumbnail data currently stored in the Google brew is lost.