### PR TITLE
Fix StringArrayEditor unique `key` error

### DIFF
--- a/client/homebrew/editor/stringArrayEditor/stringArrayEditor.jsx
+++ b/client/homebrew/editor/stringArrayEditor/stringArrayEditor.jsx
@@ -140,7 +140,7 @@ const StringArrayEditor = createClass({
 					</div>
 				</div>
 
-				{this.props.notes ? this.props.notes.map((n)=><p><small>{n}</small></p>) : null}
+				{this.props.notes ? this.props.notes.map((n, index)=><p key={index}><small>{n}</small></p>) : null}
 			</div>
 		</div>;
 	}


### PR DESCRIPTION
This is a very simple fix for a console error that happens in the Properties editor when the StringArrayEditor component is rendered.  Specifically, for the Invited Authors bit.  That bit includes a "notes" prop that gets sent to a `.map()` method, but the output `<p>` elements did not utilize an index to create a unique key.

Super simple fix to remove a very long error message.


EDIT:  I'll add that while struggling with this for a bit I came across this SO post: https://stackoverflow.com/a/43892905

If i'm reading it correctly, it is suggesting that using `index` for  the `key` prop in changing arrays may not be a good idea.  I didn't really want to go into much further after I got this working, but mentioning it in case someone thinks we need to worry about it.