### PR TITLE
Tweak table padding

### DIFF
--- a/themes/V3/5ePHB/style.less
+++ b/themes/V3/5ePHB/style.less
@@ -213,7 +213,9 @@ body {
 		tbody{
 			tr{
 				td{
-					padding : 0.14em 0.4em;
+					//padding : 0.14em 0.4em;
+					padding : 1.7px 5px;   // Both of these are temporary, just to force
+          height  : 18px;        // PDF to render at same height until Chrome 108
 				}
 				&:nth-child(odd){
 					background-color : var(--HB_Color_Accent);


### PR DESCRIPTION
A quick attempt at fixing the mismatched renderer and PDF table sizes due to Chrome 106 making table cells use fractional heights, but PDF generation has not caught up.

In general, Chrome 106 has caused tables to grow in size (no more rounding down in pixel size), so we eventually need to shrink the top/bottom padding on `td` elements. However, since PDF generation has not applied this change yet, doing so will just throw the PDFs off. Instead, this is a temporary compromise to just set an exact pixel value so no rounding occurs in either case. Should be "good enough" for most `td` cells, even multi-row cells.