### PR TITLE
Rich Indexing

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -206,6 +206,32 @@ const mustacheInjectBlock = {
 	}
 };
 
+const indexAnchors = {
+	extensions : [{
+		name  : 'indexAnchor',
+		level : 'inline',
+		start(src) {return src.match(/@((?:\\.|[^\[\]\\^@^\)])+)@\(((?:\\.|[^\[\]\\^@^\)])+)\)/)?.index;}, // Hint to Marked.js to stop and check for a match
+		tokenizer(src, tokens) {
+			const inlineRegex = /@((?:\\.|[^\[\]\\^@^\)])+)@\(((?:\\.|[^\[\]\\^@^\)])+)\)/ym;
+			const anchor = {};
+			const match = inlineRegex.exec(src);
+			if(match) {
+				anchor.lookup = match[1].trim();
+				anchor.parent = match[2].trim();
+				return {
+					type : 'indexAnchor',
+					text : src,
+					raw  : match[0],
+					anchor
+				};
+			}
+		},
+		renderer(token) {
+			return `<a href="#${token.anchor.lookup.replace(/\s/g,'').toLowerCase()}" parent="${token.anchor.parent}" lookup="${token.anchor.lookup}" />`;
+		}
+	}]
+};
+
 const definitionLists = {
 	name  : 'definitionLists',
 	level : 'block',
@@ -239,6 +265,7 @@ const definitionLists = {
 };
 
 Marked.use({ extensions: [mustacheSpans, mustacheDivs, mustacheInjectInline, definitionLists] });
+Marked.use(indexAnchors);
 Marked.use(mustacheInjectBlock);
 Marked.use({ renderer: renderer, mangle: false });
 Marked.use(MarkedExtendedTables(), MarkedGFMHeadingId(), MarkedSmartypantsLite());

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -229,7 +229,7 @@ const indexAnchors = {
 		renderer(token) {
 			// This is a Rich Index Anchor entry
 			if(token.anchor.lookup) {
-				return `<a href="#${token.anchor.lookup.replace(/\s/g,'').toLowerCase()}" parent="${token.anchor.parent}" lookup="${token.anchor.lookup}" />`;
+				return `<a href="#${token.anchor.lookup.replace(/\s/g, '').toLowerCase()}" parent="${token.anchor.parent}" lookup="${token.anchor.lookup}"></a>`;
 			} else {
 				// This is a basic index entry
 				return '';

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -210,9 +210,9 @@ const indexAnchors = {
 	extensions : [{
 		name  : 'indexAnchor',
 		level : 'inline',
-		start(src) {return src.match(/@((?:\\.|[^\[\]\\^@^\)])+)@\(((?:\\.|[^\[\]\\^@^\)])+)\)/)?.index;}, // Hint to Marked.js to stop and check for a match
+		start(src) {return src.match(/@((?:\\.|[^\[\]\\^@^\)])*)@\(((?:\\.|[^\[\]\\^@^\)])*)\)/)?.index;}, // Hint to Marked.js to stop and check for a match
 		tokenizer(src, tokens) {
-			const inlineRegex = /@((?:\\.|[^\[\]\\^@^\)])+)@\(((?:\\.|[^\[\]\\^@^\)])+)\)/ym;
+			const inlineRegex = /@((?:\\.|[^\[\]\\^@^\)])*)@\(((?:\\.|[^\[\]\\^@^\)])*)\)/ym;
 			const anchor = {};
 			const match = inlineRegex.exec(src);
 			if(match) {
@@ -227,7 +227,13 @@ const indexAnchors = {
 			}
 		},
 		renderer(token) {
-			return `<a href="#${token.anchor.lookup.replace(/\s/g,'').toLowerCase()}" parent="${token.anchor.parent}" lookup="${token.anchor.lookup}" />`;
+			// This is a Rich Index Anchor entry
+			if(token.anchor.lookup) {
+				return `<a href="#${token.anchor.lookup.replace(/\s/g,'').toLowerCase()}" parent="${token.anchor.parent}" lookup="${token.anchor.lookup}" />`;
+			} else {
+				// This is a basic index entry
+				return '';
+			}
 		}
 	}]
 };

--- a/tests/markdown/basic.test.js
+++ b/tests/markdown/basic.test.js
@@ -13,3 +13,10 @@ test('Check markdown is using the custom renderer; specifically that it adds tar
 	const rendered = Markdown.render(source);
 	expect(rendered).toBe('<div> <p><a href="#p1" target="_self">Has _self Attribute?</a></p>\n </div>');
 });
+
+test('Check Index Anchors in custom renderer', function() {
+	const source=`@hereweare@(there)Welcome traveler from an antique land. Please sit and tell us of what you have seen. The unheard of monsters, who slither and bite. @hereWeWere@(there)Tell us of the wondrous items and and artifacts you have found, their mysteries yet to be unlocked. Of the vexing vocations and surprising skills you have seen.@here We Shall be@(there)`;
+	const rendered = Markdown.render(source);
+	console.log(rendered);
+	expect(rendered).toBe('<p><a href="#hereweare" parent="there" lookup="hereweare" />Welcome traveler from an antique land. Please sit and tell us of what you have seen. The unheard of monsters, who slither and bite. <a href="#herewewere" parent="there" lookup="hereWeWere" />Tell us of the wondrous items and and artifacts you have found, their mysteries yet to be unlocked. Of the vexing vocations and surprising skills you have seen.<a href="#hereweshallbe" parent="there" lookup="here We Shall be" /></p>\n');
+});

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -114,7 +114,7 @@ module.exports = [
 			},
 			{
 				name         : 'Rich Index',
-				icon         : 'fas fa-bars',
+				icon         : 'fas fa-indent',
 				gen          : richIndexGen,
 				experimental : true
 			}

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -4,6 +4,7 @@ const WatercolorGen = require('./snippets/watercolor.gen.js');
 const ImageMaskGen  = require('./snippets/imageMask.gen.js');
 const FooterGen     = require('./snippets/footer.gen.js');
 const dedent        = require('dedent-tabs').default;
+const richIndexGen  = require('./snippets/richIndex.gen.js');
 
 module.exports = [
 
@@ -111,6 +112,13 @@ module.exports = [
 				icon : 'fas fa-code',
 				gen  : '<!-- This is a comment that will not be rendered into your brew. Hotkey (Ctrl/Cmd + /). -->'
 			},
+			{
+				name         : 'Rich Index',
+				icon         : 'fas fa-bars',
+				gen          : richIndexGen,
+				experimental : true
+			}
+
 		]
 	},
 	{

--- a/themes/V3/Blank/snippets/richIndex.gen.js
+++ b/themes/V3/Blank/snippets/richIndex.gen.js
@@ -29,7 +29,6 @@ const findIndexTerms = (pages, terms, results)=>{
 	for (const [pageNumber, page] of pages.entries()) {
 		const lowerPage = page.toLowerCase();
 		for (const [term, lt] of lowerTerms.entries()) {
-			// convert to a regex to gain some regex benefits over a straight up match.
 			const regExTerm = new RegExp(lt.replace(' ', '\s').replace(/\n/g, '\s'));
 			if(lowerPage.match(regExTerm)) {
 				if(results.has(terms[term])) {
@@ -133,7 +132,6 @@ module.exports = function (props) {
 	const richIndexEntries = findRichTags(pages, indexMarkdownRegex);
 
 	if(indexTag.length > 0) {
-		// We have search terms!
 		findIndexTerms(pages, indexTag.split('|'), index);
 	}
 
@@ -143,7 +141,6 @@ module.exports = function (props) {
 
 	const markdown = markup(index);
 
-//	return dedent``;
 	return dedent`
 		{{index,wide
 		##### Index

--- a/themes/V3/Blank/snippets/richIndex.gen.js
+++ b/themes/V3/Blank/snippets/richIndex.gen.js
@@ -66,8 +66,9 @@ const addRichIndexes = (richEntries, results)=>{
 							const childMap = new Map();
 							childMap.set(richTags[1], [entryPageNumber]);
 							results.set(parent, {
-								pages: [],
-								children: childMap
+								pages    : [],
+								children : childMap,
+								rich     : true
 							});
 						}
 					}
@@ -88,7 +89,11 @@ const markup = (index)=>{
 	for (const [parent, parentPages] of sortedIndex) {
 		results = results.concat(`- `, parent, parentPages.pages.length > 0 ? ' ... pg. ':'');
 		for (const [k, pageNumber] of parentPages.pages.entries()) {
-			results = results.concat(parseInt(pageNumber+1));
+			if(parentPages.hasOwnProperty('rich')) {
+				results = results.concat('[', parseInt(pageNumber+1), `](#${child.toLowerCase().replace(' ', '')})`);
+			} else {
+				results = results.concat('[', parseInt(pageNumber+1), `](#page${pageNumber})`);
+			}
 			if(k < (parentPages.pages.length - 1)) {
 				results = results.concat(`, `);
 			}
@@ -99,7 +104,7 @@ const markup = (index)=>{
 			for (const [child, childPages] of sortedChildren){
 				results = results.concat('  - ', child, ' ... pg. ');
 				for (const [k, pageNumber] of childPages.entries()) {
-					results = results.concat(parseInt(pageNumber+1));
+					results = results.concat('[', parseInt(pageNumber+1), `](#${child.toLowerCase().replace(' ', '')})`);
 					if(k < (childPages.length - 1)) {
 						results = results.concat(`, `);
 					}

--- a/themes/V3/Blank/snippets/richIndex.gen.js
+++ b/themes/V3/Blank/snippets/richIndex.gen.js
@@ -79,7 +79,13 @@ const addRichIndexes = (richEntries, results)=>{
 };
 
 const sortMap = (m)=> {
-	return (new Map([...m.entries()].sort()));
+	return (new Map([...m.entries()].sort((a, b)=>{
+		const lowA = a[0].toLowerCase();
+		const lowB = b[0].toLowerCase();
+		if(lowA == lowB) return 0;
+		if(lowA > lowB) return 1;
+		return -1;
+	})));
 };
 
 const markup = (index)=>{

--- a/themes/V3/Blank/snippets/richIndex.gen.js
+++ b/themes/V3/Blank/snippets/richIndex.gen.js
@@ -1,0 +1,77 @@
+const _ = require('lodash');
+const dedent = require('dedent-tabs').default;
+
+const findBasicIndex = (pages, theRegex)=>{
+	for (const page of pages) {
+		if(page.match(theRegex)) {
+			return (theRegex.exec(page)[2].trim());
+		}
+	};
+	return '';
+};
+
+const findRichTags = (pages, theRegex)=>{
+	return (pages.map(function(page) {
+		const richIndex=theRegex.exec(page);
+		if(richIndex) { return richIndex; };
+	}));
+};
+
+const findIndexTerms = (pages, terms, results)=>{
+	const lowerTerms = terms.map((term)=>term.toLowerCase());
+	for (const [pageNumber, page] of pages.entries()) {
+		const lowerPage = page.toLowerCase();
+		for (const [term, lt] of lowerTerms.entries()) {
+			// convert to a regex to gain some regex benefits over a straight up match.
+			const regExTerm = new RegExp(lt.replace(' ', '\s').replace(/\n/g, '\s'));
+			console.log(regExTerm);
+			console.log(lowerPage);
+			if(lowerPage.match(regExTerm)) {
+				console.log(`Found the term ${lt}`);
+				console.log(`Mapping to ${terms[term]}`);
+				if(results.has(terms[term])) {
+					const currentEntry = results.get(terms[term]);
+					currentEntry.pages.push(pageNumber);
+					results.set(terms[term], currentEntry);
+				} else {
+					results.set(terms[term], { pages: [pageNumber], children: [] });
+				}
+			}
+		}
+	}
+	console.log(results);
+	return results;
+};
+
+module.exports = function (props) {
+	const index = new Map();
+
+	const pages = props.brew.text.split('\\page');
+	const indexMarkdownRegex = /@((?:\\.|[^\[\]\\^@^\)])*)@\(((?:\\.|[^\[\]\\^@^\)])*)\)/gm;
+	const indexMarkdownRegexBasic = /@(\W*)@\(((?:\\.|[^\[\]\\^@^\)])+)\)/m;
+
+	const indexTag = findBasicIndex(pages, indexMarkdownRegexBasic);
+	const richIndexEntries = findRichTags(pages, indexMarkdownRegex);
+
+	if(indexTag.length > 0) {
+		// We have search terms!
+		console.log('We found the index tag in a page.');
+		console.log(indexTag);
+
+		findIndexTerms(pages, indexTag.split('|'), index);
+	}
+
+	console.log(index);
+	console.log(`Found ${richIndexEntries.length} rich tags`);
+	console.log(richIndexEntries);
+
+
+	return dedent``;
+	// return dedent`
+	// 	{{index,wide
+	// 	##### Index
+
+	// 	$markdown
+	// 	}}
+	// \n`;
+};


### PR DESCRIPTION
## Semi-Dynamic Index building for Markdown+

Build simple, rich, or hybrid indexes with internal links. 

### Usage

Both usage cases center around the use of the index extension.

``` 
@label@(parent1|parent2|...)
```

### Simple Index

Anywhere in the document add an index marker with no label and a list of terms to be indexed. Terms will be searched for in a case and whitespace insensitive manner. Pipe (|) is used as a delimiter.

```
@@(Term1|Term2|Another term)
```

### Complex Index Entry

An index marker can be placed anywhere inline.  The label will be used as the lookup term in the index. If parent(s) are listed, the label will be listed as a nested sub-entry under each of the parents. Pipe (|) is used as a delimiter.

```
@This Term@(Magic)
```

The label will also be used for the HTML translated anchor by stripping whitespace and converting it to lowercase.

### Generating the Index

The rich index snippet, when executed, combines the simple and rich index entries into a single, alphabetized index.

If you have simple and rich entries, rich entries will be folded under the simple entries as follows:
0. Simple entries are created as top-level, un-indented entries.
1. Child entries are indented under their top-level parent.
2. If a Rich entry has no parent, it will be inserted as a top-level entry.
3. If a Rich entry has a parent and that parent does not exist in the top-level entries, the parent will be added as a new top-level entry and the Rich entry will be added as a child of that top-level entry.
4. If a Rich entry has a parent and the parent exists in the top-level entries, and the Rich entry is not listed as a child of the parent, it will be added as a new child.
5. If a Rich entry has a parent and the parent exists in the top-level entries, and the Rich entry exists, the child will be updated with an additional page reference to the new Rich entry.

```
{{index,wide
##### Index

- That ... pg. [1](#page0), [3](#page2)
- there1
  - here ... pg. [3](#here)
  - onehere ... pg. [2](#onehere)
- there2
  - here ... pg. [2](#here)
- there3
  - more ... pg. [3](#more)
- This ... pg. [1](#page0), [3](#page2), [4](#page3)

}}
```

#### Known issues.
* The snippet is not smart enough to know that it is scanning markup when looking for terms. This could create bad entries.
* The simple index lookup assumes page-level anchor links in the format \#page\#\# ( e.g. \#page1 ) that do not currently exist
* The links don't seem to work
* The Styling is meh. I mostly emulated the existing Index snippet. We could do some dot padding, etc.

#### Other notes

I'm not the most efficient JS coder. I'd be very unsurprised if some of this could be condensed. 
