### PR TITLE
Encode Filename in Content-Disposition header

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -192,12 +192,19 @@ app.get('/download/:id', asyncHandler(getBrew('share')), (req, res)=>{
 	sanitizeBrew(brew, 'share');
 	const prefix = 'HB - ';
 
+	const encodeRFC3986ValueChars = (str)=>{
+		return (
+			encodeURIComponent(str)
+				.replace(/[!'()*]/g, (char)=>{`%${char.charCodeAt(0).toString(16).toUpperCase()}`;})
+		);
+	};
+
 	let fileName = sanitizeFilename(`${prefix}${brew.title}`).replaceAll(' ', '');
 	if(!fileName || !fileName.length) { fileName = `${prefix}-Untitled-Brew`; };
 	res.set({
 		'Cache-Control'       : 'no-cache',
 		'Content-Type'        : 'text/plain',
-		'Content-Disposition' : `attachment; filename="${fileName}.txt"`
+		'Content-Disposition' : `attachment; filename*=UTF-8''${encodeRFC3986ValueChars(fileName)}.txt`
 	});
 	res.status(200).send(brew.text);
 });


### PR DESCRIPTION
This is a re-do of PR #2530, which I botched.

Pasting the summary here:
> This PR fixes an [issue reported on reddit](https://old.reddit.com/r/homebrewery/comments/z8arm9/homebrews_with_nonlatin_characters_in_the_title/) where the user has a brew title with non-latin characters, and choosing to "Download" leads to an error page.
> 
> Content Disposition must be utf-8 encoded. So this PR [follows the MDN docs for doing this](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
> 
> Example title: Cześć or καλή μέρα