### PR TITLE
exclude covers from TOC generation

### DIFF
--- a/themes/V3/5ePHB/snippets/tableOfContents.gen.js
+++ b/themes/V3/5ePHB/snippets/tableOfContents.gen.js
@@ -29,21 +29,23 @@ const getTOC = (pages)=>{
 
 	const res = [];
 	_.each(pages, (page, pageNum)=>{
-		const lines = page.split('\n');
-		_.each(lines, (line)=>{
-			if(_.startsWith(line, '# ')){
-				const title = line.replace('# ', '');
-				add1(title, pageNum);
-			}
-			if(_.startsWith(line, '## ')){
-				const title = line.replace('## ', '');
-				add2(title, pageNum);
-			}
-			if(_.startsWith(line, '### ')){
-				const title = line.replace('### ', '');
-				add3(title, pageNum);
-			}
-		});
+		if(!page.includes("{{frontCover}}") && !page.includes("{{insideCover}}") && !page.includes("{{partCover}}") && !page.includes("{{backCover}}")) {
+			const lines = page.split('\n');
+			_.each(lines, (line)=>{
+				if(_.startsWith(line, '# ')){
+					const title = line.replace('# ', '');
+					add1(title, pageNum);
+				}
+				if(_.startsWith(line, '## ')){
+					const title = line.replace('## ', '');
+					add2(title, pageNum);
+				}
+				if(_.startsWith(line, '### ')){
+					const title = line.replace('### ', '');
+					add3(title, pageNum);
+				}
+			});
+		}
 	});
 	return res;
 };


### PR DESCRIPTION
Fixes #2920 

there is still the matter that h3 should be ignored to keep the theme true to the book standard, but i feel it would be detrimental to the user experience overall.