### PR TITLE
Remove Checkboxes from Github Issue Forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,10 +12,6 @@ body:
       description: The best feature requests provide an explanation of the current issue and then an explanation of how it could be improved.  Screenshots/images can be pasted right in as well!
     validations:
       required: true
-  - type: checkboxes
-    id: terms
+  - type: markdown
     attributes:
-      label: "Please confirm:"
-      options:
-        - label: I have searched the Issues tracker for any duplicate requests and found none.
-          required: true
+      value: "Please be sure to search for any close matches to your request in the GitHub Issues tracker before opening a new request, thanks!"

--- a/.github/ISSUE_TEMPLATE/general_issue.yml
+++ b/.github/ISSUE_TEMPLATE/general_issue.yml
@@ -4,14 +4,15 @@ body:
   - type: markdown
     attributes:
       value: Please include as much information as possible.
-  - type: checkboxes
+  - type: dropdown
     id: renderer
     attributes:
       label: Renderer
       description: Which renderer does this issue occur on?  If you are unsure, you can check the renderer in the Properties Editor (click the "i" in the Snippet Menu bar above the editor).
       options:
-        - label: Legacy
-        - label: v3
+        - v3
+        - Legacy
+        - Both
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
This simple PR replaces the checkboxes in Github Forms with either dropdowns or just markdown text.  This will prevent future Issues from having 'tasks' associated with them.