### PR TITLE
Fix google links with10 char shareid

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -324,8 +324,8 @@ app.get('/share/:id', asyncHandler(getBrew('share')), asyncHandler(async (req, r
 	};
 
 	if(req.params.id.length > 12 && !brew._id) {
-		const googleId = req.params.id.slice(0, -12);
-		const shareId = req.params.id.slice(-12);
+		const googleId = brew.googleId;
+		const shareId = brew.shareId;
 		await GoogleActions.increaseView(googleId, shareId, 'share', brew)
 			.catch((err)=>{next(err);});
 	} else {

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -100,12 +100,12 @@ const GoogleActions = {
 		const drive = googleDrive.drive({ version: 'v3', auth });
 
 		const fileList = [];
-		let NextPageToken = "";
+		let NextPageToken = '';
 
 		do {
 			const obj = await drive.files.list({
 				pageSize  : 1000,
-				pageToken : NextPageToken || "",
+				pageToken : NextPageToken || '',
 				fields    : 'nextPageToken, files(id, name, description, createdTime, modifiedTime, properties)',
 				q         : 'mimeType != \'application/vnd.google-apps.folder\' and trashed = false'
 			})
@@ -243,9 +243,9 @@ const GoogleActions = {
 
 		if(obj) {
 			if(accessType == 'edit' && obj.data.properties.editId != accessId){
-				throw ('Edit ID does not match');
+				throw ({ message: 'Edit ID does not match' });
 			} else if(accessType == 'share' && obj.data.properties.shareId != accessId){
-				throw ('Share ID does not match');
+				throw ({ message: 'Share ID does not match' });
 			}
 
 			const file = await drive.files.get({

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -27,8 +27,13 @@ const api = {
 
 		// If the id is longer than 12, then it's a google id + the edit id. This splits the longer id up.
 		if(id.length > 12) {
-			googleId = id.slice(0, -12);
-			id = id.slice(-12);
+			if(id.length >= (33 + 12)) {    // googleId is minimum 33 chars (may increase)
+				googleId = id.slice(0, -12);  // current editId is 12 chars
+			} else {                        // old editIds used to be 10 chars;
+				googleId = id.slice(0, -10);  // if total string is too short, must be old brew
+				console.log('Old brew, using 10-char Id');
+			}
+			id = id.slice(googleId.length);
 		}
 		return { id, googleId };
 	},

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -111,15 +111,26 @@ describe('Tests for api', ()=>{
 			expect(googleId).toEqual('12345');
 		});
 
-		it('should return id and google id from params', ()=>{
+		it('should return 12-char id and google id from params', ()=>{
 			const { id, googleId } = api.getId({
 				params : {
-					id : '123456789012abcdefghijkl'
+					id : '123456789012345678901234567890123abcdefghijkl'
 				}
 			});
-
+			
+			expect(googleId).toEqual('123456789012345678901234567890123');
 			expect(id).toEqual('abcdefghijkl');
-			expect(googleId).toEqual('123456789012');
+		});
+
+		it('should return 10-char id and google id from params', ()=>{
+			const { id, googleId } = api.getId({
+				params : {
+					id : '123456789012345678901234567890123abcdefghij'
+				}
+			});
+			
+			expect(googleId).toEqual('123456789012345678901234567890123');
+			expect(id).toEqual('abcdefghij');
 		});
 	});
 


### PR DESCRIPTION
Fixes #2917 .

Simply checks the total length of a Google brew URL to determine whether the attached shareId is 12 chars or 10 chars.

Also updates the associated error "ShareID is not valid" so the `message:` property displays properly on our error page.