### PR TITLE
Change findOneAndUpdate to FindOne and Save

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -250,7 +250,6 @@ const updateBrew = async (req, res)=>{
 		brew = _.assign(await HomebrewModel.findOne({ _id: brew._id }), brew);
 		saved = await brew.save()
 		.catch(saveError);
-		});
 	}
 	if(!saved) return;
 	// Call and wait for afterSave to complete


### PR DESCRIPTION
Setting an object property to `undefined` should tell Mongoose to remove that property (for example, remove the googleId from a brew). That doesn't seem to work with `findOneAndUpdate` however; the `undefined` property remains after the update.

Switching back to `save()` to make this work again.