### PR TITLE
Stop image movement in Image Masks

### DIFF
--- a/themes/V3/Blank/style.less
+++ b/themes/V3/Blank/style.less
@@ -254,7 +254,6 @@ body {
 		background-size       : 20px;
 		z-index               : -1;
 		transform             : translateY(50%) translateX(-50%) rotate(calc(1deg * var(--rotation))) scaleX(var(--scaleX)) scaleY(var(--scaleY));
-		transition            : transform 2s;
 		& > p:has(img) {
 			position   : absolute;
 			width      : 50%;
@@ -262,7 +261,6 @@ body {
 			bottom     : 50%;
 			left       : 50%;
 			transform  : translateX(-50%) translateY(50%) rotate(calc(-1deg * var(--rotation))) scaleX(calc(1 / var(--scaleX))) scaleY(calc(1 / var(--scaleY)));
-			transition : transform 2s;
 		}
 		& img {
 			position : absolute;


### PR DESCRIPTION
This PR resolves #2790.

This PR removes the `transition` style rules as identified in the Issue, which will stop the image movement seen inside the image masks on first load of the brew.