### PR TITLE
Send entire brew to HomePage save function

### DIFF
--- a/client/homebrew/pages/homePage/homePage.jsx
+++ b/client/homebrew/pages/homePage/homePage.jsx
@@ -38,9 +38,7 @@ const HomePage = createClass({
 	},
 	handleSave : function(){
 		request.post('/api')
-			.send({
-				text : this.state.brew.text
-			})
+			.send(this.state.brew)
 			.end((err, res)=>{
 				if(err) return;
 				const brew = res.body;


### PR DESCRIPTION
This resolves #2427.

On the HomePage, only the current state of the brew's text was being passed to the save function. This was causing brews saved from the HomePage scratch pad to change renderer from v3 to legacy, because this information simply was not being passed to the function.