### PR TITLE
Fix FreeBSD Install Script

### DIFF
--- a/install/freebsd/install.sh
+++ b/install/freebsd/install.sh
@@ -13,7 +13,7 @@ npm install
 npm audit fix
 npm run postinstall
 
-cp freebsd/rc.d/homebrewery /usr/local/etc/rc.d/
+cp install/freebsd/rc.d/homebrewery /usr/local/etc/rc.d/
 chmod +x /usr/local/etc/rc.d/homebrewery
 
 sysrc homebrewery_enable=YES


### PR DESCRIPTION
This PR resolves #3005.

This PR corrects the location of the FreeBSD service file to its current location in the repository, allowing the script to once again complete correctly.