### PR TITLE
Fix save location logic

### DIFF
--- a/client/homebrew/pages/accountPage/accountPage.jsx
+++ b/client/homebrew/pages/accountPage/accountPage.jsx
@@ -35,7 +35,7 @@ const AccountPage = createClass({
 		if(!this.state.saveLocation && this.props.uiItems.username) {
 			SAVEKEY = `HOMEBREWERY-DEFAULT-SAVE-LOCATION-${this.props.uiItems.username}`;
 			let saveLocation =  window.localStorage.getItem(SAVEKEY);
-			saveLocation = saveLocation ?? this.state.uiItems.googleId ? 'GOOGLE-DRIVE' : 'HOMEBREWERY';
+			saveLocation = saveLocation ?? (this.state.uiItems.googleId ? 'GOOGLE-DRIVE' : 'HOMEBREWERY');
 			this.makeActive(saveLocation);
 		}
 	},


### PR DESCRIPTION
The PR fixes #2993.

This PR corrects an issue with the reading of the default save location that was incorrectly returning Google Drive for all Drive-linked accounts, regardless of the user-selected setting.