### PR TITLE
[Editor] Change folded code text generation

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -356,23 +356,19 @@ const CodeEditor = createClass({
 				let currentLine = from.line;
 				const maxLength = 50;
 
-				let headerText = '';
-				let otherText = '';
+				let foldPreviewText = '';
 				while (currentLine <= to.line && text.length <= maxLength) {
 					const currentText = this.codeMirror.getLine(currentLine);
 					currentLine++;
-					if(!currentText) {
-						continue;
-					}
 					if(currentText[0] == '#'){
-						headerText = currentText;
+						foldPreviewText = currentText;
 						break;
 					}
-					if(!otherText && currentText != '\n') {
-						otherText = currentText;
+					if(!foldPreviewText && currentText != '\n') {
+						foldPreviewText = currentText;
 					}
 				}
-				text = headerText || otherText || `Lines ${from.line+1}-${to.line+1}`;
+				text = foldPreviewText || `Lines ${from.line+1}-${to.line+1}`;
 
 				text = text.trim();
 				if(text.length > maxLength)

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -355,12 +355,24 @@ const CodeEditor = createClass({
 				let text = '';
 				let currentLine = from.line;
 				const maxLength = 50;
+
+				let headerText = '';
+				let otherText = '';
 				while (currentLine <= to.line && text.length <= maxLength) {
-					text += this.codeMirror.getLine(currentLine);
-					if(currentLine < to.line)
-						text += ' ';
-					currentLine += 1;
+					const currentText = this.codeMirror.getLine(currentLine);
+					currentLine++;
+					if(!currentText) {
+						continue;
+					}
+					if(currentText[0] == '#'){
+						headerText = currentText;
+						break;
+					}
+					if(!otherText && currentText != '\n') {
+						otherText = currentText;
+					}
 				}
+				text = headerText || otherText || `Lines ${from.line+1}-${to.line+1}`;
 
 				text = text.trim();
 				if(text.length > maxLength)

--- a/shared/naturalcrit/codeEditor/codeEditor.less
+++ b/shared/naturalcrit/codeEditor/codeEditor.less
@@ -13,7 +13,8 @@
     font-family: inherit;
     text-shadow: none;
     font-weight: 600;
-  }
+    color: grey;
+}
 
   .sourceMoveFlash .CodeMirror-line{
     animation-name: sourceMoveAnimation;


### PR DESCRIPTION
This PR will resolve #1907.

This PR modifies the text generated when code is folded, using the following rules:
1. Use the first header in the folded section. At this point, a `h6` at the top of the fold will be used over a later `h1`.
2. If no headers exist, use the text of the first non-empty line.
3. If no non-empty lines exist, generate text "Lines {start line}-{end line}"

---
Example output:

Folded:
![image](https://user-images.githubusercontent.com/19826659/192123715-69641c9a-9ed2-49cd-b685-b4e154e59958.png)

Brew Source:
```
# Combat Maneuvers
\page
# Combat Actions
\page
## Movement
\page
## Defense
\page
## Special Targeting
\page
# Footnotes on source rules
\page
### Parry Defence
\page
## Other options/wrinkles
\page
### Weapon Length and Positioning
\page
## Damage-type Maneuvers
\page
## No Quarter <small>Combat manuevers - for fighting</small>
\page





\page

This is a test page.
This is the second line.

\page

This is a test page.
This is the second line.

### Header later on


\page

```