### PR TITLE
Fix Autosave Default

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -78,7 +78,7 @@ const EditPage = createClass({
 
 		this.savedBrew = JSON.parse(JSON.stringify(this.props.brew)); //Deep copy
 
-		this.setState({ autoSave: JSON.parse(localStorage.getItem('AUTOSAVE_ON')) }, ()=>{
+		this.setState({ autoSave: localStorage.getItem('AUTOSAVE_ON') ? JSON.parse(localStorage.getItem('AUTOSAVE_ON')) : true }, ()=>{
 			if(this.state.autoSave){
 				this.trySave();
 			} else {

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -78,7 +78,7 @@ const EditPage = createClass({
 
 		this.savedBrew = JSON.parse(JSON.stringify(this.props.brew)); //Deep copy
 
-		this.setState({ autoSave: localStorage.getItem('AUTOSAVE_ON') ? JSON.parse(localStorage.getItem('AUTOSAVE_ON')) : true }, ()=>{
+		this.setState({ autoSave: JSON.parse(localStorage.getItem('AUTOSAVE_ON')) ?? true }, ()=>{
 			if(this.state.autoSave){
 				this.trySave();
 			} else {


### PR DESCRIPTION
This is hopefully an easy and accurate fix for the issue caused by the autosave toggle PR just pushed through.  When opening a brew that doesn't have `AUTOSAVE_ON` key in localStorage, it defaults to True  (though it doesn't create that key, it just sets the state).

```js
this.setState({ autoSave: localStorage.getItem('AUTOSAVE_ON') ? JSON.parse(localStorage.getItem('AUTOSAVE_ON')) : true }, ()=>{
	if(this.state.autoSave){
		this.trySave();
	} else {
		this.setState({ autoSaveWarning: true });
	}
});
```