### PR TITLE
Custom function to use spaces for indent

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -97,11 +97,13 @@ const CodeEditor = createClass({
 		this.codeMirror = CodeMirror(this.refs.editor, {
 			lineNumbers       : true,
 			lineWrapping      : this.props.wrap,
-			indentWithTabs    : true,
+			indentWithTabs    : false,
 			tabSize           : 2,
 			historyEventDelay : 250,
 			scrollPastEnd     : true,
 			extraKeys         : {
+				'Tab'              : this.indent,
+				'Shift-Tab'        : this.dedent,
 				'Ctrl-B'           : this.makeBold,
 				'Cmd-B'            : this.makeBold,
 				'Ctrl-I'           : this.makeItalic,
@@ -169,6 +171,19 @@ const CodeEditor = createClass({
 		// Note: codeMirror passes a copy of itself in this callback. cm === this.codeMirror. Either one works.
 		this.codeMirror.on('change', (cm)=>{this.props.onChange(cm.getValue());});
 		this.updateSize();
+	},
+
+	indent : function () {
+		const cm = this.codeMirror;
+			if (cm.somethingSelected()) {
+				cm.execCommand('indentMore');
+			} else {
+				cm.execCommand('insertSoftTab');
+			}
+	},
+
+	dedent : function () {
+		this.codeMirror.execCommand('indentLess');
 	},
 
 	makeHeader : function (number) {

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -99,6 +99,7 @@ const CodeEditor = createClass({
 			lineWrapping      : this.props.wrap,
 			indentWithTabs    : false,
 			tabSize           : 2,
+			smartIndent       : false,
 			historyEventDelay : 250,
 			scrollPastEnd     : true,
 			extraKeys         : {

--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -176,11 +176,11 @@ const CodeEditor = createClass({
 
 	indent : function () {
 		const cm = this.codeMirror;
-			if (cm.somethingSelected()) {
-				cm.execCommand('indentMore');
-			} else {
-				cm.execCommand('insertSoftTab');
-			}
+		if (cm.somethingSelected()) {
+			cm.execCommand('indentMore');
+		} else {
+			cm.execCommand('insertSoftTab');
+		}
 	},
 
 	dedent : function () {


### PR DESCRIPTION
Fixes #2092, #1556

Apparently Codemirror doesn't have a built-in way to just use spaces instead of tabs for indentation. This PR uses a custom script to change that behavior, based on this discussion on the CodeMirror github:

https://github.com/codemirror/codemirror5/issues/988#issuecomment-549644684

- Tab: indent using spaces at the current location (will use 1 or 2 spaces, to line up with the next tab boundary)
- Tab while text is selected: indent whole line
- Shift+Tab : unindent whole line

Also removes the "smartIndent" feature which auto-indents inside HTML blocks when pressing `return`. Manual indenting and then pressing `return` will maintain the current indent.

You can test the behavior at https://homebrewery-pr-2839.herokuapp.com/