### PR TITLE
Run Tests sequentially

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - image: cimg/node:16.11.0
 
     working_directory: ~/homebrewery
-    parallelism: 4
+    parallelism: 1
 
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,14 +62,14 @@ jobs:
           name: Test - Basic
           command: npm run test:basic
       - run:
-          name: Test - Coverage
-          command: npm run test:coverage
-      - run:
           name: Test - Mustache Spans
           command: npm run test:mustache-span
       - run:
           name: Test - Routes
           command: npm run test:route
+      - run:
+          name: Test - Coverage
+          command: npm run test:coverage
 
 workflows:
   build_and_test:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:dry": "eslint **/*.{js,jsx}",
     "circleci": "npm test && eslint **/*.{js,jsx} --max-warnings=0",
     "verify": "npm run lint && npm test",
-    "test": "jest",
+    "test": "jest --runInBand",
     "test:api-unit": "jest server/*.spec.js --verbose",
     "test:coverage": "jest --coverage --silent",
     "test:dev": "jest --verbose --watch",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build/*"
   ],
   "jest": {
-    "testTimeout": 15000,
+    "testTimeout": 30000,
     "modulePaths": [
       "node_modules",
       "shared",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "verify": "npm run lint && npm test",
     "test": "jest --runInBand",
     "test:api-unit": "jest server/*.spec.js --verbose",
-    "test:coverage": "jest --coverage --silent",
+    "test:coverage": "jest --coverage --silent --runInBand",
     "test:dev": "jest --verbose --watch",
     "test:basic": "jest tests/markdown/basic.test.js --verbose",
     "test:mustache-span": "jest tests/markdown/mustache-span.test.js --verbose",


### PR DESCRIPTION
One possible solution to tests timing out on CI

https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server

Also raising the timeout limit just 'cuz.

I also noticed the `test:coverage` option re-runs all the tests a second time. Perhaps it's worth just having circleci do `run:test --coverage --runInBand` instead of breaking them all out into separate steps so we can test coverage at the same time as everything else in one pass. @jeddai ?