### PR TITLE
correct highlight of .cm-comment elements in editor

### DIFF
--- a/client/homebrew/editor/editor.less
+++ b/client/homebrew/editor/editor.less
@@ -19,17 +19,17 @@
 			background-color 	: fade(#299, 15%);
 			border-bottom    	: #299 solid 1px;
 		}
-		.block{
+		.block:not(.cm-comment){
 			color 		: purple;
 			font-weight : bold;
 			//font-style: italic;
 		}
-		.inline-block{
+		.inline-block:not(.cm-comment){
 			color 		: red;
 			font-weight : bold;
 			//font-style: italic;
 		}
-		.injection{
+		.injection:not(.cm-comment){
 			color       : green;
 			font-weight : bold;
 		}


### PR DESCRIPTION
Should fix #2784 , 