### PR TITLE
[AccountPage] Fix last login time

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -340,7 +340,7 @@ app.get('/account', asyncHandler(async (req, res, next)=>{
 	if(req.account) {
 		if(req.account.googleId) {
 			try {
-				auth = await GoogleActions.authCheck(req.account, res);
+				auth = await GoogleActions.authCheck(req.account, res, false);
 			} catch (e) {
 				auth = undefined;
 				console.log('Google auth check failed!');

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -22,7 +22,7 @@ google.options({ auth: serviceAuth || config.get('google_api_key') });
 
 const GoogleActions = {
 
-	authCheck : (account, res)=>{
+	authCheck : (account, res, updateTokens=true)=>{
 		if(!account || !account.googleId){ // If not signed into Google
 			const err = new Error('Not Signed In');
 			err.status = 401;
@@ -40,7 +40,7 @@ const GoogleActions = {
 			refresh_token : account.googleRefreshToken
 		});
 
-		oAuth2Client.on('tokens', (tokens)=>{
+		updateTokens && oAuth2Client.on('tokens', (tokens)=>{
 			if(tokens.refresh_token) {
 				account.googleRefreshToken = tokens.refresh_token;
 			}


### PR DESCRIPTION
This resolves #2521.

This PR adds an `updateTokens` parameter to `GoogleActions.js/authCheck()`, and updates the Account Page data collection to call this function with the parameter set to `false`. This prevents the JWT token from being changed to the current time by the `authCheck` call, and as a result the last login time is not changed to the current time.