### PR TITLE
Add URI encoding to User Page link

### DIFF
--- a/client/homebrew/navbar/account.navitem.jsx
+++ b/client/homebrew/navbar/account.navitem.jsx
@@ -70,7 +70,7 @@ const Account = createClass({
 					{global.account.username}
 				</Nav.item>
 				<Nav.item
-					href={`/user/${global.account.username}`}
+					href={`/user/${encodeURI(global.account.username)}`}
 					color='yellow'
 					icon='fas fa-beer'
 				>


### PR DESCRIPTION
This PR resolves #2420.

This PR adds URI encoding to the username URL when clicking the Account/Brews nav bar item. While most of this has been automatically handled at the browser level, this has resulted in user names with trailing spaces being incorrectly trimmed.