### PR TITLE
Change Model.remove to Model.deleteOne

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -305,7 +305,7 @@ If you believe you should have access to this brew, ask the file owner to invite
 
 			if(brew.authors.length === 0) {
 				// Delete brew if there are no authors left
-				await brew.remove()
+				await brew.deleteOne()
 					.catch((err)=>{
 						console.error(err);
 						throw { status: 500, message: 'Error while removing' };


### PR DESCRIPTION
This PR resolves #2769.

This PR replaces the `Model.remove()` call in `homebrew.api.js` with `Model.deleteOne()`, as the `remove()` function was deprecated in Mongoose v5.5.3, and appears to have been finally removed with v7.0.x.