### PR TITLE
Add syntax highlighting for injections

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -139,7 +139,7 @@ const Editor = createClass({
 
 						
 						if(line.includes('{') && line.includes('}')){
-							const regex = /{(?:(?=(:(?:"[\w,\-()#%. ]*"|[\w\-()#%.]*)|[^"':{}\s]*))\1)*}/g;
+							const regex = /(?<!{){(?=((?::(?:"[\w,\-()#%. ]*"|[\w\-()#%.]*)|[^"':{}\s]*)*))\1}/g;
 							let match;
 							let blockCount = 0;
 							while ((match = regex.exec(line)) != null) {

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -137,21 +137,11 @@ const Editor = createClass({
 							codeMirror.addLineClass(lineNumber, 'text', 'columnSplit');
 						}
 
-						
+						// Highlight injectors {style}
 						if(line.includes('{') && line.includes('}')){
 							const regex = /(?<!{){(?=((?::(?:"[\w,\-()#%. ]*"|[\w\-()#%.]*)|[^"':{}\s]*)*))\1}/g;
 							let match;
-							let blockCount = 0;
 							while ((match = regex.exec(line)) != null) {
-								if(match[0].startsWith('{')) {
-									blockCount += 1;
-								} else {
-									blockCount -= 1;
-								}
-								if(blockCount < 0) {
-									blockCount = 0;
-									continue;
-								}
 								codeMirror.markText({ line: lineNumber, ch: match.index }, { line: lineNumber, ch: match.index + match[0].length }, { className: 'injection' });
 							}
 						}

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -137,6 +137,24 @@ const Editor = createClass({
 							codeMirror.addLineClass(lineNumber, 'text', 'columnSplit');
 						}
 
+						
+						if(line.includes('{') && line.includes('}')){
+							const regex = /{(?:(?=(:(?:"[\w,\-()#%. ]*"|[\w\-()#%.]*)|[^"':{}\s]*))\1)*}/g;
+							let match;
+							let blockCount = 0;
+							while ((match = regex.exec(line)) != null) {
+								if(match[0].startsWith('{')) {
+									blockCount += 1;
+								} else {
+									blockCount -= 1;
+								}
+								if(blockCount < 0) {
+									blockCount = 0;
+									continue;
+								}
+								codeMirror.markText({ line: lineNumber, ch: match.index }, { line: lineNumber, ch: match.index + match[0].length }, { className: 'injection' });
+							}
+						}
 						// Highlight inline spans {{content}}
 						if(line.includes('{{') && line.includes('}}')){
 							const regex = /{{(?:(?=(:(?:"[\w,\-()#%. ]*"|[\w\-()#%.]*)|[^"':{}\s]*))\1)*|}}/g;

--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -29,6 +29,10 @@
 			font-weight : bold;
 			//font-style: italic;
 		}
+		.injection{
+			color       : green;
+			font-weight : bold;
+		}
 	}
 
 	.brewJump{


### PR DESCRIPTION
*This is a branch of PR #2501 (which I'm now realizing it likely didn't need to be...it should have branched directly from master)*

It fixes #1670 by giving the curly injection syntax a green color in the Editor.   I thought Orange would be too close to the red used for Spans, and I don't think we are using green yet?  Maybe there should be some plan for colors but if CodeMirror themes are ever added it'll be a moot point.

I do have concerns that I have unnecessarily doubled up on code here where I might not have had to.

<img width="384" alt="image" src="https://user-images.githubusercontent.com/58999374/201566776-8ebf3c2b-de74-4ad4-8975-0ab928ec34d7.png">
