### PR TITLE
Add Google file link to UserPage BrewItem

### DIFF
--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -94,7 +94,9 @@ const BrewItem = createClass({
 		if(!this.props.brew.googleId) return;
 
 		return <span>
-			<img className='googleDriveIcon' src={googleDriveIcon} alt='googleDriveIcon' />
+			<a href={this.props.brew.webViewLink} target='_blank'>
+				<img className='googleDriveIcon' src={googleDriveIcon} alt='googleDriveIcon' />
+			</a>
 		</span>;
 	},
 

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -92,14 +92,16 @@ const BrewItem = createClass({
 	},
 
 	renderStorageIcon : function(){
-		if(!this.props.brew.googleId) return <span title='Internal Homebrewery Database'>
-			<img className='homebreweryIcon' src={homebreweryIcon} alt='homebreweryIcon' />
-		</span>;
+		if(this.props.brew.googleId) {
+			return <span title={this.props.brew.webViewLink ? 'Your Google Drive Storage': 'Another User\'s Google Drive Storage'}>
+				<a href={this.props.brew.webViewLink} target='_blank'>
+					<img className='googleDriveIcon' src={googleDriveIcon} alt='googleDriveIcon' />
+				</a>
+			</span>;
+		}
 
-		return <span title='Google Drive Storage'>
-			<a href={this.props.brew.webViewLink} target='_blank'>
-				<img className='googleDriveIcon' src={googleDriveIcon} alt='googleDriveIcon' />
-			</a>
+		return <span title='Homebrewery Storage'>
+			<img className='homebreweryIcon' src={homebreweryIcon} alt='homebreweryIcon' />
 		</span>;
 	},
 

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.jsx
@@ -7,6 +7,7 @@ const moment = require('moment');
 const request = require('../../../../utils/request-middleware.js');
 
 const googleDriveIcon = require('../../../../googleDrive.svg');
+const homebreweryIcon = require('../../../../thumbnail.png');
 const dedent = require('dedent-tabs').default;
 
 const BrewItem = createClass({
@@ -90,10 +91,12 @@ const BrewItem = createClass({
 		</a>;
 	},
 
-	renderGoogleDriveIcon : function(){
-		if(!this.props.brew.googleId) return;
+	renderStorageIcon : function(){
+		if(!this.props.brew.googleId) return <span title='Internal Homebrewery Database'>
+			<img className='homebreweryIcon' src={homebreweryIcon} alt='homebreweryIcon' />
+		</span>;
 
-		return <span>
+		return <span title='Google Drive Storage'>
 			<a href={this.props.brew.webViewLink} target='_blank'>
 				<img className='googleDriveIcon' src={googleDriveIcon} alt='googleDriveIcon' />
 			</a>
@@ -146,7 +149,7 @@ const BrewItem = createClass({
 					Last updated: ${moment(brew.updatedAt).local().format(dateFormatString)}`}>
 					<i className='fas fa-sync-alt' /> {moment(brew.updatedAt).fromNow()}
 				</span>
-				{this.renderGoogleDriveIcon()}
+				{this.renderStorageIcon()}
 			</div>
 
 			<div className='links'>

--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
@@ -98,4 +98,11 @@
 		padding : 0px;
 		margin  : -5px;
 	}
+	.homebreweryIcon {
+		mix-blend-mode : darken;
+		height         : 24px;
+		position       : relative;
+		top            : 5px;
+		left           : -5px;
+	}
 }

--- a/server/app.js
+++ b/server/app.js
@@ -257,6 +257,7 @@ app.get('/user/:username', async (req, res, next)=>{
 					brew.pageCount = googleBrews[match].pageCount;
 					brew.renderer = googleBrews[match].renderer;
 					brew.version = googleBrews[match].version;
+					brew.webViewLink = googleBrews[match].webViewLink;
 					googleBrews.splice(match, 1);
 				}
 			}

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -106,7 +106,7 @@ const GoogleActions = {
 			const obj = await drive.files.list({
 				pageSize  : 1000,
 				pageToken : NextPageToken || '',
-				fields    : 'nextPageToken, files(id, name, description, createdTime, modifiedTime, properties)',
+				fields    : 'nextPageToken, files(id, name, description, createdTime, modifiedTime, properties, webViewLink)',
 				q         : 'mimeType != \'application/vnd.google-apps.folder\' and trashed = false'
 			})
 			.catch((err)=>{
@@ -139,7 +139,8 @@ const GoogleActions = {
 				published   : file.properties.published ? file.properties.published == 'true' : false,
 				systems     : [],
 				lang        : file.properties.lang,
-				thumbnail   : file.properties.thumbnail
+				thumbnail   : file.properties.thumbnail,
+				webViewLink : file.webViewLink
 			};
 		});
 	  return brews;


### PR DESCRIPTION
This PR follows up on a side issue raised in #2954.

This PR adds a link to the file on Google Drive via the Drive Icon on the User Page. In the event that a user cannot find their brew document but it does still exist in their Drive somewhere, they can use this link to locate the file.