### PR TITLE
Dockerfile - Change to npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /usr/src/app
 # This improves caching so we don't have to download the dependencies every time the code changes
 COPY package.json ./
 # --ignore-scripts tells yarn not to run postbuild.  We run it explicitly later
-RUN yarn install --ignore-scripts
+RUN npm install --ignore-scripts
 
 # Bundle app source and build application
 COPY . .
-RUN yarn build
+RUN npm run build
 
 EXPOSE 8000
-CMD [ "yarn", "start" ]
+CMD [ "npm", "start" ]


### PR DESCRIPTION
This PR resolves #2801.

For reasons as yet undetermined, Docker builds have been failing due to an unsupported engine. Diagnostics have isolated this to `yarn` installing a newer version of a dependency than `npm` does, despite the two being fed the same dependency configuration file.

Switching to use `npm` instead of `yarn` provides consistency across Docker and bare metal local installs, which should make troubleshooting any future issues simpler.