### PR TITLE
Prevent Injection if preceded by another Injection token

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -134,7 +134,7 @@ const mustacheInjectInline = {
 		const match = inlineRegex.exec(src);
 		if(match) {
 			const lastToken = tokens[tokens.length - 1];
-			if(!lastToken)
+			if(!lastToken || lastToken.type == 'mustacheInjectInline')
 				return false;
 
 			const tags = ` ${processStyleTags(match[1])}`;
@@ -169,7 +169,8 @@ const mustacheInjectBlock = {
 			const match = inlineRegex.exec(src);
 			if(match) {
 				const lastToken = tokens[tokens.length - 1];
-				if(!lastToken)
+				console.log(lastToken);
+				if(!lastToken || lastToken.type == 'mustacheInjectBlock')
 					return false;
 
 				lastToken.originalType = 'mustacheInjectBlock';

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -169,7 +169,6 @@ const mustacheInjectBlock = {
 			const match = inlineRegex.exec(src);
 			if(match) {
 				const lastToken = tokens[tokens.length - 1];
-				console.log(lastToken);
 				if(!lastToken || lastToken.type == 'mustacheInjectBlock')
 					return false;
 

--- a/tests/markdown/mustache-span.test.js
+++ b/tests/markdown/mustache-span.test.js
@@ -105,6 +105,22 @@ test('Renders a mustache span with text, id, class and a couple of css propertie
 	expect(rendered).toBe('<span class="inline-block pen" id="author" style="color:orange; font-family:trebuchet ms;">text</span>');
 });
 
+test('Two consecutive injections into Inline', function() {
+	const source = '{{dog Sample Text}}{cat}{toad}';
+	const rendered = Markdown.render(source);
+	// FIXME: Drops original attributes in favor of injection, rather than adding.
+	// FIXME: Doesn't keep the raw text of second injection.
+	// FIXME: Renders the extra class attribute (which is dropped by the browser).
+	expect(rendered).toBe('<p><span class=" cat"   class="inline-block cat"  >Sample Text</span></p>\n');
+});
+
+test('Two consecutive injections into Block', function() {
+	const source = '{{dog\nSample Text\n}}\n{cat}\n{toad}';
+	const rendered = Markdown.render(source);
+	// FIXME: Renders the extra class attribute (which is dropped by the browser).
+	expect(rendered).toBe('<div class=" cat"   class="block cat"  ><p>Sample Text</p>\n</div><p>{toad}</p>\n');
+});
+
 // TODO: add tests for ID with accordance to CSS spec:
 //
 // From https://drafts.csswg.org/selectors/#id-selectors:

--- a/themes/V3/Blank/snippets/imageMask.gen.js
+++ b/themes/V3/Blank/snippets/imageMask.gen.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const dedent = require('dedent-tabs').default;
 
 module.exports = {
-	center :()=>{
+	center : ()=>{
 		return dedent`
 			{{imageMaskCenter${_.random(1, 16)},--offsetX:0%,--offsetY:0%,--rotation:0;
 			  ![](https://i.imgur.com/GZfjDWV.png){height:100%}


### PR DESCRIPTION
This is a *short and sweet* fix for #2712 (fixes #2712).  It just adds an escape hatch in case of two consecutive inject blocks.

Note:  This is sort of a *half measure*, and should be improved in a future PR.  Specifically, you will see that consecutive mustacheInjectBlock tokens are rendered as plain text after the first, but mustacheInjectInline does not render the subsequent tokens as text (they are absorbed into the previous token).   I think the standard behavior that is desired is to follow the Block process, so that anything that isn't being tokenized is just coming out as plain text.  I don't want to bog this PR down with any further delays, so I'm going ahead without worrying about this for now.