### PR TITLE
Add link to FAQ in "Need Help" menu

### DIFF
--- a/client/homebrew/navbar/help.navitem.jsx
+++ b/client/homebrew/navbar/help.navitem.jsx
@@ -20,6 +20,12 @@ module.exports = function(props){
 			rel='noopener noreferrer'>
 			report issue
 		</Nav.item>
+		<Nav.item color='green' icon='fas fa-question-circle'
+			href='/faq'
+			newTab={true}
+			rel='noopener noreferrer'>
+			FAQ
+		</Nav.item>
 		<Nav.item color='blue' icon='fas fa-fw fa-file-import'
 			href='/migrate'
 			newTab={true}


### PR DESCRIPTION
This simply adds a link to the FAQ in the Navbar's "Need Help?" dropdown.  

<img width="213" alt="image" src="https://user-images.githubusercontent.com/58999374/201972259-5c8af484-a632-45a3-a259-1d2e3f2014aa.png">
