### PR TITLE
Update engines to Node 16.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.11-alpine
+FROM node:16.13-alpine
 RUN apk --no-cache add git
 
 ENV NODE_ENV=docker

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "supertest": "^6.3.3"
       },
       "engines": {
-        "node": "16.11.x"
+        "node": "16.13.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Create authentic looking D&D homebrews using only markdown",
   "version": "3.7.2",
   "engines": {
-    "node": "16.11.x"
+    "node": "16.13.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR resolves #2756.

This PR updates the Node engine to version 16.13.0 in `package.json`, `package-lock.json`, and `Dockerfile`. This corrects the issues created by the previous `npm` version change (from `^8.10.0` to `9.6.3`).