### PR TITLE
[Docker] - Bump Node from 16.13 to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.13-alpine
+FROM node:18-alpine
 RUN apk --no-cache add git
 
 ENV NODE_ENV=docker


### PR DESCRIPTION
This PR resolves #2861.

This PR increases the version of the Alpine image used in the Docker build from v16.13 to v18. This will hopefully put the Docker image several versions ahead of any imminent package dependency requirements.