### PR TITLE
Update Style for V3 & Legacy

### DIFF
--- a/themes/Legacy/5ePHB/style.less
+++ b/themes/Legacy/5ePHB/style.less
@@ -58,6 +58,7 @@ body {
 	text-rendering    : optimizeLegibility;
 	page-break-before : always;
 	page-break-after  : always;
+	contain           : size;
 	//*****************************
 	// *            BASE
 	// *****************************/

--- a/themes/V3/Blank/style.less
+++ b/themes/V3/Blank/style.less
@@ -39,6 +39,7 @@ body {
 	text-rendering    : optimizeLegibility;
 	page-break-before : always;
 	page-break-after  : always;
+	contain           : size;
 }
 	//*****************************
 	// *            BASE


### PR DESCRIPTION
This PR resolves #2516, resolves #2445

This PR adds `contain: size;` to both V3/Blank and Legacy/5ePHB styles. This should fix the printing issue seen in Chrome Canary for the upcoming Chrome release, scheduled for Nov 29, 2022.