### PR TITLE
Simple adjustments for mobile viewing

### DIFF
--- a/client/template.js
+++ b/client/template.js
@@ -11,8 +11,7 @@ const template = async function(name, title='', props = {}){
 	return `<!DOCTYPE html>
 	<html>
 		<head>
-			<meta name="viewport" content="width=device-width, initial-scale=1" />
-
+			<meta name="viewport" content="width=device-width, initial-scale=1, height=device-height, interactive-widget=resizes-visual" />
 			<link href="//use.fontawesome.com/releases/v5.15.1/css/all.css" rel="stylesheet" />
 			<link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css" />
 			<link href=${`/${name}/bundle.css`} rel='stylesheet' />

--- a/client/template.js
+++ b/client/template.js
@@ -11,6 +11,8 @@ const template = async function(name, title='', props = {}){
 	return `<!DOCTYPE html>
 	<html>
 		<head>
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+
 			<link href="//use.fontawesome.com/releases/v5.15.1/css/all.css" rel="stylesheet" />
 			<link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css" />
 			<link href=${`/${name}/bundle.css`} rel='stylesheet' />

--- a/shared/naturalcrit/codeEditor/codeEditor.less
+++ b/shared/naturalcrit/codeEditor/codeEditor.less
@@ -9,6 +9,9 @@
 }
 
 .codeEditor{
+  @media screen and (pointer : coarse) {
+    font-size : 16px;
+  }
   .CodeMirror-foldmarker {
     font-family: inherit;
     text-shadow: none;

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -61,7 +61,8 @@ const SplitPane = createClass({
 		return result;
 	},
 
-	handleUp : function(){
+	handleUp : function(e){
+		e.preventDefault();
 		if(this.state.isDragging){
 			this.props.onDragFinish(this.state.currentDividerPos);
 			window.localStorage.setItem(this.props.storageKey, this.state.currentDividerPos);
@@ -76,6 +77,8 @@ const SplitPane = createClass({
 	},
 
 	handleMove : function(e){
+
+		e.preventDefault();
 		if(!this.state.isDragging) return;
 
 		const newSize = this.limitPosition(e.pageX);

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -122,7 +122,7 @@ const SplitPane = createClass({
 	renderDivider : function(){
 		return <>
 			{this.renderMoveArrows()}
-			<div className='divider' onMouseDown={this.handleDown} >
+			<div className='divider' onPointerDown={this.handleDown} >
 				<div className='dots'>
 					<i className='fas fa-circle' />
 					<i className='fas fa-circle' />
@@ -133,7 +133,7 @@ const SplitPane = createClass({
 	},
 
 	render : function(){
-		return <div className='splitPane' onMouseMove={this.handleMove} onMouseUp={this.handleUp}>
+		return <div className='splitPane' onPointerMove={this.handleMove} onPointerUp={this.handleUp}>
 			<Pane
 				ref='pane1'
 				width={this.state.currentDividerPos}

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -125,7 +125,7 @@ const SplitPane = createClass({
 	renderDivider : function(){
 		return <>
 			{this.renderMoveArrows()}
-			<div className='divider' onPointerDown={this.handleDown} >
+			<div className='divider' onPointerDown={this.handleDown}  onPointerMove={this.handleMove} onPointerUp={this.handleUp} >
 				<div className='dots'>
 					<i className='fas fa-circle' />
 					<i className='fas fa-circle' />
@@ -136,7 +136,7 @@ const SplitPane = createClass({
 	},
 
 	render : function(){
-		return <div className='splitPane' onPointerMove={this.handleMove} onPointerUp={this.handleUp}>
+		return <div className='splitPane'>
 			<Pane
 				ref='pane1'
 				width={this.state.currentDividerPos}

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -63,6 +63,7 @@ const SplitPane = createClass({
 
 	handleUp : function(e){
 		e.preventDefault();
+		console.log('up');
 		if(this.state.isDragging){
 			this.props.onDragFinish(this.state.currentDividerPos);
 			window.localStorage.setItem(this.props.storageKey, this.state.currentDividerPos);
@@ -72,6 +73,8 @@ const SplitPane = createClass({
 
 	handleDown : function(e){
 		e.preventDefault();
+
+		console.log('down');
 		this.setState({ isDragging: true });
 		//this.unFocus()
 	},
@@ -79,6 +82,8 @@ const SplitPane = createClass({
 	handleMove : function(e){
 
 		e.preventDefault();
+
+		console.log('move');
 		if(!this.state.isDragging) return;
 
 		const newSize = this.limitPosition(e.pageX);
@@ -125,7 +130,7 @@ const SplitPane = createClass({
 	renderDivider : function(){
 		return <>
 			{this.renderMoveArrows()}
-			<div className='divider' onPointerDown={this.handleDown}  onPointerMove={this.handleMove} onPointerUp={this.handleUp} >
+			<div className='divider' onPointerDown={this.handleDown} >
 				<div className='dots'>
 					<i className='fas fa-circle' />
 					<i className='fas fa-circle' />
@@ -136,7 +141,7 @@ const SplitPane = createClass({
 	},
 
 	render : function(){
-		return <div className='splitPane'>
+		return <div className='splitPane' onPointerMove={this.handleMove} onPointerUp={this.handleUp}>
 			<Pane
 				ref='pane1'
 				width={this.state.currentDividerPos}

--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -63,7 +63,6 @@ const SplitPane = createClass({
 
 	handleUp : function(e){
 		e.preventDefault();
-		console.log('up');
 		if(this.state.isDragging){
 			this.props.onDragFinish(this.state.currentDividerPos);
 			window.localStorage.setItem(this.props.storageKey, this.state.currentDividerPos);
@@ -73,17 +72,12 @@ const SplitPane = createClass({
 
 	handleDown : function(e){
 		e.preventDefault();
-
-		console.log('down');
 		this.setState({ isDragging: true });
 		//this.unFocus()
 	},
 
 	handleMove : function(e){
-
 		e.preventDefault();
-
-		console.log('move');
 		if(!this.state.isDragging) return;
 
 		const newSize = this.limitPosition(e.pageX);

--- a/shared/naturalcrit/splitPane/splitPane.less
+++ b/shared/naturalcrit/splitPane/splitPane.less
@@ -1,5 +1,6 @@
 
 .splitPane{
+	touch-action: none;
 	position       : relative;
 	display        : flex;
 	height         : 100%;

--- a/shared/naturalcrit/splitPane/splitPane.less
+++ b/shared/naturalcrit/splitPane/splitPane.less
@@ -1,6 +1,5 @@
 
 .splitPane{
-	touch-action: none;
 	position       : relative;
 	display        : flex;
 	height         : 100%;
@@ -12,6 +11,7 @@
 		flex       : 1;
 	}
 	.divider{
+		touch-action     : none;
 		display          : table;
 		height           : 100%;
 		width            : 15px;


### PR DESCRIPTION
This PR takes a few simple steps to improve the mobile aspect of the app without going to far into the weeds.

It adds a `viewport` meta tag to set the initial size of the app to the device width and height (edit: I totally missed that we already have this meta tag, even when i *looked* for it).  This isn't perfect, because the mobile browsers (at least iOS browsers) cover a portion of the viewport with their address bars or other items like that, but it's better.  Further improvement could likely be done by utilizing `window.screen.availHeight` or some such, but I didn't want to get into the JS of it all.

It also changes the `onmousedown` and similar events on the splitView component, and uses `onpointerdown` etc.  Now the divider bar can be moved with a touch.  One improvement that I'm a little stuck on is that the pointer event seems to require a 'hard press' or long press on the divider before it "picks it up" and allows you to move it.  I wasn't sure if this was a bad thing, though.

This PR doesn't touch any real CSS, doesn't move buttons around, so everything is basically the same. It still works on desktop.

I used my iphone with Safari and Firefox (webkit) to test it.  