### PR TITLE
Update Jest test  for moved legacy homepage

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -92,7 +92,7 @@ app.get('/', (req, res, next)=>{
 	return next();
 });
 
-//Home page v3
+//Home page legacy
 app.get('/legacy', (req, res, next)=>{
 	req.brew = {
 		text     : welcomeTextLegacy,

--- a/tests/routes/static-pages.test.js
+++ b/tests/routes/static-pages.test.js
@@ -9,8 +9,8 @@ describe('Tests for static pages', ()=>{
 		return app.get('/').expect(200);
 	});
 
-	it('Home page v3 works', ()=>{
-		return app.get('/v3_preview').expect(200);
+	it('Home page legacy works', ()=>{
+		return app.get('/legacy').expect(200);
 	});
 
 	it('Changelog page works', ()=>{


### PR DESCRIPTION
When making V3 default, the legacy homepage was moved to `/legacy`, and `/v3_preview` was moved to the top-level `/` route. This fixes a Jest test to validate the new `/legacy` route instead of `/v3_preview` which no longer exists.