### PR TITLE
Change error message about googleActions on local startup.

### DIFF
--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -7,7 +7,7 @@ const config = require('./config.js');
 
 let serviceAuth;
 if(!config.get('service_account')){
-	console.log('No Google Service Account in config files - Google Drive functionality will not function.');
+	console.log('No Google Service Account in config files - Google Drive integration will not be available.');
 } else  {
 	const keys = typeof(config.get('service_account')) == 'string' ?
 		JSON.parse(config.get('service_account')) :
@@ -15,12 +15,10 @@ if(!config.get('service_account')){
 
 	try {
 		serviceAuth = google.auth.fromJSON(keys);
-		serviceAuth.scopes = [
-			'https://www.googleapis.com/auth/drive'
-		];
+		serviceAuth.scopes = ['https://www.googleapis.com/auth/drive'];
 	} catch (err) {
 		console.warn(err);
-		console.log('Please make sure that a Google Service Account is set up properly in your config files.');
+		console.log('Please make sure the Google Service Account is set up properly in your config files.');
 	}
 }
 

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -5,23 +5,25 @@ const { nanoid } = require('nanoid');
 const token = require('./token.js');
 const config = require('./config.js');
 
-const keys = typeof(config.get('service_account')) == 'string' ?
-	JSON.parse(config.get('service_account')) :
-	config.get('service_account');
 let serviceAuth;
-try {
-	serviceAuth = google.auth.fromJSON(keys);
-	serviceAuth.scopes = [
-		'https://www.googleapis.com/auth/drive'
-	];
-} catch (err) {
-	if(!keys){
-		console.log('No Google Service Account in config files - Google Drive functionality will not function.');
-	} else {
+if(!config.get('service_account')){
+	console.log('No Google Service Account in config files - Google Drive functionality will not function.');
+} else  {
+	const keys = typeof(config.get('service_account')) == 'string' ?
+		JSON.parse(config.get('service_account')) :
+		config.get('service_account');
+
+	try {
+		serviceAuth = google.auth.fromJSON(keys);
+		serviceAuth.scopes = [
+			'https://www.googleapis.com/auth/drive'
+		];
+	} catch (err) {
 		console.warn(err);
 		console.log('Please make sure that a Google Service Account is set up properly in your config files.');
 	}
 }
+
 google.options({ auth: serviceAuth || config.get('google_api_key') });
 
 const GoogleActions = {

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -15,8 +15,12 @@ try {
 		'https://www.googleapis.com/auth/drive'
 	];
 } catch (err) {
-	console.warn(err);
-	console.log('Please make sure that a Google Service Account is set up properly in your config files.');
+	if(!keys){
+		console.log('No Google Service Account in config files - Google Drive functionality will not function.');
+	} else {
+		console.warn(err);
+		console.log('Please make sure that a Google Service Account is set up properly in your config files.');
+	}
 }
 google.options({ auth: serviceAuth || config.get('google_api_key') });
 


### PR DESCRIPTION
This PR simply checks to see if `keys` exist in googleActions.js and if not, throws a less ~~scary~~ verbose error message.

Fixes #2424