### PR TITLE
\page as Marked token

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -36,7 +36,8 @@ const BrewRenderer = createClass({
 		if(this.props.renderer == 'legacy') {
 			pages = this.props.text.split('\\page');
 		} else {
-			pages = this.props.text.split(/^\\page$/gm);
+			// pages = this.props.text.split(/^\\page$/gm);
+			pages = [this.props.text];
 		}
 
 		return {
@@ -68,7 +69,7 @@ const BrewRenderer = createClass({
 			if(this.props.renderer == 'legacy') {
 				pages = this.props.text.split('\\page');
 			} else {
-				pages = this.props.text.split(/^\\page$/gm);
+				pages = [this.props.text];
 			}
 			this.setState({
 				pages  : pages,
@@ -149,13 +150,11 @@ const BrewRenderer = createClass({
 	renderPage : function(pageText, index){
 		let cleanPageText = this.sanitizeScriptTags(pageText);
 		if(this.props.renderer == 'legacy')
-			return <div className='phb page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(cleanPageText) }} key={index} />;
+			return <div className='pages' ref='pages' lang={`${this.props.lang || 'en'}`}><div className='phb page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(cleanPageText) }} key={index} /></div>;
 		else {
 			cleanPageText += `\n\n&nbsp;\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
 			return (
-				<div className='page' id={`p${index + 1}`} key={index} >
-					<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: Markdown.render(cleanPageText) }} />
-				</div>
+				<div className='pages' ref='pages' lang={`${this.props.lang || 'en'}`} dangerouslySetInnerHTML={{ __html: Markdown.render(cleanPageText || ' ') }} />
 			);
 		}
 	},
@@ -239,9 +238,7 @@ const BrewRenderer = createClass({
 							&&
 							<>
 								{this.renderStyle()}
-								<div className='pages' ref='pages' lang={`${this.props.lang || 'en'}`}>
-									{this.renderPages()}
-								</div>
+								{this.renderPages()}
 							</>
 						}
 					</div>

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -113,6 +113,7 @@ const BrewRenderer = createClass({
 
 	shouldRender : function(pageText, index){
 		if(!this.state.isMounted) return false;
+		if(this.props.renderer == 'V3') return true;
 
 		const viewIndex = this.state.viewablePageNumber;
 		if(index == viewIndex - 3) return true;
@@ -172,9 +173,10 @@ const BrewRenderer = createClass({
 		if(this.props.renderer == 'legacy')
 			return <div className='pages' ref='pages' lang={`${this.props.lang || 'en'}`}><div className='phb page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(cleanPageText) }} key={index} /></div>;
 		else {
-			cleanPageText += `\n\n&nbsp;\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
+			cleanPageText = cleanPageText.split(/^\\page$/gm).join(`\n\n&nbsp;\n\\column\n&nbsp;\n\\page\n`); //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
+
 			return (
-				<div className='pages' ref='pages' lang={`${this.props.lang || 'en'}`} dangerouslySetInnerHTML={{ __html: Markdown.render(cleanPageText || ' ', this.state.usePPR ? this.state.viewablePageNumber : -1, 2) }} />
+				<div className='pages' ref='pages' lang={`${this.props.lang || 'en'}`} dangerouslySetInnerHTML={{ __html: Markdown.render(cleanPageText || ' ', this.state.usePPR ? this.state.viewablePageNumber : -1, 3) }} />
 			);
 		}
 	},

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -117,7 +117,9 @@ const api = {
 	},
 	getGoodBrewTitle : (text)=>{
 		let tokens = Markdown.marked.lexer(text);
-		if(tokens[0].type == 'pageBlock') { tokens = tokens[0].tokens; };
+		while (tokens[0].type == 'pageBlock'){
+			tokens = tokens[0].tokens;
+		};
 		return (tokens.find((token)=>token.type === 'heading' || token.type === 'paragraph')?.text || 'No Title')
 			.slice(0, MAX_TITLE_LENGTH);
 	},

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -116,7 +116,8 @@ const api = {
 		return text;
 	},
 	getGoodBrewTitle : (text)=>{
-		const tokens = Markdown.marked.lexer(text);
+		let tokens = Markdown.marked.lexer(text);
+		if(tokens[0].type == 'pageBlock') { tokens = tokens[0].tokens; };
 		return (tokens.find((token)=>token.type === 'heading' || token.type === 'paragraph')?.text || 'No Title')
 			.slice(0, MAX_TITLE_LENGTH);
 	},

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -433,7 +433,7 @@ const processStyleTags = (string)=>{
 
 module.exports = {
 	marked : Marked,
-	render : (rawBrewText, pageToRender = -1, pageRange = 2)=>{
+	render : (rawBrewText, pageToRender = -1, pageRange = 3)=>{
 		rawBrewText = rawBrewText.replace(/^\\column$/gm, `\n<div class='columnSplit'></div>\n`)
 														 .replace(/^(:+)$/gm, (match)=>`${`<div class='blank'></div>`.repeat(match.length)}\n`);
 		targetPage = pageToRender;

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -12,9 +12,9 @@ renderer.html = function (html) {
 		const openTag = html.substring(0, html.indexOf('>')+1);
 		html = html.substring(html.indexOf('>')+1);
 		html = html.substring(0, html.lastIndexOf('</div>'));
-		hasPageBlockParent = true;
+		isInsidePageBlock = true;
 		html = `${openTag} ${Marked.parse(html)} </div>`;
-		hasPageBlockParent = false;
+		isInsidePageBlock = false;
 	}
 	return html;
 };
@@ -270,7 +270,7 @@ const definitionLists = {
 	}
 };
 
-let hasPageBlockParent = false;
+let isInsidePageBlock = false;
 let pageBlockNumber = 0;
 let targetPage = -1;
 let targetRange = 0;
@@ -279,12 +279,12 @@ const pageBlocks = {
 		name  : 'pageBlock',
 		level : 'block',
 		tokenizer(src, tokens) {
-			if(hasPageBlockParent) return false;
-			const pageArray = src.split(/^\\page$/gm, 1);
-			if(this.lexer.tokens?.length == 0 && this.lexer.state.top) pageBlockNumber = 0;
+			if(isInsidePageBlock) return false;
+			const pageArray = src.split(/^(\\page)$/gm, 2);
+			if(tokens?.length == 0 && this.lexer.state.top) pageBlockNumber = 0;
 			pageBlockNumber++;
 
-			const rawText = src.length > pageArray[0].length ? `${pageArray[0]}\\page` : pageArray[0];
+			const rawText = pageArray.join();
 
 			const token = {
 				type       : 'pageBlock',
@@ -299,9 +299,9 @@ const pageBlocks = {
 				token.prune = true;
 			}
 
-			hasPageBlockParent = true;
+			isInsidePageBlock = true;
 			this.lexer.blockTokens(token.text, token.tokens);
-			hasPageBlockParent = false;
+			isInsidePageBlock = false;
 
 			return token;
 		},

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -306,7 +306,8 @@ const pageBlocks = {
 		renderer(token) {
 			return `<div class='page' id='p${token.pageNumber}' key=${token.pageNumber}>\n${this.parser.parse(token.tokens)}</div>`;
 		}
-	}, {
+	},
+	{
 		name  : 'hiddenBlock',
 		level : 'block',
 		renderer(token) {
@@ -319,7 +320,7 @@ const pageBlocks = {
 
 		if(token.prune) {
 			token.tokens?.forEach((childToken)=>{
-				if(!permittedTypes.includes(childToken.type)) {
+				if(!permittedTypes.includes(childToken.type) ||	(childToken.type == 'html' && !(childToken.text?.match('id=') || childToken.text?.startsWith('<style')))) {
 					childToken.originalType = childToken.type;
 					childToken.type = 'hiddenBlock';
 				};

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -320,7 +320,7 @@ const pageBlocks = {
 
 		if(token.prune) {
 			token.tokens?.forEach((childToken)=>{
-				if(!permittedTypes.includes(childToken.type) ||	(childToken.type == 'html' && !(childToken.text?.match('id=') || childToken.text?.startsWith('<style')))) {
+				if(!permittedTypes.includes(childToken.type) ||	(childToken.type == 'html' && !(childToken.text?.match(/id=/i) || childToken.text?.startsWith('<style')))) {
 					childToken.originalType = childToken.type;
 					childToken.type = 'hiddenBlock';
 				};

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -295,7 +295,7 @@ const pageBlocks = {
 				tokens     : []
 			};
 
-			if(targetPage > 0 && (token.pageNumber < (targetPage - targetRange) || token.pageNumber > (targetPage + targetRange))) {
+			if(targetPage > 0 && Math.abs(targetPage- token.pageNumber) > targetRange) {
 				token.prune = true;
 			}
 

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -282,9 +282,11 @@ const pageBlocks = {
 			if(this.lexer.tokens?.length == 0 && this.lexer.state.top) pageBlockNumber = 0;
 			pageBlockNumber++;
 
+			const rawText = src.length > pageArray[0].length ? `${pageArray[0]}\\page` : pageArray[0];
+
 			const token = {
 				type       : 'pageBlock',
-				raw        : `${pageArray[0]}\\page`,
+				raw        : rawText,
 				text       : pageArray[0],
 				pageNumber : pageBlockNumber,
 				prune      : false,

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -270,6 +270,8 @@ const definitionLists = {
 
 let pageBlockTopLevel = true;
 let pageBlockNumber = 0;
+let targetPage = -1;
+let targetRange = 0;
 const pageBlocks = {
 	name  : 'pageBlock',
 	level : 'block',
@@ -285,8 +287,13 @@ const pageBlocks = {
 			raw        : `${pageArray[0]}\\page`,
 			text       : pageArray[0],
 			pageNumber : pageBlockNumber,
+			prune      : false,
 			tokens     : []
 		};
+
+		if(targetPage > 0 && (token.pageNumber < (targetPage - targetRange) || token.pageNumber > (targetPage + targetRange))) {
+			token.prune = true;
+		}
 
 		pageBlockTopLevel = false;
 		this.lexer.blockTokens(token.text, token.tokens);
@@ -295,7 +302,8 @@ const pageBlocks = {
 		return token;
 	},
 	renderer(token) {
-		return `<div class='page' id='p${token.pageNumber}'>\n${this.parser.parse(token.tokens)}</div>`;
+		if(token.prune) { return `<div class='page' id='p${token.pageNumber}' key=${token.pageNumber}>\n<i className='fas fa-spinner fa-spin' />\n</div>`; };
+		return `<div class='page' id='p${token.pageNumber}' key=${token.pageNumber}>\n${this.parser.parse(token.tokens)}</div>`;
 	}
 };
 
@@ -401,9 +409,11 @@ const processStyleTags = (string)=>{
 
 module.exports = {
 	marked : Marked,
-	render : (rawBrewText)=>{
+	render : (rawBrewText, pageToRender = -1, pageRange = 0)=>{
 		rawBrewText = rawBrewText.replace(/^\\column$/gm, `\n<div class='columnSplit'></div>\n`)
 														 .replace(/^(:+)$/gm, (match)=>`${`<div class='blank'></div>`.repeat(match.length)}\n`);
+		targetPage = pageToRender;
+		targetRange = pageRange;
 		return Marked.parse(rawBrewText);
 	},
 

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -438,7 +438,16 @@ module.exports = {
 														 .replace(/^(:+)$/gm, (match)=>`${`<div class='blank'></div>`.repeat(match.length)}\n`);
 		targetPage = pageToRender;
 		targetRange = pageRange;
-		return Marked.parse(rawBrewText);
+
+		//v=======------Split Markdown parsing into 5 manual steps------=======v//
+		const opts = Marked.defaults;
+
+		rawBrewText = opts.hooks.preprocess(rawBrewText); // 1) Preprocess String
+		const tokens = Marked.lexer(rawBrewText, opts);   // 2) String to Token Tree
+		Marked.walkTokens(tokens, opts.walkTokens);       // 3) Walk Tokens
+		const html = Marked.parser(tokens, opts);         // 4) Token Tree to HTML
+		return opts.hooks.postprocess(html);              // 5) Postprocess HTML
+		//^=======------------------------------------------------------=======^//
 	},
 
 	validate : (rawBrewText)=>{

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -313,6 +313,7 @@ const pageBlocks = {
 	}],
 	walkTokens(token) {
 		const permittedTypes = ['heading', 'html', 'mustacheDivs', 'pageBlock'];
+		const stopPruningTypes = ['heading'];
 
 		if(token.prune) {
 			token.tokens?.forEach((childToken)=>{
@@ -320,7 +321,7 @@ const pageBlocks = {
 					childToken.originalType = childToken.type;
 					childToken.type = 'hiddenBlock';
 				};
-				childToken.prune = (childToken.type != 'heading');
+				childToken.prune = (!stopPruningTypes.includes(childToken.type));
 			});
 		}
 	}

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -7,44 +7,16 @@ const { gfmHeadingId: MarkedGFMHeadingId } = require('marked-gfm-heading-id');
 const renderer = new Marked.Renderer();
 
 //Processes the markdown within an HTML block if it's just a class-wrapper
-// renderer.html = function (html) {
-// 	if(_.startsWith(_.trim(html), '<div') && _.endsWith(_.trim(html), '</div>')){
-// 		const openTag = html.substring(0, html.indexOf('>')+1);
-// 		html = html.substring(html.indexOf('>')+1);
-// 		html = html.substring(0, html.lastIndexOf('</div>'));
-// 		return `${openTag} ${html} </div>`;
-// 	}
-// 	return html;
-// };
-
-//Processes the markdown within an HTML block if it's just a class-wrapper
-const htmlDiv = {
-	name  : 'htmlDiv',
-	level : 'block',
-	tokenizer(src, tokens) {
-		let html = src;
-		if(_.startsWith(_.trim(html), '<div') && _.endsWith(_.trim(html), '</div>')){
-			const openTag = html.substring(0, html.indexOf('>')+1);
-			html = html.substring(html.indexOf('>')+1);
-			html = html.substring(0, html.lastIndexOf('</div>'));
-
-			const item = {                                                  // Token to generate
-				type    : 'htmlDiv',                                        // Should match "name" above
-				raw     : src.substring(0, src.indexOf('</div>')+6),        // Text to consume from the source
-				text    : html,                                             // Additional custom properties
-				openTag : openTag,
-				tokens  : []
-			};
-
-			this.lexer.blockTokens(html, item.tokens);
-
-			return item;
-		}
-		return false;
-	},
-	renderer(token) {
-		return `${token.openTag} ${this.parser.parse(token.tokens)} </div>`;
+renderer.html = function (html) {
+	if(_.startsWith(_.trim(html), '<div') && _.endsWith(_.trim(html), '</div>')){
+		const openTag = html.substring(0, html.indexOf('>')+1);
+		html = html.substring(html.indexOf('>')+1);
+		html = html.substring(0, html.lastIndexOf('</div>'));
+		hasPageBlockParent = true;
+		html = `${openTag} ${Marked.parse(html)} </div>`;
+		hasPageBlockParent = false;
 	}
+	return html;
 };
 
 // Don't wrap {{ Divs or {{ empty Spans in <p> tags
@@ -57,6 +29,36 @@ renderer.paragraph = function(text){
 	} else
 		return `<p>${text}</p>\n`;
 };
+
+//Processes the markdown within an HTML block if it's just a class-wrapper
+// const htmlDiv = {
+// 	name  : 'htmlDiv',
+// 	level : 'block',
+// 	tokenizer(src, tokens) {
+// 		let html = src;
+// 		if(_.startsWith(_.trim(html), '<div') && _.endsWith(_.trim(html), '</div>')){
+// 			const openTag = html.substring(0, html.indexOf('>')+1);
+// 			html = html.substring(html.indexOf('>')+1);
+// 			html = html.substring(0, html.lastIndexOf('</div>'));
+
+// 			const item = {                                                  // Token to generate
+// 				type    : 'htmlDiv',                                        // Should match "name" above
+// 				raw     : src.substring(0, src.indexOf('</div>')+6),        // Text to consume from the source
+// 				text    : html,                                             // Additional custom properties
+// 				openTag : openTag,
+// 				tokens  : []
+// 			};
+
+// 			this.lexer.blockTokens(html, item.tokens);
+
+// 			return item;
+// 		}
+// 		return false;
+// 	},
+// 	renderer(token) {
+// 		return `${token.openTag} ${this.parser.parse(token.tokens)} </div>`;
+// 	}
+// };
 
 const mustacheSpans = {
 	name  : 'mustacheSpans',
@@ -330,7 +332,7 @@ const pageBlocks = {
 	}
 };
 
-Marked.use({ extensions: [mustacheSpans, mustacheDivs, mustacheInjectInline, definitionLists, htmlDiv] });
+Marked.use({ extensions: [mustacheSpans, mustacheDivs, mustacheInjectInline, definitionLists] });
 Marked.use(pageBlocks);
 Marked.use(mustacheInjectBlock);
 Marked.use({ renderer: renderer, mangle: false });

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -430,13 +430,11 @@ const processStyleTags = (string)=>{
 
 module.exports = {
 	marked : Marked,
-	render : (rawBrewText, pageToRender = -1, pageRange = 0)=>{
+	render : (rawBrewText, pageToRender = -1, pageRange = 2)=>{
 		rawBrewText = rawBrewText.replace(/^\\column$/gm, `\n<div class='columnSplit'></div>\n`)
 														 .replace(/^(:+)$/gm, (match)=>`${`<div class='blank'></div>`.repeat(match.length)}\n`);
 		targetPage = pageToRender;
 		targetRange = pageRange;
-		targetPage = 6;
-		targetRange = 2;
 		return Marked.parse(rawBrewText);
 	},
 

--- a/tests/markdown/basic.test.js
+++ b/tests/markdown/basic.test.js
@@ -5,11 +5,11 @@ const Markdown = require('naturalcrit/markdown.js');
 test('Processes the markdown within an HTML block if its just a class wrapper', function() {
 	const source = '<div>*Bold text*</div>';
 	const rendered = Markdown.render(source);
-	expect(rendered).toBe('<div> <p><em>Bold text</em></p>\n </div>');
+	expect(rendered).toBe('<div class=\'page\' id=\'p1\' key=1>\n<div> <p><em>Bold text</em></p>\n </div></div>');
 });
 
 test('Check markdown is using the custom renderer; specifically that it adds target=_self attribute to internal links in HTML blocks', function() {
 	const source = '<div>[Has _self Attribute?](#p1)</div>';
 	const rendered = Markdown.render(source);
-	expect(rendered).toBe('<div> <p><a href="#p1" target="_self">Has _self Attribute?</a></p>\n </div>');
+	expect(rendered).toBe('<div class=\'page\' id=\'p1\' key=1>\n<div> <p><a href="#p1" target="_self">Has _self Attribute?</a></p>\n </div></div>');
 });

--- a/tests/markdown/mustache-syntax.test.js
+++ b/tests/markdown/mustache-syntax.test.js
@@ -122,7 +122,7 @@ describe('Inline: When using the Inline syntax {{ }}', ()=>{
 	it('Renders a mustache span with text, id, class and a couple of css properties', function() {
 		const source = '{{pen,#author,color:orange,font-family:"trebuchet ms" text}}';
 		const rendered = Markdown.render(source);
-		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block pen" id="author" style="color:orange; font-family:trebuchet ms;">text</span>');
+		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<div class=\'page\' id=\'p1\' key=1>\n<span class="inline-block pen" id="author" style="color:orange; font-family:trebuchet ms;">text</span></div>');
 	});
 });
 
@@ -152,7 +152,7 @@ describe(`Block: When using the Block syntax {{tags\\ntext\\n}}`, ()=>{
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
 		// this actually renders in HB as '{{ }}'...
-		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<p>{{}}</p>`);
+		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class='page' id='p1' key=1><p>{{}}</p></div>`);
 	});
 
 	it.failing('Renders a div with a single class', function() {
@@ -170,7 +170,7 @@ describe(`Block: When using the Block syntax {{tags\\ntext\\n}}`, ()=>{
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
 		// FIXME: adds two extra \s before closing `>` in opening tag
-		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat"><p>Sample text.</p></div>`);
+		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class='page' id='p1' key=1><div class="block cat"><p>Sample text.</p></div></div>`);
 	});
 
 	it.failing('Renders a div with two classes and text', function() {
@@ -205,7 +205,7 @@ describe(`Block: When using the Block syntax {{tags\\ntext\\n}}`, ()=>{
 		Sample text.
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat" id="dog" style="color:red;"><p>Sample text.</p></div>`);
+		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class='page' id='p1' key=1><div class="block cat" id="dog" style="color:red;"><p>Sample text.</p></div></div>`);
 	});
 
 	it.failing('Renders a div with a single ID', function() {


### PR DESCRIPTION
This PR is to demonstrate the use of \page as a Marked token, allowing us to render the entire document in a single `Marked.parse` call, rather than breaking up the document into individual pages as a preprocessing step.

This should immediately create unique heading IDs throughout the document (or at least, the ones created by Marked will be unique), and allow other future enhancements to affect the entire document, rather than just one page.