### PR TITLE
Add Share link to Unauthorized Edit Access error message

### DIFF
--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -22,18 +22,18 @@ const errorIndex = (props)=>{
 			## We can't find this brew in Google Drive!
 			
 			This file was saved on Google Drive, but this link doesn't work anymore.
-			${ props.brew.authors?.length > 0
-				? `Note that this brew belongs to the Homebrewery account **${ props.brew.authors[0] }**,
-				${ props.brew.account
-					? `which is
+			${props.brew.authors?.length > 0
+		? `Note that this brew belongs to the Homebrewery account **${props.brew.authors[0]}**,
+				${props.brew.account
+		? `which is
 						${props.brew.authors[0] == props.brew.account
-							? `your account.`
-							: `not your account (you are currently signed in as **${props.brew.account}**).`
-						}`
-					: 'and you are not currently signed in to any account.'
-				}`
-				: ''
-			}
+		? `your account.`
+		: `not your account (you are currently signed in as **${props.brew.account}**).`
+}`
+		: 'and you are not currently signed in to any account.'
+}`
+		: ''
+}
 			The Homebrewery cannot delete files from Google Drive on its own, so there
 			are three most likely possibilities:
 			:
@@ -75,7 +75,9 @@ const errorIndex = (props)=>{
 		
 		**Brew Title:** ${props.brew.brewTitle || 'Unable to show title'}
 
-		**Current Authors:** ${props.brew.authors?.map((author)=>{return `${author}`;}).join(', ') || 'Unable to list authors'}`,
+		**Current Authors:** ${props.brew.authors?.map((author)=>{return `${author}`;}).join(', ') || 'Unable to list authors'}
+		
+		[Click here to be redirected to the brew's share page.](/share/${props.brew.shareId})`,
 
 		// User is not signed in; must be a user on the Authors List
 		'04' : dedent`

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -79,7 +79,7 @@ const api = {
 			if(accessType === 'edit' && (authorsExist && !(isAuthor || isInvited))) {
 				const accessError = { name: 'Access Error', status: 401 };
 				if(req.account){
-					throw { ...accessError, message: 'User is not an Author', HBErrorCode: '03', authors: stub.authors, brewTitle: stub.title };
+					throw { ...accessError, message: 'User is not an Author', HBErrorCode: '03', authors: stub.authors, brewTitle: stub.title, shareId: stub.shareId };
 				}
 				throw { ...accessError, message: 'User is not logged in', HBErrorCode: '04', authors: stub.authors, brewTitle: stub.title };
 			}


### PR DESCRIPTION
This PR resolves #3086.

When a new user asks for help in the public forums, we often ask for a link to their document. While we specify that we need the `/share/` link, quite often the inexperienced user will instead post the `/edit/` links. This has been a problem since... well, forever.

This PR adds a link to the brew's `/share/` page to the error message that is received when a user attempts to access an brew that they are not an author of.