### PR TITLE
update twitter:card meta tag to have "summary" as the content

### DIFF
--- a/client/template.js
+++ b/client/template.js
@@ -15,7 +15,7 @@ module.exports = async(name, title = '', props = {})=>{
 		<meta property="og:description" content="${props.brew?.description || 'No description.'}">
 		<meta property="og:site_name" content="The Homebrewery - Make your Homebrew content look legit!">
 		<meta property="og:type" content="article">
-		<meta name="twitter:card" content="summary_large_image">
+		<meta name="twitter:card" content="summary">
 		<title>${title.length ? `${title} - The Homebrewery`: 'The Homebrewery - NaturalCrit'}</title>
 	</head>
 	<body>


### PR DESCRIPTION
Updates the `twitter:card` meta tag's content to be `summary`, enabling the thumbnail image to be inline with the embed.

![image](https://user-images.githubusercontent.com/4909307/198463080-5b7cd867-3364-4546-9192-429a97d5f52f.png)
