### PR TITLE
Add link to instructions to refresh Google creds

### DIFF
--- a/client/homebrew/pages/accountPage/accountPage.jsx
+++ b/client/homebrew/pages/accountPage/accountPage.jsx
@@ -42,7 +42,6 @@ const AccountPage = createClass({
 	},
 
 	renderUiItems : function() {
-		// console.log(this.props.uiItems);
 		return 	<>
 			<div className='dataGroup'>
 				<h1>Account Information  <i className='fas fa-user'></i></h1>
@@ -56,7 +55,11 @@ const AccountPage = createClass({
 			<div className='dataGroup'>
 				<h3>Google Information <i className='fab fa-google-drive'></i></h3>
 				<p><strong>Linked to Google: </strong> {this.props.uiItems.googleId ? 'YES' : 'NO'}</p>
-				{this.props.uiItems.googleId ? <p><strong>Brews on Google Drive: </strong> {this.props.uiItems.fileCount || '-'}</p> : '' }
+				{this.props.uiItems.googleId &&
+					<p>
+						<strong>Brews on Google Drive: </strong> {this.props.uiItems.fileCount != '-' ? this.props.uiItems.fileCount : <>Unable to retrieve files - <a href='https://github.com/naturalcrit/homebrewery/discussions/1580'>follow these steps to renew your Google credentials.</a></>}
+					</p>
+				}
 			</div>
 		</>;
 	},

--- a/client/homebrew/pages/accountPage/accountPage.jsx
+++ b/client/homebrew/pages/accountPage/accountPage.jsx
@@ -57,7 +57,7 @@ const AccountPage = createClass({
 				<p><strong>Linked to Google: </strong> {this.props.uiItems.googleId ? 'YES' : 'NO'}</p>
 				{this.props.uiItems.googleId &&
 					<p>
-						<strong>Brews on Google Drive: </strong> {this.props.uiItems.googleCount ? this.props.uiItems.googleCount : <>Unable to retrieve files - <a href='https://github.com/naturalcrit/homebrewery/discussions/1580'>follow these steps to renew your Google credentials.</a></>}
+						<strong>Brews on Google Drive: </strong> {this.props.uiItems.googleCount ?? <>Unable to retrieve files - <a href='https://github.com/naturalcrit/homebrewery/discussions/1580'>follow these steps to renew your Google credentials.</a></>}
 					</p>
 				}
 			</div>

--- a/client/homebrew/pages/accountPage/accountPage.jsx
+++ b/client/homebrew/pages/accountPage/accountPage.jsx
@@ -50,14 +50,14 @@ const AccountPage = createClass({
 			</div>
 			<div className='dataGroup'>
 				<h3>Homebrewery Information <NaturalCritIcon /></h3>
-				<p><strong>Brews on Homebrewery: </strong> {this.props.uiItems.mongoCount || '-'}</p>
+				<p><strong>Brews on Homebrewery: </strong> {this.props.uiItems.mongoCount}</p>
 			</div>
 			<div className='dataGroup'>
 				<h3>Google Information <i className='fab fa-google-drive'></i></h3>
 				<p><strong>Linked to Google: </strong> {this.props.uiItems.googleId ? 'YES' : 'NO'}</p>
 				{this.props.uiItems.googleId &&
 					<p>
-						<strong>Brews on Google Drive: </strong> {this.props.uiItems.fileCount != '-' ? this.props.uiItems.fileCount : <>Unable to retrieve files - <a href='https://github.com/naturalcrit/homebrewery/discussions/1580'>follow these steps to renew your Google credentials.</a></>}
+						<strong>Brews on Google Drive: </strong> {this.props.uiItems.googleCount ? this.props.uiItems.googleCount : <>Unable to retrieve files - <a href='https://github.com/naturalcrit/homebrewery/discussions/1580'>follow these steps to renew your Google credentials.</a></>}
 					</p>
 				}
 			</div>

--- a/server/app.js
+++ b/server/app.js
@@ -361,30 +361,20 @@ app.get('/account', asyncHandler(async (req, res, next)=>{
 			}
 		}
 
-		const aggregateQuery =[{
-			'$match' : {
-				'googleId' : {
-					'$exists' : false
-				},
-				'authors' : req.account.username
-			}
-		}, {
-			  '$count' : 'total'
-		}];
-		const mongoCount = [];
-		mongoCount.push(...await HomebrewModel.aggregate(aggregateQuery)
+		const query = { authors: req.account.username, googleId: { $exists: false } };
+		const mongoCount = await HomebrewModel.countDocuments(query)
 			.catch((err)=>{
+				mongoCount = 0;
 				console.log(err);
-			}));
-		mongoCount.push({ total: 0 });
+			});
 
 		data.uiItems = {
 			username    : req.account.username,
 			issued      : req.account.issued,
-			mongoCount  : mongoCount[0]?.total.toString(),
 			googleId    : Boolean(req.account.googleId),
 			authCheck   : Boolean(req.account.googleId && auth.credentials.access_token),
-			googleCount : googleCount?.length.toString() || null
+			mongoCount  : mongoCount,
+			googleCount : googleCount?.length
 		};
 	}
 


### PR DESCRIPTION
This PR resolves #2520.

This PR adds a link to the instructions for a user to refresh their Google credentials to the Account Page in the event that the list of Google files are unable to be received.