### PR TITLE
Shift manual save to use debounced save function

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -91,7 +91,7 @@ const EditPage = createClass({
 		if(!(e.ctrlKey || e.metaKey)) return;
 		const S_KEY = 83;
 		const P_KEY = 80;
-		if(e.keyCode == S_KEY) this.save();
+		if(e.keyCode == S_KEY) this.trySave(true);
 		if(e.keyCode == P_KEY) window.open(`/print/${this.processShareId()}?dialog=true`, '_blank').focus();
 		if(e.keyCode == P_KEY || e.keyCode == S_KEY){
 			e.stopPropagation();
@@ -137,13 +137,14 @@ const EditPage = createClass({
 		return !_.isEqual(this.state.brew, this.savedBrew);
 	},
 
-	trySave : function(){
+	trySave : function(immediate=false){
 		if(!this.debounceSave) this.debounceSave = _.debounce(this.save, SAVE_TIMEOUT);
 		if(this.hasChanges()){
 			this.debounceSave();
 		} else {
 			this.debounceSave.cancel();
 		}
+		if(immediate) this.debounceSave.flush();
 	},
 
 	handleGoogleClick : function(){


### PR DESCRIPTION
This PR resolves #2641.

This PR shifts the manual save process to use the same debounced save function as the auto-save functionality. This will eliminate the race condition that leads to the version mismatch error ("This brew has been changed on another device").

As every change triggers the debounced autosave function, this change causes the pending function to be fired immediately using Lodash's built-in `flush` function. This also has the happy side effect of clearing the pending autosave when the manual save is triggered early, reducing the total number of save (and thus DB writes).