### PR TITLE
[AccountPage] Modify query to exclude Google brew stubs

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -289,7 +289,8 @@ app.get('/account', asyncHandler(async (req, res, next)=>{
 			}
 		}
 
-		const brews = await HomebrewModel.getByUser(req.account.username, true, 'id')
+		const query = { authors: req.account.username, googleId: { $exists: false } };
+		const brews = await HomebrewModel.find(query, 'id')
 			.catch((err)=>{
 				console.log(err);
 			});


### PR DESCRIPTION
This PR resolves #2478.

This PR alters the fetch query, so rather than re-using the existing function to get all of a user's brews, it uses a new function to get only the user's non-Google brew. It does this by excluding brews with a `googleId` property at the query, so those brews are never retrieved.