### PR TITLE
Move e.preventDefault to after isDragging check

### DIFF
--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -77,9 +77,9 @@ const SplitPane = createClass({
 	},
 
 	handleMove : function(e){
-		e.preventDefault();
 		if(!this.state.isDragging) return;
 
+		e.preventDefault();
 		const newSize = this.limitPosition(e.pageX);
 		this.setState({
 			currentDividerPos : newSize,


### PR DESCRIPTION
This PR resolves #2996.

This PR moves the `preventDefault` call to after the `isDragging` check, so it should only fire when the center divider is being moved.