### PR TITLE
Set Language Attribute of the `.pages` Element

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -58,10 +58,6 @@ const BrewRenderer = createClass({
 	height     : 0,
 	lastRender : <div></div>,
 
-	componentDidMount : function(){
-		console.log(this.props);
-	},
-
 	componentWillUnmount : function() {
 		window.removeEventListener('resize', this.updateSize);
 	},
@@ -194,8 +190,6 @@ const BrewRenderer = createClass({
 		const rendererPath = this.props.renderer == 'V3' ? 'V3' : 'Legacy';
 		const themePath    = this.props.theme ?? '5ePHB';
 		const baseThemePath = Themes[rendererPath][themePath].baseTheme;
-		const language = 'fr';
-		console.log(this);
 		return (
 			<React.Fragment>
 				{!this.state.isMounted

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -58,6 +58,10 @@ const BrewRenderer = createClass({
 	height     : 0,
 	lastRender : <div></div>,
 
+	componentDidMount : function(){
+		console.log(this.props);
+	},
+
 	componentWillUnmount : function() {
 		window.removeEventListener('resize', this.updateSize);
 	},
@@ -189,10 +193,9 @@ const BrewRenderer = createClass({
 		//Also render dummy page while iframe is mounting.
 		const rendererPath = this.props.renderer == 'V3' ? 'V3' : 'Legacy';
 		const themePath    = this.props.theme ?? '5ePHB';
-		const language = this.props.lang;
-		console.log(language);
 		const baseThemePath = Themes[rendererPath][themePath].baseTheme;
-
+		const language = 'fr';
+		console.log(this);
 		return (
 			<React.Fragment>
 				{!this.state.isMounted
@@ -225,7 +228,7 @@ const BrewRenderer = createClass({
 							&&
 							<>
 								{this.renderStyle()}
-								<div className='pages' ref='pages' lang={language}>
+								<div className='pages' ref='pages' lang={`${this.props.lang}`}>
 									{this.renderPages()}
 								</div>
 							</>

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -27,6 +27,7 @@ const BrewRenderer = createClass({
 			style    : '',
 			renderer : 'legacy',
 			theme    : '5ePHB',
+			lang     : '',
 			errors   : []
 		};
 	},
@@ -183,6 +184,8 @@ const BrewRenderer = createClass({
 		//Also render dummy page while iframe is mounting.
 		const rendererPath = this.props.renderer == 'V3' ? 'V3' : 'Legacy';
 		const themePath    = this.props.theme ?? '5ePHB';
+		const language = this.props.lang;
+		console.log(language);
 		const baseThemePath = Themes[rendererPath][themePath].baseTheme;
 
 		return (
@@ -217,7 +220,7 @@ const BrewRenderer = createClass({
 							&&
 							<>
 								{this.renderStyle()}
-								<div className='pages' ref='pages'>
+								<div className='pages' ref='pages' lang={language}>
 									{this.renderPages()}
 								</div>
 							</>

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -28,7 +28,7 @@ const MetadataEditor = createClass({
 				systems     : [],
 				renderer    : 'legacy',
 				theme       : '5ePHB',
-				lang        : ''
+				lang        : 'en'
 			},
 			onChange : ()=>{}
 		};
@@ -56,8 +56,8 @@ const MetadataEditor = createClass({
 			...this.props.metadata,
 			[name] : e.target.value
 		});
-		console.log(this.props.metadata[name]);
 	},
+
 	handleSystem : function(system, e){
 		if(e.target.checked){
 			this.props.metadata.systems.push(system);
@@ -101,6 +101,32 @@ const MetadataEditor = createClass({
 			.end(function(err, res){
 				window.location.href = '/';
 			});
+	},
+
+	constructLanguageRegExp : function(){
+		const grandfathered = '(' +
+		/* irregular */ '(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)' +
+		'|' +
+		/* regular */ '(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)' +
+		')';
+		const langtag = '(' +
+			'(' + (
+			'([A-Za-z]{2,3}(-' +
+				'([A-Za-z]{3}(-[A-Za-z]{3}){0,2})' +
+				')?)|[A-Za-z]{4}|[A-Za-z]{5,8})'
+		) +
+			'(-' + '([A-Za-z]{4})' + ')?' +
+			'(-' + '([A-Za-z]{2}|[0-9]{3})' + ')?' +
+			'(-' + '([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3})' + ')*' +
+			'(-' + '(' + (
+			/* singleton */ '[0-9A-WY-Za-wy-z]' +
+				'(-[A-Za-z0-9]{2,8})+)'
+		) +
+			')*' +
+			'(-' + '(x(-[A-Za-z0-9]{1,8})+)' + ')?' +
+			')';
+		return  '^(' + grandfathered + '|' + langtag + '|' + '(x(-[A-Za-z0-9]{1,8})+)' + ')$';
+
 	},
 
 	renderSystems : function(){
@@ -225,6 +251,32 @@ const MetadataEditor = createClass({
 		</div>;
 	},
 
+	renderLanguageDropdown : function(){
+		const langCodes = ['en', 'de', 'fr', 'ja', 'es', 'it'];
+		const listLanguages = ()=>{
+			return _.map(langCodes, (code)=>{
+				const languageNames = new Intl.DisplayNames([code], { type: 'language' });
+				return <option value={`${code}`}>{`${languageNames.of(code)}`}</option>;
+			});
+		};
+
+
+
+		return <div className='field language'>
+			<label>language</label>
+			<input type='text' className='value'
+				value={this.props.metadata.lang}
+				onChange={(e)=>this.handleFieldChange('lang', e)}
+				list='languageList'
+				pattern='[a-zA-Z]{2,3}(-.*)?' />
+			<datalist id='languageList'>
+				{listLanguages()}
+			</datalist>
+			<span class='validity'>Must be 2-3 letters, optionally followed by '-...'</span>
+		</div>;
+	},
+
+
 	render : function(){
 		return <div className='metadataEditor'>
 			<div className='field title'>
@@ -269,12 +321,7 @@ const MetadataEditor = createClass({
 				</div>
 			</div>
 
-			<div className='field language'>
-				<label>language</label>
-				<input type='text' className='value'
-					value={this.props.metadata.lang}
-					onChange={(e)=>this.handleFieldChange('lang', e)} />
-			</div>
+			{this.renderLanguageDropdown()}
 
 			{this.renderThemeDropdown()}
 

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -56,6 +56,7 @@ const MetadataEditor = createClass({
 			...this.props.metadata,
 			[name] : e.target.value
 		});
+		console.log(this.props.metadata[name]);
 	},
 	handleSystem : function(system, e){
 		if(e.target.checked){

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -27,7 +27,8 @@ const MetadataEditor = createClass({
 				authors     : [],
 				systems     : [],
 				renderer    : 'legacy',
-				theme       : '5ePHB'
+				theme       : '5ePHB',
+				lang        : 'en'
 			},
 			onChange : ()=>{}
 		};
@@ -261,6 +262,13 @@ const MetadataEditor = createClass({
 				<div className='value'>
 					{this.renderSystems()}
 				</div>
+			</div>
+
+			<div className='field language'>
+				<label>language</label>
+				<input type='text' className='value'
+					value={this.props.metadata.lang}
+					onChange={(e)=>this.handleFieldChange('lang', e)} />
 			</div>
 
 			{this.renderThemeDropdown()}

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -28,7 +28,7 @@ const MetadataEditor = createClass({
 				systems     : [],
 				renderer    : 'legacy',
 				theme       : '5ePHB',
-				lang        : 'en'
+				lang        : ''
 			},
 			onChange : ()=>{}
 		};

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -28,10 +28,14 @@
 		gap: 10px;
 		
 	}
+
+
+
 	.field{
 		display       : flex;
 		width         : 100%;
 		min-width     : 200px;
+		position      : relative;
 		&>label{
 			width          : 80px;
 			font-size      : 11px;
@@ -42,6 +46,17 @@
 		&>.value{
 			flex           : 1 1 auto;
 			width          : 50px;
+			&:valid ~ .validity  {
+				display: none;
+			}
+			&:invalid ~ .validity {
+				display   : block;
+				color     : #ffdddd;
+				position  : absolute;
+				bottom    : -1em;
+				right     : 0;
+				font-size : .6em;
+			}
 		}
 		&.thumbnail{
 			height      : 1.4em;

--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -46,6 +46,7 @@ const Homebrew = createClass({
 				editId    : null,
 				createdAt : null,
 				updatedAt : null,
+				lang      : ''
 			}
 		};
 	},

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -47,7 +47,7 @@ const EditPage = createClass({
 				authors     : [],
 				systems     : [],
 				renderer    : 'legacy',
-				lang        : ''
+				lang        : 'en'
 			}
 		};
 	},
@@ -472,7 +472,14 @@ const EditPage = createClass({
 						onMetaChange={this.handleMetaChange}
 						renderer={this.state.brew.renderer}
 					/>
-					<BrewRenderer text={this.state.brew.text} style={this.state.brew.style} renderer={this.state.brew.renderer} theme={this.state.brew.theme} errors={this.state.htmlErrors} />
+					<BrewRenderer
+						text={this.state.brew.text}
+						style={this.state.brew.style}
+						renderer={this.state.brew.renderer}
+						theme={this.state.brew.theme}
+						errors={this.state.htmlErrors}
+						lang={this.state.brew.lang}
+					/>
 				</SplitPane>
 			</div>
 		</div>;

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -46,7 +46,8 @@ const EditPage = createClass({
 				published   : false,
 				authors     : [],
 				systems     : [],
-				renderer    : 'legacy'
+				renderer    : 'legacy',
+				lang        : ''
 			}
 		};
 	},

--- a/server/app.js
+++ b/server/app.js
@@ -21,7 +21,7 @@ const splitTextStyleAndMetadata = (brew)=>{
 		const index = brew.text.indexOf('```\n\n');
 		const metadataSection = brew.text.slice(12, index - 1);
 		const metadata = yaml.load(metadataSection);
-		Object.assign(brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme']));
+		Object.assign(brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']));
 		brew.text = brew.text.slice(index + 5);
 	}
 	if(brew.text.startsWith('```css')) {
@@ -173,6 +173,7 @@ app.get('/user/:username', async (req, res, next)=>{
 		'pageCount',
 		'description',
 		'authors',
+		'lang',
 		'published',
 		'views',
 		'shareId',

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -126,6 +126,7 @@ const GoogleActions = {
 				views       : parseInt(file.properties.views),
 				published   : file.properties.published ? file.properties.published == 'true' : false,
 				systems     : [],
+				lang        : file.properties.lang,
 				thumbnail   : file.properties.thumbnail
 			};
 		});
@@ -255,6 +256,7 @@ const GoogleActions = {
 				tags        : obj.data.properties.tags ? obj.data.properties.tags : '',
 				systems     : obj.data.properties.systems ? obj.data.properties.systems.split(',') : [],
 				authors     : [],
+				lang        : obj.data.properties.lang,
 				published   : obj.data.properties.published ? obj.data.properties.published == 'true' : false,
 				trashed     : obj.data.trashed,
 

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -147,7 +147,8 @@ const GoogleActions = {
 					editId    : brew.editId || nanoid(12),
 					pageCount : brew.pageCount,
 					renderer  : brew.renderer || 'legacy',
-					isStubbed : true
+					isStubbed : true,
+					lang      : brew.lang || 'en'
 				}
 			},
 			media : {
@@ -185,7 +186,8 @@ const GoogleActions = {
 				pageCount : brew.pageCount,
 				renderer  : brew.renderer || 'legacy',
 				isStubbed : true,
-				version   : 1
+				version   : 1,
+				lang      : brew.lang || 'en'
 			}
 		};
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -108,7 +108,7 @@ const excludePropsFromUpdate = (brew)=>{
 
 const excludeGoogleProps = (brew)=>{
 	const modified = _.clone(brew);
-	const propsToExclude = ['tags', 'systems', 'published', 'authors', 'owner', 'views', 'thumbnail'];
+	const propsToExclude = ['tags', 'systems', 'published', 'authors', 'owner', 'views', 'thumbnail', 'lang'];
 	for (const prop of propsToExclude) {
 		delete modified[prop];
 	}

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -80,7 +80,7 @@ const mergeBrewText = (brew)=>{
 			`\`\`\`\n\n` +
 			`${text}`;
 	}
-	const metadata = _.pick(brew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme']);
+	const metadata = _.pick(brew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']);
 	text = `\`\`\`metadata\n` +
 		`${yaml.dump(metadata)}\n` +
 		`\`\`\`\n\n` +

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -15,7 +15,7 @@ const HomebrewSchema = mongoose.Schema({
 	description : { type: String, default: '' },
 	tags        : [String],
 	systems     : [String],
-	lang        : { type: String, default: 'en' },
+	lang        : { type: String, default: '' },
 	renderer    : { type: String, default: '' },
 	authors     : [String],
 	published   : { type: Boolean, default: false },

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -15,6 +15,7 @@ const HomebrewSchema = mongoose.Schema({
 	description : { type: String, default: '' },
 	tags        : [String],
 	systems     : [String],
+	lang        : { type: String, default: 'en' },
 	renderer    : { type: String, default: '' },
 	authors     : [String],
 	published   : { type: Boolean, default: false },


### PR DESCRIPTION
This pr resolves #1343 by adding a "Language" property in the properties editor.   The input value is then sent to the BrewRenderer component and inserted into the `.pages` element.

The property input field is a datalist that shows the language code + the name of the language in that language.  Adding languages to this list is easy, just add the code and the "name" is automatically added.  There is a very simple pattern validation, and an error message that displays under the input field....this isn't my favorite, since the text is so small and it's on a gray background (so it is difficult to get high contrast), but this can be changed to match whatever is decided on PR #2374 so i didn't spend a lot of time on it.   Here is a picture of it now:

<img width="478" alt="image" src="https://user-images.githubusercontent.com/58999374/197408880-d4888223-f0d5-4f48-b253-25b9d9389320.png">

The pattern itself could be made significantly more robust, or we could use a new library to actually check to see if the language tag is valid (mentioned in attached Issue).