### PR TITLE
Fix og:image and og:site_name

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -80,7 +80,7 @@ String.prototype.replaceAll = function(s, r){return this.split(s).join(r);};
 const defaultMetaTags = {
 	site_name   : 'The Homebrewery - Make your Homebrew content look legit!',
 	title       : 'The Homebrewery',
-	description : 'A NaturalCrit Tool for Homebrews',
+	description : 'A NaturalCrit Tool for creating authentic Homebrews using Markdown.',
 	image       : `${config.get('publicUrl')}/thumbnail.png`,
 	type        : 'website'
 };
@@ -148,8 +148,7 @@ app.get('/changelog', async (req, res, next)=>{
 
 	req.ogMeta = { ...defaultMetaTags,
 		title       : 'Changelog',
-		description : 'Development changelog.',
-		image   : null
+		description : 'Development changelog.'
 	};
 
 	splitTextStyleAndMetadata(req.brew);
@@ -208,8 +207,7 @@ app.get('/user/:username', async (req, res, next)=>{
 
 	req.ogMeta = { ...defaultMetaTags,
 		title       : `${req.params.username}'s Collection`,
-		description : 'View my collection of homebrew on the Homebrewery.',
-		image       : null
+		description : 'View my collection of homebrew on the Homebrewery.'
 		// type        :  could be 'profile'?
 	};
 
@@ -274,7 +272,7 @@ app.get('/edit/:id', asyncHandler(getBrew('edit')), (req, res, next)=>{
 	req.ogMeta = { ...defaultMetaTags,
 		title       : req.brew.title || 'Untitled Brew',
 		description : req.brew.description || 'No description.',
-		image       : req.brew.thumbnail || null,
+		image       : req.brew.thumbnail || `${config.get('publicUrl')}/thumbnail.png`,
 		type        : 'article'
 	};
 
@@ -292,8 +290,7 @@ app.get('/new/:id', asyncHandler(getBrew('share')), (req, res, next)=>{
 
 	req.ogMeta = { ...defaultMetaTags,
 		title       : 'New',
-		description : 'Start crafting your homebrew on the Homebrewery!',
-		image       : null
+		description : 'Start crafting your homebrew on the Homebrewery!'
 	};
 
 	return next();
@@ -306,7 +303,7 @@ app.get('/share/:id', asyncHandler(getBrew('share')), asyncHandler(async (req, r
 	req.ogMeta = { ...defaultMetaTags,
 		title       : req.brew.title || 'Untitled Brew',
 		description : req.brew.description || 'No description.',
-		image       : req.brew.thumbnail || null,
+		image       : req.brew.thumbnail || `${config.get('publicUrl')}/thumbnail.png`,
 		type        : 'article'
 	};
 
@@ -377,8 +374,7 @@ app.get('/account', asyncHandler(async (req, res, next)=>{
 
 	req.ogMeta = { ...defaultMetaTags,
 		title       : `Account Page`,
-		description : null,
-		image       : null
+		description : null
 	};
 
 	return next();

--- a/server/app.js
+++ b/server/app.js
@@ -272,7 +272,8 @@ app.get('/edit/:id', asyncHandler(getBrew('edit')), (req, res, next)=>{
 	req.ogMeta = { ...defaultMetaTags,
 		title       : req.brew.title || 'Untitled Brew',
 		description : req.brew.description || 'No description.',
-		image       : req.brew.thumbnail || `${config.get('publicUrl')}/thumbnail.png`,
+		image       : req.brew.thumbnail || defaultMetaTags.image,
+
 		type        : 'article'
 	};
 

--- a/server/app.js
+++ b/server/app.js
@@ -78,10 +78,10 @@ const faqText           = require('fs').readFileSync('faq.md', 'utf8');
 String.prototype.replaceAll = function(s, r){return this.split(s).join(r);};
 
 const defaultMetaTags = {
-	siteName    : 'The Homebrewery - Make your Homebrew content look legit!',
+	site_name   : 'The Homebrewery - Make your Homebrew content look legit!',
 	title       : 'The Homebrewery',
 	description : 'A NaturalCrit Tool for Homebrews',
-	thumbnail   : `${config.get('publicUrl')}/thumbnail.png`,
+	image       : `${config.get('publicUrl')}/thumbnail.png`,
 	type        : 'website'
 };
 
@@ -149,7 +149,7 @@ app.get('/changelog', async (req, res, next)=>{
 	req.ogMeta = { ...defaultMetaTags,
 		title       : 'Changelog',
 		description : 'Development changelog.',
-		thumbnail   : null
+		image   : null
 	};
 
 	splitTextStyleAndMetadata(req.brew);

--- a/server/app.js
+++ b/server/app.js
@@ -304,7 +304,7 @@ app.get('/share/:id', asyncHandler(getBrew('share')), asyncHandler(async (req, r
 	req.ogMeta = { ...defaultMetaTags,
 		title       : req.brew.title || 'Untitled Brew',
 		description : req.brew.description || 'No description.',
-		image       : req.brew.thumbnail || `${config.get('publicUrl')}/thumbnail.png`,
+		image       : req.brew.thumbnail || defaultMetaTags.image,
 		type        : 'article'
 	};
 


### PR DESCRIPTION
This fixes some typo's I made in the OG meta tags.  

`og:siteName` => `og:site_name`
`og:thumbnail` => `og:image`

Before merging, let me know if you prefer `edit` and `share` links to display the d20 logo by default if the user hasn't set their own thumbnail.  Currently it is set to not display anything.

