### PR TITLE
Add basic localStorage mechanism to check user status at save

### DIFF
--- a/client/homebrew/navbar/account.navitem.jsx
+++ b/client/homebrew/navbar/account.navitem.jsx
@@ -32,6 +32,7 @@ const Account = createClass({
 				}
 				domain = domainArray.join('.');
 			}
+			window.localStorage.removeItem('username');
 			document.cookie = `nc_session=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/;samesite=lax;${domain ? `domain=${domain}` : ''}`;
 			window.location = '/';
 		}
@@ -53,7 +54,7 @@ const Account = createClass({
 					console.warn(err);
 				});
 		if(!token) return;
-
+		window.localStorage.setItem('username', username);
 		document.cookie = `nc_session=${token};expires=${expiry};path=/;samesite=lax;${window.domain ? `domain=${window.domain}` : ''}`;
 		window.location.reload(true);
 	},

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -183,6 +183,13 @@ const EditPage = createClass({
 	save : async function(){
 		if(this.debounceSave && this.debounceSave.cancel) this.debounceSave.cancel();
 
+		if(this.state.brew.authors.includes(window.localStorage.getItem('username') || '') == false){
+			console.log('not logged in');
+			return;
+		};
+
+
+
 		this.setState((prevState)=>({
 			isSaving   : true,
 			error      : null,


### PR DESCRIPTION
This is a draft, and likely a weak one, to fix #2975.  It doesn't pop any error right now besides a little message in the console.  It also only works on **LOCAL** because I didn't want to dig into the NaturalCrit system (I thought I might have to) and because I'm sort of doubtful this is the best method anyway.  

### Method
This is basically creating a localStorage key `username` anytime you do a local login.  Then, if you are logged in with multiple tabs, if you log out from any of those tabs the localStorage key is deleted which updates in all tabs.  When you try to save in any of those tabs it checks for that `username` key and only continues with the save if the key exists.

### Possible alternatives and concerns
I wanted to try checking not just that the user was signed in, but was the correct user (in case they sign out and switch accounts in one tab, and try to save in another), so I'm dropping the username into localStorage.  If we didn't care about that, we could just check for the existence of the nc_session cookie.  

I'm not super sure on security of this?  I'm nervous that someone could just change the localStorage key value to whatever they want....but not sure what that would accomplish?  

I'm not very sure about how the log-in system works on the production site, and I don't think i'm ready to learn(?), so maybe this method won't translate well.

It'd be neat to immediately show the effect of logging out across all open tabs, right in the navbar:  when you log out, it could automatically update the `<Account />` menu component to remove the username.  As I was reading, I thought I saw a method of doing this with React Router but I didn't dig into it.  Possibly it's easier in newer React with useContext()?