### PR TITLE
Fix Nodemon config in `buildHomebrew.js`

### DIFF
--- a/scripts/buildHomebrew.js
+++ b/scripts/buildHomebrew.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 const zlib = require('zlib');
 const Proj = require('./project.json');
 
-const { pack, watchFile, livereload } = require('vitreum');
+const { pack, watchFile } = require('vitreum');
 const isDev = !!process.argv.find((arg)=>arg=='--dev');
 
 const lessTransform  = require('vitreum/transforms/less.js');
@@ -135,12 +135,11 @@ fs.emptyDirSync('./build');
 
 })().catch(console.error);
 
-//In development set up a watch server and livereload
+//In development, set up a watch server (uses Nodemon)
 if(isDev){
-	livereload('./build');
-	watchFile('./server.js', { // Rebuild when change detected to this file or any nested directory from here
-		ignore : ['./build'],    // Ignore ./build or it will rebuild again
-		ext    : 'less',             // Other extensions to watch (only .js/.json/.jsx by default)
-		//watch: ['./client', './server', './themes'], // Watch additional folders if you want
+	watchFile('./server.js', { // Restart server when change detected to this file or any nested directory from here
+		ignore : ['./build', './client', './themes'],  // Ignore folders that are not running server code / avoids unneeded restarts
+		ext    : 'js json'                             // Extensions to watch (only .js/.json by default)
+		//watch : ['./server', './themes'],            // Watch additional folders if needed
 	});
 }


### PR DESCRIPTION
Due to a misunderstanding of how the build file worked (see https://github.com/naturalcrit/homebrewery/issues/2909#issuecomment-1622294460), the Nodemon server restart configuration was not working properly. This ensures that Nodemon restarts when server files of type `.js` or `.json` are edited. Previously only `.less` files were triggering restarts, as we wrongly assumed this was the package bundler monitor.

Also removes `liveReload` which does nothing, as the Chrome Extension needed to use it no longer works.