### PR TITLE
Fix issues starting server first time in Dev environment

### DIFF
--- a/scripts/buildHomebrew.js
+++ b/scripts/buildHomebrew.js
@@ -154,14 +154,14 @@ fs.emptyDirSync('./build');
 	// build(bundles);
 	//
 
-})().catch(console.error);
+	//In development, set up LiveReload (refreshes browser), and Nodemon (restarts server)
+	if(isDev){
+		livereload('./build');     // Install the Chrome extension LiveReload to automatically refresh the browser
+		watchFile('./server.js', { // Restart server when change detected to this file or any nested directory from here
+			ignore : ['./build', './client', './themes'],  // Ignore folders that are not running server code / avoids unneeded restarts
+			ext    : 'js json'                             // Extensions to watch (only .js/.json by default)
+			//watch : ['./server', './themes'],            // Watch additional folders if needed
+		});
+	}
 
-//In development, set up LiveReload (refreshes browser), and Nodemon (restarts server)
-if(isDev){
-	livereload('./build');     // Install the Chrome extension LiveReload to automatically refresh the browser
-	watchFile('./server.js', { // Restart server when change detected to this file or any nested directory from here
-		ignore : ['./build', './client', './themes'],  // Ignore folders that are not running server code / avoids unneeded restarts
-		ext    : 'js json'                             // Extensions to watch (only .js/.json by default)
-		//watch : ['./server', './themes'],            // Watch additional folders if needed
-	});
-}
+})().catch(console.error);


### PR DESCRIPTION
Using `node scripts/buildHomebrew.js --dev` can sometimes start up the server before the build is complete, so `ssr.js` is not quite ready and the app crashes. This puts the server startup inside the async block to it must await everything else being complete.