### PR TITLE
[UserPage] Add key prop to Brew tags

### DIFF
--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -117,7 +117,7 @@ const BrewItem = createClass({
 						<i className='fas fa-tags'/>
 						{brew.tags.map((tag, idx)=>{
 							const matches = tag.match(/^(?:([^:]+):)?([^:]+)$/);
-							return <span className={matches[1]}>{matches[2]}</span>;
+							return <span key={idx} className={matches[1]}>{matches[2]}</span>;
 						})}
 					</div>
 				</> : <></>


### PR DESCRIPTION
This PR resolves #2451.

The function to create Brew tag elements was missing a `key` prop. Adding this prevents the "Warning: Each child in a list should have a unique "key" prop" error from occurring.