### PR TITLE
Fix redundant build/ properly watch .less

### DIFF
--- a/scripts/buildHomebrew.js
+++ b/scripts/buildHomebrew.js
@@ -138,7 +138,9 @@ fs.emptyDirSync('./build');
 //In development set up a watch server and livereload
 if(isDev){
 	livereload('./build');
-	watchFile('./server.js', {
-		watch : ['./client', './server', './themes'] // Watch additional folders if you want
+	watchFile('./server.js', { // Rebuild when change detected to this file or any nested directory from here
+		ignore : ['./build'],    // Ignore ./build or it will rebuild again
+		ext    : 'less',             // Other extensions to watch (only .js/.json/.jsx by default)
+		//watch: ['./client', './server', './themes'], // Watch additional folders if you want
 	});
 }


### PR DESCRIPTION
Fixes #2836 

Makes two changes to the `buildHomebrew.js` build script:

1) Ignore the `./build` folder when monitoring for changes to auto-rebuild. Prevents double-rebuild which delays server restart.
2) Add `.less` extension as a filetype to monitor (by default, Nodemon only monitors `.js`-related files. Should speed styles development.