### PR TITLE
Move save location logic out of ShareID check

### DIFF
--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -50,14 +50,12 @@ const NewPage = createClass({
 		document.addEventListener('keydown', this.handleControlKeys);
 
 		const brew = this.state.brew;
+		const output = {};
 
 		if(!this.props.brew.shareId && typeof window !== 'undefined') { //Load from localStorage if in client browser
 			const brewStorage  = localStorage.getItem(BREWKEY);
 			const styleStorage = localStorage.getItem(STYLEKEY);
 			const metaStorage = JSON.parse(localStorage.getItem(METAKEY));
-
-			SAVEKEY = `HOMEBREWERY-DEFAULT-SAVE-LOCATION-${global.account?.username || ''}`;
-			const saveStorage = localStorage.getItem(SAVEKEY) || 'HOMEBREWERY';
 
 			brew.text  = brewStorage  ?? brew.text;
 			brew.style = styleStorage ?? brew.style;
@@ -67,11 +65,14 @@ const NewPage = createClass({
 			brew.theme    = metaStorage?.theme    ?? brew.theme;
 			brew.lang     = metaStorage?.lang     ?? brew.lang;
 
-			this.setState({
-				brew       : brew,
-				saveGoogle : (saveStorage == 'GOOGLE-DRIVE' && this.state.saveGoogle)
-			});
+			output.brew = brew;
 		}
+
+		SAVEKEY = `HOMEBREWERY-DEFAULT-SAVE-LOCATION-${global.account?.username || ''}`;
+		const saveStorage = localStorage.getItem(SAVEKEY) || 'HOMEBREWERY';
+		output.saveGoogle = (saveStorage == 'GOOGLE-DRIVE' && this.state.saveGoogle);
+
+		this.setState(output);
 
 		localStorage.setItem(BREWKEY, brew.text);
 		if(brew.style)

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -50,7 +50,6 @@ const NewPage = createClass({
 		document.addEventListener('keydown', this.handleControlKeys);
 
 		const brew = this.state.brew;
-		const output = {};
 
 		if(!this.props.brew.shareId && typeof window !== 'undefined') { //Load from localStorage if in client browser
 			const brewStorage  = localStorage.getItem(BREWKEY);
@@ -64,15 +63,15 @@ const NewPage = createClass({
 			brew.renderer = metaStorage?.renderer ?? brew.renderer;
 			brew.theme    = metaStorage?.theme    ?? brew.theme;
 			brew.lang     = metaStorage?.lang     ?? brew.lang;
-
-			output.brew = brew;
 		}
 
 		SAVEKEY = `HOMEBREWERY-DEFAULT-SAVE-LOCATION-${global.account?.username || ''}`;
 		const saveStorage = localStorage.getItem(SAVEKEY) || 'HOMEBREWERY';
-		output.saveGoogle = (saveStorage == 'GOOGLE-DRIVE' && this.state.saveGoogle);
 
-		this.setState(output);
+		this.setState({
+			brew       : brew,
+			saveGoogle : (saveStorage == 'GOOGLE-DRIVE' && this.state.saveGoogle)
+		});
 
 		localStorage.setItem(BREWKEY, brew.text);
 		if(brew.style)


### PR DESCRIPTION
This PR resolves #2998.

This PR moves the save location logic out of the `shareId` check, ensuring that it runs for cloned Brew documents.