### PR TITLE
[WIP] Update SharePage when brew is edited

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -26,6 +26,8 @@ const googleDriveInactive = require('../../googleDriveMono.png');
 
 const SAVE_TIMEOUT = 3000;
 
+let broadcastChannel;
+
 const EditPage = createClass({
 	displayName     : 'EditPage',
 	getDefaultProps : function() {
@@ -101,6 +103,7 @@ const EditPage = createClass({
 	componentWillUnmount : function() {
 		window.onbeforeunload = function(){};
 		document.removeEventListener('keydown', this.handleControlKeys);
+		broadcastChannel.close();
 	},
 
 	handleControlKeys : function(e){
@@ -236,6 +239,17 @@ const EditPage = createClass({
 			isSaving    : false,
 			unsavedTime : new Date()
 		}));
+
+		this.sendUpdate();
+	},
+
+	sendUpdate : function() {
+		const channelName = this.state.brew.shareId;
+		broadcastChannel = new window.BroadcastChannel(channelName);
+
+		const message = `brewUpdate:${this.state.brew.shareId}`;
+		// console.log(`SEND UPDATE: ${message} || ${channelName}`);
+		broadcastChannel.postMessage(message);
 	},
 
 	renderGoogleDriveIcon : function(){

--- a/client/homebrew/pages/sharePage/sharePage.jsx
+++ b/client/homebrew/pages/sharePage/sharePage.jsx
@@ -12,6 +12,7 @@ const Account = require('../../navbar/account.navitem.jsx');
 
 const BrewRenderer = require('../../brewRenderer/brewRenderer.jsx');
 
+let broadcastChannel;
 
 const SharePage = createClass({
 	displayName     : 'SharePage',
@@ -32,10 +33,16 @@ const SharePage = createClass({
 
 	componentDidMount : function() {
 		document.addEventListener('keydown', this.handleControlKeys);
+
+		const channelName = this.props.brew.shareId;
+		broadcastChannel = new window.BroadcastChannel(channelName);
+		broadcastChannel.onmessage = (event)=>{this.messageReceived(event);};
 	},
 
 	componentWillUnmount : function() {
 		document.removeEventListener('keydown', this.handleControlKeys);
+
+		broadcastChannel.close();
 	},
 
 	handleControlKeys : function(e){
@@ -45,6 +52,13 @@ const SharePage = createClass({
 			window.open(`/print/${this.processShareId()}?dialog=true`, '_blank').focus();
 			e.stopPropagation();
 			e.preventDefault();
+		}
+	},
+
+	messageReceived : function(e){
+		console.log(`Message RX: ${new Date}`);
+		if(e.origin === window.location.origin && e.data === `brewUpdate:${this.props.brew.shareId}`) {
+			window.location.reload();
 		}
 	},
 


### PR DESCRIPTION
I was experimenting with the BroadcastChannel functionality and managed to create the following:

- When SharePage is loaded, subscribe to a BroadcastChannel with name `shareId`
- When EditPage is saved, post a new message in the `shareId` BroadcastChannel
- When SharePage receives an update message, confirm `shareId` and `origin` match; if so, perform a `window.location.reload()`, refreshing the brew and allowing effectively real time updates

Future improvements:
- a window reload loses the place in the brew, returning to the top; this can probably be resolved by instead sending the brew content and updating the brew state on the SharePage, causing only a re-render rather than a whole refresh.

Primarily, I see this as being useful for DMs who wish to present to their parties on a second screen - pull up EditPage on the hidden screen, and SharePage on the second monitor. Alter EditPage - for example, toggle an item's visibility from hidden to visible - and suddenly it will appear on the SharePage.