### PR TITLE
Add default brew on load and before save

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,7 +29,6 @@ const splitTextStyleAndMetadata = (brew)=>{
 		brew.style = brew.text.slice(7, index - 1);
 		brew.text = brew.text.slice(index + 5);
 	}
-	_.defaults(brew, { 'renderer': 'legacy', 'theme': '5ePHB' });
 };
 
 const sanitizeBrew = (brew, accessType)=>{

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -9,6 +9,18 @@ const yaml = require('js-yaml');
 const asyncHandler = require('express-async-handler');
 const { nanoid } = require('nanoid');
 
+const DEFAULT_BREW = {
+	title       : 'Untitled Brew',
+	description : '',
+	renderer    : 'V3',
+	tags        : [],
+	systems     : [],
+	thumbnail   : '',
+	published   : false,
+	pageCount   : 1,
+	theme       : '5ePHB'
+};
+
 // const getTopBrews = (cb) => {
 // 	HomebrewModel.find().sort({ views: -1 }).limit(5).exec(function(err, brews) {
 // 		cb(brews);
@@ -66,6 +78,8 @@ const getBrew = (accessType)=>{
 		if(typeof stub.tags === 'string') {
 			stub.tags = [];
 		}
+
+		_.defaults(stub, DEFAULT_BREW);
 		req.brew = stub;
 
 		next();
@@ -130,6 +144,8 @@ const beforeNewSave = (account, brew)=>{
 
 	brew.authors = (account) ? [account.username] : [];
 	brew.text = mergeBrewText(brew);
+
+	_.defaults(brew, DEFAULT_BREW);
 };
 
 const newGoogleBrew = async (account, brew, res)=>{

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -46,8 +46,6 @@ HomebrewSchema.statics.get = function(query, fields=null){
 				unzipped = zlib.inflateRawSync(brews[0].textBin);
 				brews[0].text = unzipped.toString();
 			}
-			if(!brews[0].renderer)
-				brews[0].renderer = 'legacy';
 			return resolve(brews[0]);
 		});
 	});


### PR DESCRIPTION
While investigating #2427, it became apparent that the default brew settings are not being applied in the save function, nor are they being applied at the time that the brew is loaded.

This Draft PR uses the Lodash `defaults` function to apply the properties of a default brew object to the brew object before the data is saved, and also as a final step when the brew is loaded. This function ONLY copies the property from the default when the property is missing or undefined on the source object.