### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ config/docker.*
 todo.md
 startDB.bat
 startMViewer.bat
+.vscode


### PR DESCRIPTION
This PR adds the `.vscode` folder to the `.gitignore` file, to prevent any project files created by users of that IDE from being included in any Homebrewery commits.