### PR TITLE
Fix template.js crash when ogMeta undefined

### DIFF
--- a/client/template.js
+++ b/client/template.js
@@ -1,6 +1,7 @@
 const template = async function(name, title='', props = {}){
 	const ogTags = [];
-	Object.entries(props.ogMeta).forEach(([key, value])=>{
+	const ogMeta = props.ogMeta ?? {};
+	Object.entries(ogMeta).forEach(([key, value])=>{
 		if(!value) return;
 		const tag = `<meta property="og:${key}" content="${value}">`;
 		ogTags.push(tag);

--- a/server/app.js
+++ b/server/app.js
@@ -415,7 +415,7 @@ app.use(asyncHandler(async (req, res, next)=>{
 		enable_v3     : config.get('enable_v3'),
 		enable_themes : config.get('enable_themes'),
 		config        : configuration,
-		ogMeta        : req.ogMeta ?? {}
+		ogMeta        : req.ogMeta
 	};
 	const title = req.brew ? req.brew.title : '';
 	const page = await templateFn('homebrew', title, props)

--- a/server/app.js
+++ b/server/app.js
@@ -415,7 +415,7 @@ app.use(asyncHandler(async (req, res, next)=>{
 		enable_v3     : config.get('enable_v3'),
 		enable_themes : config.get('enable_themes'),
 		config        : configuration,
-		ogMeta        : req.ogMeta
+		ogMeta        : req.ogMeta ?? {}
 	};
 	const title = req.brew ? req.brew.title : '';
 	const page = await templateFn('homebrew', title, props)


### PR DESCRIPTION
This PR resolves #2498.

This PR adds an empty object as the default `ogMeta` value, when no `ogMeta` object has been explicitly defined.

Fixing this in `template.js` rather than `app.js` fixes crashes with all pages that have undefined `prop.ogMeta`, including the Admin pages.