### PR TITLE
Disable @layers on core CSS due to crashing ios

### DIFF
--- a/scripts/buildHomebrew.js
+++ b/scripts/buildHomebrew.js
@@ -20,8 +20,8 @@ const transforms = {
 };
 
 const build = async ({ bundle, render, ssr })=>{
-	let css = await lessTransform.generate({ paths: './shared' });
-	css = `@layer bundle {\n${css}\n}`;
+	const css = await lessTransform.generate({ paths: './shared' });
+	//css = `@layer bundle {\n${css}\n}`;
 	await fs.outputFile('./build/homebrew/bundle.css', css);
 	await fs.outputFile('./build/homebrew/bundle.js', bundle);
 	await fs.outputFile('./build/homebrew/ssr.js', ssr);


### PR DESCRIPTION
@Layers is not supported on IOS devices, leading to the whole site crashing. This removes @layers from the core CSS bundle which we forgot to remove when undoing layers previously.