### PR TITLE
License Snippet Dropdown update

### DIFF
--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -3,6 +3,12 @@
 const WatercolorGen = require('./snippets/watercolor.gen.js');
 const ImageMaskGen  = require('./snippets/imageMask.gen.js');
 const FooterGen     = require('./snippets/footer.gen.js');
+const LicenseGenCC  = require('./snippets/licenseCC.gen.js');
+const LicenseGenWotC = require('./snippets/licenseWotC.gen.js');
+const LicenseGenORC = require('./snippets/licenseOrc.gen.js');
+const LicenseGenGNU = require('./snippets/licenseGNU.gen.js');
+const LicenseGen = require('./snippets/license.gen.js');
+
 const dedent        = require('dedent-tabs').default;
 
 module.exports = [
@@ -114,6 +120,130 @@ module.exports = [
 		]
 	},
 	{
+		groupName : 'License',
+		icon	  : 'fas fa-copyright',
+		view	  : 'text',
+		snippets  : [
+			{
+				name        : 'Creative Commons',
+				icon        : 'fab fa-creative-commons',
+				subsnippets : [
+
+					{
+						name : 'CC0 4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.zero,
+					},
+
+					{
+						name : 'CC-BY-4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.by,
+					},
+
+					{
+						name : 'CC-BY-SA 4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.bysa,
+					},
+
+					{
+						name : 'CC-BY-NC 4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.bync,
+					},
+
+					{
+						name : 'CC-BY-NC-SA 4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.byncsa,
+					},
+
+					{
+						name : 'CC-BY-ND 4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.bynd,
+					},
+
+					{
+						name : 'CC-BY-NC-ND 4.0',
+						icon : 'fab fa-creative-commons',
+						gen	 : LicenseGenCC.byncnd,
+					},
+				]
+			},
+
+			{
+				name        : 'GNU',
+				icon        : 'fas fa-w',
+				subsnippets : [
+
+					{
+						name : 'GNU Free Documentation License',
+						icon : 'fas fa-w',
+						gen	 : LicenseGenGNU.gfdl,
+					},
+
+					{
+						name : 'GNU FDL Title Page',
+						icon : 'fas fa-w',
+						gen	 : LicenseGenGNU.gfdltitle,
+					},
+
+					{
+						name : 'GNU FDL Title Page w/alterations',
+						icon : 'fas fa-w',
+						gen	 : LicenseGenGNU.gfdltitleinvariant,
+					},
+
+					{
+						name : 'GNU General Public License v3',
+						icon : 'fas fa-w',
+						gen	 : LicenseGenGNU.gpl3,
+					},
+
+					{
+						name : 'GNU GPLv3 Title Page',
+						icon : 'fas fa-w',
+						gen	 : LicenseGenGNU.gpl3title,
+					},
+				]
+			},
+
+			{
+				name        : 'Wizards of the Coast',
+				icon        : 'fab fa-wizards-of-the-coast',
+				subsnippets : [
+
+					{
+						name : 'OGL 1.0 A',
+						icon : 'fab fa-wizards-of-the-coast',
+						gen	 : LicenseGenWotC.ogl1a,
+					},
+
+					{
+						name : 'WoTC Fan Content Policy',
+						icon : 'fas fa-w',
+						gen	 : LicenseGenWotC.fcp,
+					},
+				]
+			},
+
+			{
+				name : 'MIT License',
+				icon : 'fas fa-mit',
+				gen  : LicenseGen.mit,
+			},
+
+			{
+				name : 'ORC License',
+				icon : 'fas fa-Paizo',
+				gen	 : LicenseGenORC.orc1,
+			},
+
+		]
+	},
+	{
 		groupName : 'Style Editor',
 		icon      : 'fas fa-pencil-alt',
 		view      : 'style',
@@ -125,7 +255,6 @@ module.exports = [
 			},
 		]
 	},
-
 	/*********************** IMAGES *******************/
 	{
 		groupName : 'Images',

--- a/themes/V3/Blank/snippets/license.gen.js
+++ b/themes/V3/Blank/snippets/license.gen.js
@@ -1,0 +1,20 @@
+/* eslint-disable max-lines */
+const _ = require('lodash');
+
+// Small and one-off licenses
+
+module.exports = {
+
+	mit : function() {
+		return `{{license,wide
+Copyright \\<YEAR\\> \\<COPYRIGHT HOLDER\\>
+:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+:
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+}}`;
+	},
+
+};

--- a/themes/V3/Blank/snippets/licenseCC.gen.js
+++ b/themes/V3/Blank/snippets/licenseCC.gen.js
@@ -1,0 +1,711 @@
+/* eslint-disable max-lines */
+const _ = require('lodash');
+const dedent = require('dedent');
+
+// Creative Commons Licenses
+
+module.exports = {
+	by : function () {
+		return dedent`{{license,wide
+			### Attribution 4.0 International
+			
+			By exercising the Licensed Rights (defined below), You accept and agree
+			to be bound by the terms and conditions of this Creative Commons
+			Attribution 4.0 International Public License ("Public License"). To the
+			extent this Public License may be interpreted as a contract, You are
+			granted the Licensed Rights in consideration of Your acceptance of
+			these terms and conditions, and the Licensor grants You such rights in
+			consideration of benefits the Licensor receives from making the
+			Licensed Material available under these terms and conditions.
+			
+			### Section 1 -- Definitions.
+			{{ol-ccby,
+			1. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+			2. Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+			3. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+			4. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+			5. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+			6. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+			7. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+			8. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+			9. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+			10. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+			11. You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+			}}
+			}}
+			\page
+			{{license,wide
+			
+			### Section 2 -- Scope.
+			{{ol-ccby,
+			1. **License grant**.
+				1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to
+			exercise the Licensed Rights in the Licensed Material to:
+					1. reproduce and Share the Licensed Material, in whole or in part; and
+					2. produce, reproduce, and Share Adapted Material.
+				2. **Exceptions and Limitations**. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+				3. **Term**. The term of this Public License is specified in Section 6(a).
+				4. **Media and formats; technical modifications allowed**. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. 
+			The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a) (4) never produces Adapted Material.
+				5. Downstream recipients.
+					1. Offer from the Licensor -- Licensed Material. Everyrecipient of the Licensed Material automaticallyreceives an offer from the Licensor to exercise theLicensed Rights under the terms and conditions of this Public License.
+					2. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+				6. No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+			2. **Other rights**.
+				1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+				2. Patent and trademark rights are not licensed under this Public License.
+				3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+			}}
+			### Section 3 -- License Conditions.
+			Your exercise of the Licensed Rights is expressly made subject to thefollowing conditions.
+			{{ol-ccby,
+			1. **Attribution**.
+				1. If You Share the Licensed Material (including in modifiedform), You must:
+					1. retain the following if it is supplied by the Licensorwith the Licensed Material:
+						1. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+						2. a copyright notice;
+						3. a notice that refers to this Public License;
+						4. a notice that refers to the disclaimer ofwarranties;
+						5. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+					2. indicate if You modified the Licensed Material andretain an indication of any previous modifications; and
+					3. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+				2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+				3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+				4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+			}}
+			### Section 4 -- Sui Generis Database Rights.
+				
+			Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+			
+			{{ol-ccby,
+			1. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+			2. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+			3. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+			}}
+			For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+			
+			
+			### Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+			{{ol-ccby,
+			1. Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+			2. To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+			3. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 6 -- Term and Termination.
+			{{ol-ccby,
+				
+			1. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+			2. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+				1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+				2. upon express reinstatement by the Licensor.
+			
+			For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+			
+			3. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+			4. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+			}}
+			### Section 7 -- Other Terms and Conditions.
+			{{ol-ccby,
+			1. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+			2. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+			}}
+			### Section 8 -- Interpretation.
+			{{ol-ccby,
+			1. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+			2. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+			3. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+			4. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+			}}
+			}}
+		`;
+	},
+	zero : function() {
+		return `{{license,wide
+## CC0 1.0 Universal
+CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED HEREUNDER.
+
+### Statement of Purpose
+The laws of most jurisdictions throughout the world automatically confer exclusive Copyright and Related Rights (defined below) upon the creator and subsequent owner(s) (each and all, an "owner") of an original work of authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for the purpose of contributing to a commons of creative, cultural and scientific works ("Commons") that the public can reliably and without fear of later claims of infringement build upon, modify, incorporate in other works, reuse and redistribute as freely as possible in any form whatsoever and for any purposes, including without limitation commercial purposes. These owners may contribute to the Commons to promote the ideal of a free culture and the further production of creative, cultural and scientific works, or to gain reputation or greater distribution for their Work in part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any expectation of additional consideration or compensation, the person associating CC0 with a Work (the "Affirmer"), to the extent that he or she is an owner of Copyright and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and publicly distribute the Work under its terms, with knowledge of his or her Copyright and Related Rights in the Work and the meaning and intended legal effect of CC0 on those rights.
+
+### 1. Copyright and Related Rights.
+A Work made available under CC0 may be protected by copyright and related or neighboring rights ("Copyright and Related Rights"). Copyright and Related Rights include, but are not limited to, the following:
+
+i. the right to reproduce, adapt, distribute, perform, display, communicate, and translate a Work;
+
+ii. moral rights retained by the original author(s) and/or performer(s);
+
+iii.publicity and privacy rights pertaining to a person's image or likeness depicted in a Work;
+
+iv. rights protecting against unfair competition in regards to a Work, subject to the limitations in paragraph 4(a), below;
+
+v. rights protecting the extraction, dissemination, use and reuse of data in a Work;
+
+vi. database rights (such as those arising under Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, and under any national implementation thereof, including any amended or successor version of such directive); and
+other similar, equivalent or corresponding rights throughout the world based on applicable law or treaty, and any national implementations thereof.
+
+### 2. Waiver.
+To the greatest extent permitted by, but not in contravention of, applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and unconditionally waives, abandons, and surrenders all of Affirmer's Copyright and Related Rights and associated claims and causes of action, whether now known or unknown (including existing as well as future claims and causes of action), in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each member of the public at large and to the detriment of Affirmer's heirs and successors, fully intending that such Waiver shall not be subject to revocation, rescission, cancellation, termination, or any other legal or equitable action to disrupt the quiet enjoyment of the Work by the public as contemplated by Affirmer's express Statement of Purpose.
+
+### 3. Public License Fallback.
+Should any part of the Waiver for any reason be judged legally invalid or ineffective under applicable law, then the Waiver shall be preserved to the maximum extent permitted taking into account Affirmer's express Statement of Purpose. In addition, to the extent the Waiver is so judged Affirmer hereby grants to each affected person a royalty-free, non transferable, non sublicensable, non exclusive, irrevocable and unconditional license to exercise Affirmer's Copyright and Related Rights in the Work (i) in all territories worldwide, (ii) for the maximum duration provided by applicable law or treaty (including future time extensions), (iii) in any current or future medium and for any number of copies, and (iv) for any purpose whatsoever, including without limitation commercial, advertising or promotional purposes (the "License"). The License shall be deemed effective as of the date CC0 was applied by Affirmer to the Work. Should any part of the License for any reason be judged legally invalid or ineffective under applicable law, such partial invalidity or ineffectiveness shall not invalidate the remainder of the License, and in such case Affirmer hereby affirms that he or she will not (i) exercise any of his or her remaining Copyright and Related Rights in the Work or (ii) assert any associated claims and causes of action with respect to the Work, in either case contrary to Affirmer's express Statement of Purpose.
+
+### 4. Limitations and Disclaimers.
+a. No trademark or patent rights held by Affirmer are waived, abandoned, surrendered, licensed or otherwise affected by this document.
+
+b. Affirmer offers the Work as-is and makes no representations or warranties of any kind concerning the Work, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non infringement, or the absence of latent or other defects, accuracy, or the present or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law.
+
+c. Affirmer disclaims responsibility for clearing rights of other persons that may apply to the Work or any use thereof, including without limitation any person's Copyright and Related Rights in the Work. Further, Affirmer disclaims responsibility for obtaining any necessary consents, permissions or other rights required for any use of the Work.
+d. Affirmer understands and acknowledges that Creative Commons is not a party to this document and has no duty or obligation with respect to this CC0 or use of the Work.
+}}`;
+	},
+	bysa : function() {
+		return dedent`{{license,wide
+			### Attribution-ShareAlike 4.0 International
+			By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+			
+			### Section 1 – Definitions.
+			{{ol-ccby,
+			1. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+			2. Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+			3. BY-SA Compatible License means a license listed at creativecommons.org/compatiblelicenses , approved by Creative Commons as essentially the equivalent of this Public License.
+			4. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+			5. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+			6. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+			7. License Elements means the license attributes listed in the name of a Creative Commons Public License. The License Elements of this Public License are Attribution and ShareAlike.
+			8. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+			9. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+			10. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+			11. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+			12. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+			13. You means the individual or entity exercising the Licensed Rights under this Public License. **Your** has a corresponding meaning.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 2 – Scope.
+			{{ol-ccby
+			1. **License grant** .
+				1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+					1. reproduce and Share the Licensed Material, in whole or in part; and 
+					2. produce, reproduce, and Share Adapted Material.
+				2. **Exceptions and Limitations** . For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+				3. **Term** . The term of this Public License is specified in Section 6(a) .
+				4. **Media and formats; technical modifications allowed** . The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+				5. Downstream recipients .
+					1. Offer from the Licensor – Licensed Material . Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+					2. Additional offer from the Licensor – Adapted Material . Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+					3. No downstream restrictions . You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+				6. No endorsement . Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i) .
+			2. Other rights .
+				1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+				2. Patent and trademark rights are not licensed under this Public License.
+				3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 3 – License Conditions.
+			Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+			{{ol-ccby
+			1. **Attribution** .
+				1. If You Share the Licensed Material (including in modified form), You must:
+			
+					1. retain the following if it is supplied by the Licensor with the Licensed Material:
+						1. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+						2. a copyright notice;
+						3. a notice that refers to this Public License;
+						4. a notice that refers to the disclaimer of warranties;
+						5. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+					2. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+					3. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+				2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+				3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+			2. **ShareAlike** .<br />
+			In addition to the conditions in Section 3(a) , if You Share Adapted Material You produce, the following conditions also apply.
+			
+				1. The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
+				2. You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
+				3. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
+			}}
+			#### Section 4 – Sui Generis Database Rights.
+			Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+			{{ol-ccby
+			1. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+			2. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b) ; and
+			3. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+			}}
+			For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+			
+			#### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+			{{ol-ccby
+			1. **Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+			2. **To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+			3. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 6 – Term and Termination.
+			{{ol-ccby
+			1. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+			2. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+				1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+				2. upon express reinstatement by the Licensor.
+			}}
+			For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+			{{ol-ccby
+			3. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+			4. Sections 1 , 5 , 6 , 7 , and 8 survive termination of this Public License.
+			}}
+			
+			### Section 7 – Other Terms and Conditions.
+			{{ol-ccby
+			1. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+			2. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+			}}
+			
+			### Section 8 – Interpretation.
+			{{ol-ccby
+			1. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+			2. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+			3. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+			4. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+			}}
+			}}
+		`;
+	},
+	bync : function() {
+		return dedent`{{license,wide
+			### Attribution-NonCommercial 4.0 International
+			By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NonCommercial 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+			
+			### Section 1 – Definitions.
+			{{ol-ccby
+			1. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+			2. Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+			3. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+			4. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+			5. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+			6. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+			7. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+			8. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+			9. NonCommercial means not primarily intended for or directed towards commercial advantage or monetary compensation. For purposes of this Public License, the exchange of the Licensed Material for other material subject to Copyright and Similar Rights by digital file-sharing or similar means is NonCommercial provided there is no payment of monetary compensation in connection with the exchange.
+			10. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+			11. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+			12. You means the individual or entity exercising the Licensed Rights under this Public License. **Your** has a corresponding meaning.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 2 – Scope.
+			{{ol-ccby
+			1. License grant .
+				1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+					1. reproduce and Share the Licensed Material, in whole or in part, for NonCommercial purposes only; and
+					2. produce, reproduce, and Share Adapted Material for NonCommercial purposes only.
+				2. **Exceptions and Limitations** . For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+				3. **Term** . The term of this Public License is specified in Section 6(a) .
+				4. **Media and formats; technical modifications allowed** . The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+				5. Downstream recipients .
+					1. Offer from the Licensor – Licensed Material . Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+					2. No downstream restrictions . You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+				6. No endorsement . Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i) .
+			2. **Other rights** .
+				1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+				2. Patent and trademark rights are not licensed under this Public License.
+				3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties, including when the Licensed Material is used other than for NonCommercial purposes.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 3 – License Conditions.
+			Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+			{{ol-ccby
+			  1. Attribution .
+				  1. If You Share the Licensed Material (including in modified form), You must:
+					  1. retain the following if it is supplied by the Licensor with the Licensed Material:
+						  1. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+						  2. a copyright notice;
+						  3. a notice that refers to this Public License;
+						  4. a notice that refers to the disclaimer of warranties;
+						  5. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+					  2. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+					  3. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+				  2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+				  3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+				  4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+			}}
+			### Section 4 – Sui Generis Database Rights.
+			Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+			{{ol-ccby
+			1. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database for NonCommercial purposes only;
+			2. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+			3. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+			}}
+			For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+			
+			### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+			{{ol-ccby
+			1. **Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+			2. **To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+			3. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 6 – Term and Termination.
+			{{ol-ccby
+			1. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+			2. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+				1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+				2. upon express reinstatement by the Licensor.
+			}}
+			For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+			{{ol-ccby    
+			3. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+			4. Sections 1 , 5 , 6 , 7 , and 8 survive termination of this Public License.
+			}}
+			### Section 7 – Other Terms and Conditions.
+			{{ol-ccby    
+			1. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+			2. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+			}}
+			### Section 8 – Interpretation.
+			{{ol-ccby    
+			1. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+			2. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+			3. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+			4. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+			}}
+			}}
+		`;
+	},
+	byncsa : function() {
+		return dedent`{{license,wide
+			### Attribution-NonCommercial-ShareAlike 4.0 International
+			By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+			
+			### Section 1 – Definitions.
+			{{ol-ccby
+			1. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+			2. Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+			3. BY-NC-SA Compatible License means a license listed at creativecommons.org/compatiblelicenses , approved by Creative Commons as essentially the equivalent of this Public License.
+			4. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+			5. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+			6. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+			7. License Elements means the license attributes listed in the name of a Creative Commons Public License. The License Elements of this Public License are Attribution, NonCommercial, and ShareAlike.
+			8. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+			9. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+			10. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+			11. NonCommercial means not primarily intended for or directed towards commercial advantage or monetary compensation. For purposes of this Public License, the exchange of the Licensed Material for other material subject to Copyright and Similar Rights by digital file-sharing or similar means is NonCommercial provided there is no payment of monetary compensation in connection with the exchange.
+			12. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+			13. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+			14. You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 2 – Scope.
+			{{ol-ccby
+			1. **License grant** .
+				1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+					1. reproduce and Share the Licensed Material, in whole or in part; and
+					2. produce, reproduce, and Share Adapted Material for NonCommercial purposes only.
+				2. **Exceptions and Limitations** . For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+				3. **Term** . The term of this Public License is specified in Section 6(a) .
+				4. **Media and formats; technical modifications allowed** . The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+				5. Downstream recipients .
+					1. Offer from the Licensor – Licensed Material . Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+					2. Additional offer from the Licensor – Adapted Material . Every recipient of Adapted Material from You automatically receives an offer from the Licensor to exercise the Licensed Rights in the Adapted Material under the conditions of the Adapter’s License You apply.
+					3. No downstream restrictions . You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+				6. No endorsement . Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i) .
+			2. **Other rights** .
+				1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+				2. Patent and trademark rights are not licensed under this Public License.
+				3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties, including when the Licensed Material is used other than for NonCommercial purposes.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 3 – License Conditions.
+			Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+			{{ol-ccby
+			1. **Attribution** .
+				1. If You Share the Licensed Material (including in modified form), You must:
+					1. retain the following if it is supplied by the Licensor with the Licensed Material:
+						1. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+						2. a copyright notice;
+						3. a notice that refers to this Public License;
+						4. a notice that refers to the disclaimer of warranties;
+						5. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+					2. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+					3. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+				2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+				3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+			2. **ShareAlike** .<br /> 
+			In addition to the conditions in Section 3(a) , if You Share Adapted Material You produce, the following conditions also apply.
+				  1.  The Adapter’s License You apply must be a Creative Commons license with the same License Elements, this version or later, or a BY-SA Compatible License.
+				  2. You must include the text of, or the URI or hyperlink to, the Adapter's License You apply. You may satisfy this condition in any reasonable manner based on the medium, means, and context in which You Share Adapted Material.
+				  3. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, Adapted Material that restrict exercise of the rights granted under the Adapter's License You apply.
+			}}
+			### Section 4 – Sui Generis Database Rights.
+			Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+			{{ol-ccby
+			1. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database for NonCommercial purposes only;
+			2. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material, including for purposes of Section 3(b) ; and
+			3. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+			}}
+			For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+			### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+			{{ol-ccby
+			1. **Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+			2. **To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+			3. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 6 – Term and Termination.
+			{{ol-ccby
+			1. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+			2. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+				1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+				2. upon express reinstatement by the Licensor.
+			
+			For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+			
+			3. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+			4. Sections 1 , 5 , 6 , 7 , and 8 survive termination of this Public License.
+			}}
+			### Section 7 – Other Terms and Conditions.
+			{{ol-ccby
+			1. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+			2. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+			}}
+			### Section 8 – Interpretation.
+			{{ol-ccby
+			1. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+			2. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+			3. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+			4. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+			}}
+			}}		
+		`;
+	},
+	bynd : function() {
+		return dedent`{{license,wide
+			### Attribution-NoDerivatives 4.0 International
+			By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NoDerivatives 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+			### Section 1 – Definitions.
+			{{ol-ccby
+			1. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+			2. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+			3. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+			4. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+			5. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+			6. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+			7. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+			8. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+			9. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+			10. You means the individual or entity exercising the Licensed Rights under this Public License. **Your** has a corresponding meaning.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 2 – Scope.
+			{{ol-ccby
+			1. **License grant** .
+				1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+					1. reproduce and Share the Licensed Material, in whole or in part; and
+					2. produce and reproduce, but not Share, Adapted Material.
+				2. **Exceptions and Limitations** . For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+				3. **Term** . The term of this Public License is specified in Section 6(a) .
+				4. **Media and formats; technical modifications allowed** . The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+				5. Downstream recipients .
+					1. Offer from the Licensor – Licensed Material . Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+					2. No downstream restrictions . You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+					3. No endorsement . Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i) .
+			2. **Other rights** .
+				1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+				2. Patent and trademark rights are not licensed under this Public License.
+				3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+			}}
+			### Section 3 – License Conditions.
+			Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+			{{ol-ccby
+			1. **Attribution** .
+				1. If You Share the Licensed Material (including in modified form), You must:
+					1. retain the following if it is supplied by the Licensor with the Licensed Material:
+						1. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+						2. a copyright notice;
+						3. a notice that refers to this Public License;
+						4. a notice that refers to the disclaimer of warranties;
+						5. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+					2. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+					3. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+					
+				For the avoidance of doubt, You do not have permission under this Public License to Share Adapted Material.
+				
+				2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+				3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 4 – Sui Generis Database Rights.
+			Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+			{{ol-ccby
+			1. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database, provided You do not Share Adapted Material;
+			2. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+			3. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+			}}
+			For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+			
+			### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+			{{ol-ccby
+			1. **Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+			2. **To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+			3. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+			}}
+			### Section 6 – Term and Termination.
+			{{ol-ccby
+			1. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+			2. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+				1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+				2. upon express reinstatement by the Licensor.
+				
+			For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+			
+			3. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+			4. Sections 1 , 5 , 6 , 7 , and 8 survive termination of this Public License.
+			}}
+			### Section 7 – Other Terms and Conditions.
+			{{ol-ccby
+			1. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+			2. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 8 – Interpretation.
+			{{ol-ccby
+			1. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+			2. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+			3. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+			4. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+			}}
+			}}`;
+	},
+	byncnd : function() {
+		return dedent`{{license,wide
+			### Attribution-NonCommercial-NoDerivatives 4.0 International
+			By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+			### Section 1 – Definitions.
+			{{ol-ccby
+			1. Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+			2. Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+			3. Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+			4. Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+			5. Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+			6. Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+			7. Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+			8. NonCommercial means not primarily intended for or directed towards commercial advantage or monetary compensation. For purposes of this Public License, the exchange of the Licensed Material for other material subject to Copyright and Similar Rights by digital file-sharing or similar means is NonCommercial provided there is no payment of monetary compensation in connection with the exchange.
+			9. Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+			10. Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+			11. You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 2 – Scope.
+			{{ol-ccby
+			1. **License grant** .
+				1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+					1. reproduce and Share the Licensed Material, in whole or in part, for NonCommercial purposes only; and
+					2. produce and reproduce, but not Share, Adapted Material for NonCommercial purposes only.
+				2. **Exceptions and Limitations** . For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+				3. **Term** . The term of this Public License is specified in Section 6(a) .
+				4. **Media and formats; technical modifications allowed** . The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+				5. Downstream recipients .
+					1. Offer from the Licensor – Licensed Material . Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+					2. No downstream restrictions . You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+					3. No endorsement . Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i) .
+			2. **Other rights** .
+				1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+				2. Patent and trademark rights are not licensed under this Public License.
+				3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties, including when the Licensed Material is used other than for NonCommercial purposes.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 3 – License Conditions.
+			Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+			{{ol-ccby
+			1. Attribution .
+				1. If You Share the Licensed Material (including in modified form), You must:
+					1. retain the following if it is supplied by the Licensor with the Licensed Material:
+						1. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+						2. a copyright notice;
+						3. a notice that refers to this Public License;
+						4. a notice that refers to the disclaimer of warranties;
+						5. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+					2. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+					3. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+			
+				For the avoidance of doubt, You do not have permission under this Public License to Share Adapted Material.
+				
+				2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+				3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+			}}
+			### Section 4 – Sui Generis Database Rights.
+			Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+			{{ol-ccby
+			1. for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database for NonCommercial purposes only and provided You do not Share Adapted Material;
+			2. if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+			3. You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+			}}
+			For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+			### Section 5 – Disclaimer of Warranties and Limitation of Liability.
+			{{ol-ccby
+			1. **Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.**
+			2. **To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.**
+			3. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+			}}
+			}}
+			\page
+			{{license,wide
+			### Section 6 – Term and Termination.
+			{{ol-ccby
+			1. This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+			2. Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+				1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+				2. upon express reinstatement by the Licensor.
+				
+			For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+			
+			3. For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+			4. Sections 1 , 5 , 6 , 7 , and 8 survive termination of this Public License.
+			}}
+			### Section 7 – Other Terms and Conditions.
+			{{ol-ccby
+			1. The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+			2. Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+			}}
+			### Section 8 – Interpretation.
+			{{ol-ccby
+			1. For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+			2. To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+			3. No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+			4. Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+			}}
+			}}
+		`;
+	},
+};

--- a/themes/V3/Blank/snippets/licenseGNU.gen.js
+++ b/themes/V3/Blank/snippets/licenseGNU.gen.js
@@ -1,0 +1,435 @@
+/* eslint-disable max-lines */
+const _ = require('lodash');
+const dedent = require('dedent');
+
+// GNU Licenses
+
+module.exports = {
+
+	gpl3 : function () {
+		return dedent`{{license,wide
+			### GNU GENERAL PUBLIC LICENSE
+			*Version 3, 29 June 2007*
+			:
+			Copyright © 2007 Free Software Foundation, Inc. <https://fsf.org/>
+			:
+			Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+			:
+			#### Preamble
+			:
+			The GNU General Public License is a free, copyleft license for software and other kinds of works.
+			:
+			The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+			:
+			When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+			:
+			To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+			:
+			For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+			:
+			Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+			:
+			For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+			:
+			Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+			:
+			Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+			:
+			The precise terms and conditions for copying, distribution and modification follow.
+			}}
+			\page
+			{{license,wide
+			#### TERMS AND CONDITIONS
+			
+			##### 0. Definitions.
+			
+			“This License” refers to version 3 of the GNU General Public License.
+			:
+			“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+			:
+			“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations.
+			:
+			To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work.
+			:
+			A “covered work” means either the unmodified Program or a work based on the Program.
+			:
+			To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+			:
+			To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+			:
+			An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+			
+			##### 1. Source Code.
+			
+			The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work.
+			:
+			A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+			:
+			The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+			:
+			The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+			:
+			The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+			:
+			The Corresponding Source for a work in source code form is that same work.
+			}}
+			\page
+			{{license,wide
+			##### 2. Basic Permissions.
+			
+			All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+			You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+			:
+			Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+			
+			##### 3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+			
+			No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+			:
+			When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+			
+			##### 4. Conveying Verbatim Copies.
+			
+			You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+			:
+			You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+			
+			##### 5. Conveying Modified Source Versions.
+			
+			You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+			:
+			**a)** The work must carry prominent notices stating that you modified it, and giving a relevant date.
+			:
+			
+			**b)** The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”.
+			:
+			
+			**c)** You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+			:
+			
+			**d)** If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+			:
+			A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+			}}
+			\page
+			{{license,wide
+			##### 6. Conveying Non-Source Forms.
+			
+			You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+			:
+			**a)** Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+			:
+			**b)** Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+			:
+			**c)** Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+			:
+			**d)** Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+			:
+			**e)** Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+			:
+			A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+			:
+			A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+			:
+			“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+			:
+			If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+			:
+			The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+			:
+			}}
+			\page
+			{{license,wide
+			Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+			
+			##### 7. Additional Terms.
+			
+			“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+			:
+			When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+			:
+			Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+			:
+			**a)** Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+			:
+			**b)** Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+			:
+			**c)** Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+			:
+			**d)** Limiting the use for publicity purposes of names of licensors or authors of the material; or
+			:
+			**e)** Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+			:
+			**f)** Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+			:
+			All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+			:
+			If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+			:
+			Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+			
+			##### 8. Termination.
+			
+			You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+			:
+			However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+			:
+			Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+			:
+			Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+			}}
+			\page
+			{{license,wide
+			##### 9. Acceptance Not Required for Having Copies.
+			
+			You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+			
+			##### 10. Automatic Licensing of Downstream Recipients.
+			
+			Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+			:
+			An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. 
+			:
+			If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+			:
+			You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+			
+			##### 11. Patents.
+			:
+			A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's “contributor version”.
+			:
+			A contributor's “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+			:
+			Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+			:
+			In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+			:
+			If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+			:
+			If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+			}}
+			\page
+			{{license,wide
+			A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+			:
+			Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+			
+			##### 12. No Surrender of Others' Freedom.
+			
+			If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all.
+			:
+			For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+			
+			##### 13. Use with the GNU Affero General Public License.
+			
+			Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+			
+			##### 14. Revised Versions of this License.
+			
+			The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+			:
+			Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+			:
+			If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+			:
+			Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+			
+			##### 15. Disclaimer of Warranty.
+			
+			THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+			}}
+			\page
+			{{license,wide
+			##### 16. Limitation of Liability.
+			
+			IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+			
+			##### 17. Interpretation of Sections 15 and 16.
+			
+			If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+			}}`;
+	},
+	gpl3title : function() {
+		return `
+		\<one line to give the program's name and a brief idea of what it does.\>
+		Copyright (C) \<year\>  \<name of author\>
+
+		This program is free software: you can redistribute it and/or modify
+		it under the terms of the GNU General Public License as published by
+		the Free Software Foundation, either version 3 of the License, or
+		(at your option) any later version.
+
+		This program is distributed in the hope that it will be useful,
+		but WITHOUT ANY WARRANTY; without even the implied warranty of
+		MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+		GNU General Public License for more details.
+
+		You should have received a copy of the GNU General Public License
+		along with this program.  If not, see <https://www.gnu.org/licenses/>.
+		`;
+	},
+	gfdl : function() {
+		return dedent`{{license,wide
+		## GNU Free Documentation License
+		:
+		Version 1.3, 3 November 2008
+		:
+		Copyright (C) 2000, 2001, 2002, 2007, 2008 Free Software Foundation,
+		Inc. <https://fsf.org/>
+		:
+		Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+		## 0. PREAMBLE
+		:
+		The purpose of this License is to make a manual, textbook, or other functional and useful document "free" in the sense of freedom: to assure everyone the effective freedom to copy and redistribute it, with or without modifying it, either commercially or noncommercially. Secondarily, this License preserves for the author and publisher a way to get credit for their work, while not being considered responsible for modifications made by others.
+		:
+		This License is a kind of "copyleft", which means that derivative works of the document must themselves be free in the same sense. It complements the GNU General Public License, which is a copyleft license designed for free software.
+		:
+		We have designed this License in order to use it for manuals for free software, because free software needs free documentation: a free program should come with manuals providing the same freedoms that the software does. But this License is not limited to software manuals; it can be used for any textual work, regardless of subject matter or whether it is published as a printed book. We recommend this License principally for works whose purpose is instruction or reference.
+
+		## 1. APPLICABILITY AND DEFINITIONS
+		:
+		This License applies to any manual or other work, in any medium, that contains a notice placed by the copyright holder saying it can be distributed under the terms of this License. Such a notice grants a world-wide, royalty-free license, unlimited in duration, to use that work under the conditions stated herein. The "Document", below, refers to any such manual or work. Any member of the public is a licensee, and is addressed as "you". You accept the license if you copy, modify or distribute the work in a way requiring permission under copyright law.
+		:
+		A "Modified Version" of the Document means any work containing the Document or a portion of it, either copied verbatim, or with modifications and/or translated into another language.
+		:
+		A "Secondary Section" is a named appendix or a front-matter section of the Document that deals exclusively with the relationship of the publishers or authors of the Document to the Document's overall subject (or to related matters) and contains nothing that could fall directly within that overall subject. (Thus, if the Document is in part a textbook of mathematics, a Secondary Section may not explain any mathematics.) The relationship could be a matter of historical connection with the subject or with related matters, or of legal, commercial, philosophical, ethical or political position regarding them.
+		:
+		The "Invariant Sections" are certain Secondary Sections whose titles are designated, as being those of Invariant Sections, in the notice that says that the Document is released under this License. If a section does not fit the above definition of Secondary then it is not allowed to be designated as Invariant. The Document may contain zero Invariant Sections. If the Document does not identify any Invariant Sections then there are none.
+		:
+		The "Cover Texts" are certain short passages of text that are listed, as Front-Cover Texts or Back-Cover Texts, in the notice that says that the Document is released under this License. A Front-Cover Text may be at most 5 words, and a Back-Cover Text may be at most 25 words.
+		:
+		A "Transparent" copy of the Document means a machine-readable copy, represented in a format whose specification is available to the general public, that is suitable for revising the document straightforwardly with generic text editors or (for images composed of pixels) generic paint programs or (for drawings) some widely available drawing editor, and that is suitable for input to text formatters or for automatic translation to a variety of formats suitable for input to text formatters. A copy made in an otherwise Transparent file format whose markup, or absence of markup, has been arranged to thwart or discourage subsequent modification by readers is not Transparent. An image format is not Transparent if used for any substantial amount of text. A copy that is not "Transparent" is called "Opaque".
+		}}
+		\page
+		{{license,wide
+		Examples of suitable formats for Transparent copies include plain ASCII without markup, Texinfo input format, LaTeX input format, SGML or XML using a publicly available DTD, and standard-conforming simple HTML, PostScript or PDF designed for human modification. Examples of transparent image formats include PNG, XCF and JPG. Opaque formats include proprietary formats that can be read and edited only by proprietary word processors, SGML or XML for which the DTD and/or processing tools are not generally available, and the machine-generated HTML, PostScript or PDF produced by some word processors for output purposes only.
+		:
+		The "Title Page" means, for a printed book, the title page itself, plus such following pages as are needed to hold, legibly, the material this License requires to appear in the title page. For works in formats which do not have any title page as such, "Title Page" means the text near the most prominent appearance of the work's title, preceding the beginning of the body of the text.
+		:
+		The "publisher" means any person or entity that distributes copies of the Document to the public.
+		:
+		A section "Entitled XYZ" means a named subunit of the Document whose title either is precisely XYZ or contains XYZ in parentheses following text that translates XYZ in another language. (Here XYZ stands for a specific section name mentioned below, such as "Acknowledgements", "Dedications", "Endorsements", or "History".) To "Preserve the Title" of such a section when you modify the Document means that it remains a section "Entitled XYZ" according to this definition.
+		:
+		The Document may include Warranty Disclaimers next to the notice which states that this License applies to the Document. These Warranty Disclaimers are considered to be included by reference in this License, but only as regards disclaiming warranties: any other implication that these Warranty Disclaimers may have is void and has no effect on the meaning of this License.
+
+		## 2. VERBATIM COPYING
+		:
+		You may copy and distribute the Document in any medium, either commercially or noncommercially, provided that this License, the copyright notices, and the license notice saying this License applies to the Document are reproduced in all copies, and that you add no other conditions whatsoever to those of this License. You may not use technical measures to obstruct or control the reading or further copying of the copies you make or distribute. However, you may accept compensation in exchange for copies. If you distribute a large enough number of copies you must also follow the conditions in section 3.
+		:
+		You may also lend copies, under the same conditions stated above, and you may publicly display copies.
+
+		## 3. COPYING IN QUANTITY
+		:
+		If you publish printed copies (or copies in media that commonly have printed covers) of the Document, numbering more than 100, and the Document's license notice requires Cover Texts, you must enclose the copies in covers that carry, clearly and legibly, all these Cover Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on the back cover. Both covers must also clearly and legibly identify you as the publisher of these copies. The front cover must present the full title with all words of the title equally prominent and visible. You may add other material on the covers in addition. Copying with changes limited to the covers, as long as they preserve the title of the Document and satisfy these conditions, can be treated as verbatim copying in other respects.
+		:
+		If the required texts for either cover are too voluminous to fit legibly, you should put the first ones listed (as many as fit reasonably) on the actual cover, and continue the rest onto adjacent pages.
+		:
+		If you publish or distribute Opaque copies of the Document numbering more than 100, you must either include a machine-readable Transparent copy along with each Opaque copy, or state in or with each Opaque copy a computer-network location from which the general network-using public has access to download using public-standard network protocols a complete Transparent copy of the Document, free of added material. If you use the latter option, you must take reasonably prudent steps, when you begin distribution of Opaque copies in quantity, to ensure that this Transparent copy will remain thus accessible at the stated location until at least one year after the last time you distribute an Opaque copy (directly or through your agents or retailers) of that edition to the public.
+		:
+		It is requested, but not required, that you contact the authors of the Document well before redistributing any large number of copies, to give them a chance to provide you with an updated version of the Document.
+		}}
+		\page
+		{{license,wide
+		## 4. MODIFICATIONS
+		:
+		You may copy and distribute a Modified Version of the Document under the conditions of sections 2 and 3 above, provided that you release the Modified Version under precisely this License, with the Modified Version filling the role of the Document, thus licensing distribution and modification of the Modified Version to whoever possesses a copy of it. In addition, you must do these things in the Modified Version:
+		:
+		::A. Use in the Title Page (and on the covers, if any) a title distinct from that of the Document, and from those of previous versions (which should, if there were any, be listed in the	History section of the Document). You may use the same title as a previous version if the original publisher of that version 	gives permission.
+		::B. List on the Title Page, as authors, one or more persons or entities responsible for authorship of the modifications in the Modified Version, together with at least five of the principal authors of the Document (all of its principal authors, if it has fewer than five), unless they release you from this requirement.
+		::C. State on the Title page the name of the publisher of the Modified Version, as the publisher.
+		::D. Preserve all the copyright notices of the Document.
+		::E. Add an appropriate copyright notice for your modifications adjacent to the other copyright notices.
+		::F. Include, immediately after the copyright notices, a license notice giving the public permission to use the Modified Version under the terms of this License, in the form shown in the Addendum below.
+		::G. Preserve in that license notice the full lists of Invariant Sections and required Cover Texts given in the Document's license notice.
+		::H. Include an unaltered copy of this License.
+		::I. Preserve the section Entitled "History", Preserve its Title, and add to it an item stating at least the title, year, new authors, and publisher of the Modified Version as given on the Title Page. If there is no section Entitled "History" in the Document, create one stating the title, year, authors, and publisher of the Document as given on its Title Page, then add an item describing the Modified Version as stated in the previous sentence.
+		::J. Preserve the network location, if any, given in the Document for public access to a Transparent copy of the Document, and likewise the network locations given in the Document for previous versions it was based on. These may be placed in the "History" section. You may omit a network location for a work that was published at least four years before the Document itself, or if the original publisher of the version it refers to gives permission.
+		::K. For any section Entitled "Acknowledgements" or "Dedications", Preserve the Title of the section, and preserve in the section all the substance and tone of each of the contributor acknowledgements and/or dedications given therein.
+		::L. Preserve all the Invariant Sections of the Document, unaltered in their text and in their titles. Section numbers or the equivalent are not considered part of the section titles.
+		::M. Delete any section Entitled "Endorsements". Such a section may not be included in the Modified Version.
+		::N. Do not retitle any existing section to be Entitled "Endorsements" or to conflict in title with any Invariant Section.
+		::O. Preserve any Warranty Disclaimers.
+		:
+		If the Modified Version includes new front-matter sections or appendices that qualify as Secondary Sections and contain no material copied from the Document, you may at your option designate some or all of these sections as invariant. To do this, add their titles to the list of Invariant Sections in the Modified Version's license notice. These titles must be distinct from any other section titles.
+		:
+		You may add a section Entitled "Endorsements", provided it contains nothing but endorsements of your Modified Version by various partiesâ€”for example, statements of peer review or that the text has been approved by an organization as the authoritative definition of a standard.
+		:
+		You may add a passage of up to five words as a Front-Cover Text, and a passage of up to 25 words as a Back-Cover Text, to the end of the list of Cover Texts in the Modified Version. Only one passage of Front-Cover Text and one of Back-Cover Text may be added by (or through arrangements made by) any one entity. If the Document already includes a cover text for the same cover, previously added by you or by arrangement made by the same entity you are acting on behalf of, you may not add another; but you may replace the old one, on explicit permission from the previous publisher that added the old one.
+		:
+		The author(s) and publisher(s) of the Document do not by this License give permission to use their names for publicity for or to assert or imply endorsement of any Modified Version.
+		}}
+		\page
+		{{license,wide
+		## 5. COMBINING DOCUMENTS
+		:
+		You may combine the Document with other documents released under this License, under the terms defined in section 4 above for modified versions, provided that you include in the combination all of the Invariant Sections of all of the original documents, unmodified, and list them all as Invariant Sections of your combined work in its license notice, and that you preserve all their Warranty Disclaimers.
+		:
+		The combined work need only contain one copy of this License, and multiple identical Invariant Sections may be replaced with a single copy. If there are multiple Invariant Sections with the same name but different contents, make the title of each such section unique by adding at the end of it, in parentheses, the name of the original author or publisher of that section if known, or else a unique number. Make the same adjustment to the section titles in the list of Invariant Sections in the license notice of the combined work. 
+		:
+		In the combination, you must combine any sections Entitled "History" in the various original documents, forming one section Entitled "History"; likewise combine any sections Entitled "Acknowledgements", and any sections Entitled "Dedications". You must delete all sections Entitled "Endorsements".
+
+		## 6. COLLECTIONS OF DOCUMENTS
+		:
+		You may make a collection consisting of the Document and other documents released under this License, and replace the individual copies of this License in the various documents with a single copy that is included in the collection, provided that you follow the rules of this License for verbatim copying of each of the documents in all other respects.
+		:
+		You may extract a single document from such a collection, and distribute it individually under this License, provided you insert a copy of this License into the extracted document, and follow this License in all other respects regarding verbatim copying of that document.
+
+		## 7. AGGREGATION WITH INDEPENDENT WORKS
+		:
+		A compilation of the Document or its derivatives with other separate and independent documents or works, in or on a volume of a storage or distribution medium, is called an "aggregate" if the copyright resulting from the compilation is not used to limit the legal rights of the compilation's users beyond what the individual works permit. When the Document is included in an aggregate, this License does not apply to the other works in the aggregate which are not themselves derivative works of the Document.
+		:
+		If the Cover Text requirement of section 3 is applicable to these copies of the Document, then if the Document is less than one half of the entire aggregate, the Document's Cover Texts may be placed on covers that bracket the Document within the aggregate, or the electronic equivalent of covers if the Document is in electronic form. Otherwise they must appear on printed covers that bracket the whole aggregate.
+
+		## 8. TRANSLATION
+		:
+		Translation is considered a kind of modification, so you may distribute translations of the Document under the terms of section 4. Replacing Invariant Sections with translations requires special permission from their copyright holders, but you may include translations of some or all Invariant Sections in addition to the original versions of these Invariant Sections. You may include a translation of this License, and all the license notices in the Document, and any Warranty Disclaimers, provided that you also include the original English version of this License and the original versions of those notices and disclaimers. In case of a disagreement between the translation and the original version of this License or a notice or disclaimer, the original version will prevail.
+		:
+		If a section in the Document is Entitled "Acknowledgements", "Dedications", or "History", the requirement (section 4) to Preserve its Title (section 1) will typically require changing the actual title.
+		}}
+		\page
+		{{license,wide
+		## 9. TERMINATION
+		:
+		You may not copy, modify, sublicense, or distribute the Document except as expressly provided under this License. Any attempt otherwise to copy, modify, sublicense, or distribute it is void, and will automatically terminate your rights under this License.
+		:
+		However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+		:
+		Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+		:
+		Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, receipt of a copy of some or all of the same material does not give you any rights to use it.
+
+		## 10. FUTURE REVISIONS OF THIS LICENSE
+		:
+		The Free Software Foundation may publish new, revised versions of the GNU Free Documentation License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns. See <https://www.gnu.org/licenses/>.
+		:
+		Each version of the License is given a distinguishing version number. If the Document specifies that a particular numbered version of this License "or any later version" applies to it, you have the option of following the terms and conditions either of that specified version or of any later version that has been published (not as a draft) by the Free Software Foundation. If the Document does not specify a version number of this License, you may choose any version ever published (not as a draft) by the Free Software Foundation. If the Document specifies that a proxy can decide which future versions of this License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Document.
+
+		## 11. RELICENSING
+		:
+		"Massive Multiauthor Collaboration Site" (or "MMC Site") means any World Wide Web server that publishes copyrightable works and also provides prominent facilities for anybody to edit those works. A public wiki that anybody can edit is an example of such a server. A "Massive Multiauthor Collaboration" (or "MMC") contained in the site means any set of copyrightable works thus published on the MMC site.
+		:
+		"CC-BY-SA" means the Creative Commons Attribution-Share Alike 3.0 license published by Creative Commons Corporation, a not-for-profit corporation with a principal place of business in San Francisco, California, as well as future copyleft versions of that license published by that same organization.
+		:
+		"Incorporate" means to publish or republish a Document, in whole or in part, as part of another Document.
+		:
+		An MMC is "eligible for relicensing" if it is licensed under this License, and if all works that were first published under this License somewhere other than this MMC, and subsequently incorporated in whole or in part into the MMC, (1) had no cover texts or invariant sections, and (2) were thus incorporated prior to November 1, 2008.
+		:
+		The operator of an MMC Site may republish an MMC contained in the site under CC-BY-SA on the same site at any time before August 1, 2009, provided the MMC is eligible for relicensing.
+		}}`;
+	},
+	gfdltitle : function() {
+		return `
+		Copyright (C)  YEAR  YOUR NAME.
+		Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+		A copy of the license is included in the section entitled "GNU Free Documentation License".
+		`;
+	},
+	gfdltitleinvariant : function() {
+		return `
+		Copyright (C)  YEAR  YOUR NAME.
+		Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.3 or any later version published by the Free Software Foundation; with the Invariant Sections being LIST THEIR TITLES, with the Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+		A copy of the license is included in the section entitled "GNU Free Documentation License".
+		`;
+	},
+};

--- a/themes/V3/Blank/snippets/licenseOrc.gen.js
+++ b/themes/V3/Blank/snippets/licenseOrc.gen.js
@@ -1,0 +1,138 @@
+/* eslint-disable max-lines */
+const _ = require('lodash');
+
+module.exports = {
+
+	orc1 : function () {
+		return `
+{{license,wide
+
+### ORC LICENSE [INTERIM]
+
+This Open RPG Creative license (“ORC License”) grants the right to use Licensed Material subject to the
+terms and conditions set forth and referenced as follows:
+
+:
+
+**I. Definitions.**
+
+- **Adapted Licensed Material**: Means Derivative Works that Use all or any portion of the Licensed Material that You create or publish to the limited extent that such Derivative Works would otherwise constitute those forms of Licensed Material set forth in Section I.e.(2) below. Adapted Licensed Material expressly excludes works that would constitute Reserved Material.
+- **Copyright and Similar Rights**: Means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. In no event shall Copyright and Similar Rights include trademark or patent rights.
+- **Derivative Work**: Means:
+
+{{padding-left:2em
+
+**(i)**:: for a product that Uses a single playable game system, the entire product published by or on behalf of You that is based on, derived from, or incorporates all or any portion of the Licensed Material; and 
+
+**(ii)**:: for products containing sections relating to multiple non-interoperable game systems (such as a magazine featuring sections regarding multiple unrelated games from different publishers or a website with portions related to different games) the entire portion of the product related to or derived from the Licensed Material shall constitute the Derivative Work.
+
+}}
+
+:
+  
+- **Effective Technological Measures**: Means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+- **Licensed Material**: Means (1) any material contained in a Work that would otherwise constitute Reserved Material but that has been expressly designated as Licensed Material by that material’s Licensor, and (2) those expressions reasonably necessary to convey functional ideas and methods of operation of a game that are contained in a Work that are comprised of systems, procedures, processes, rules, laws, instructions, heuristics, routines, functional elements, commands, structures, principles, methodologies, operations, devices, and concepts of play, and the limitations, restraints, constraints, allowances, and affordances inherent in gameplay, including but not limited to expressions describing the function of or providing instructions as to the following:
+
+{{padding-left:2em
+
+**i.**:: Creation and play of player and non-player characters (such as statistics, attributes, statblocks, traits, classes, jobs, alignments, professions, proficiencies, abilities, spells, skills, actions, reactions, interactions, resources, and equipment);
+  
+**ii.**:: Systems and classifications applicable to gameplay (such as alignments, backgrounds, classes, experience points, levels and leveling up, encounters, combat, initiative and turn order, movement, monster statistics, creature types, traps, conditions, buffs and debuffs, powers, terrain types, challenge ratings, moves, difficulty classes, skill checks, saving throws, resting and resource management, classification of magic systems, spell and ability effects, looting, items and equipment, diplomacy systems, dialogue options, and outcome determination);
+
+**iii.**:: Methods of determining success, failure, or outcome, and any expressions of such methods or of such successes, failures, or outcomes; and
+
+**iv.**:: Methods and mediums by which players play the game (such as dice rolling, random number generation, coin flipping, card drawing and play, applying modifiers to results of chance, creating or filling in character sheets, moving and interacting with tokens or figurines, drawing maps and illustrations, speaking, messaging, acting, pantomime, writing notes, asking questions, and making statements).
+
+}}
+
+The term Licensed Material shall in no event include Third Party Reserved Material. For the avoidance of doubt, the term Licensed Material is intended to exclude Reserved Material except to the limited extent a Licensor has expressly designated content that would otherwise constitute their Reserved Material as Licensed Material pursuant to notice published under Article III.
+
+- **Licensed Rights**: Means the rights granted to You subject to the terms and conditions of this ORC License, which are limited to all Copyright and Similar Rights that apply to Your Use of the Licensed Material and that the Licensor has authority to license.
+- **Licensor**: Means any individual or entity granting rights under this ORC License.
+
+}}
+
+\\page
+{{license,wide
+
+- **Reserved Material**: Means trademarks, trade dress, and creative expressions that are not essential to, or can be varied without altering, the ideas or methods of operation of a game system, including works of visual art, music and sound design, and clearly expressed and sufficiently delineated characters, character organizations, dialogue, settings, locations, worlds, plots, or storylines, including proper nouns and the adjectives, names, and titles derived from proper nouns. The term Reserved Material shall in no event include elements that have been previously expressly designated as Licensed Material by that material’s Licensor, that are Adapted Licensed Material, that constitute Third Party Reserved Material, or that are in the public domain.
+- **Sui Generis Database Rights**: Means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+- **Term**: Means the longer of the term of the Copyright and Similar Rights licensed herein.
+- **Third Party Reserved Material**: Means all intellectual property rights that are not or have not been licensed under the ORC License and that are neither owned nor controlled by Licensor or You or any person or entity that directly or indirectly controls, is controlled by, or is under common control with You or Licensor.
+- **Use or Used**: Means to use material by any means or process that requires permission under the Licensed Rights, such as production, reproduction, creation of derivative works, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+- **Work or Works**: Means that where a Licensor applies notice substantially in the form described in Section III to a product, (i) for products containing a single playable game, the entire product published by Licensor shall constitute the Work, and (ii) for products containing sections relating to multiple non-interoperable games (such as a magazine featuring sections regarding multiple unrelated games from different publishers or a website with portions related to different games) the entire portion of the product related to or derived from the Licensed Material shall constitute the Work.
+- **You or Your**: Means the individual or entity exercising rights granted under this ORC License.
+
+:
+
+**II. Grants & Limitations.**
+
+- **Primary Grant to You**: Subject to the terms and conditions of this ORC License, for the Term Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to Use the Licensed Material, in whole or in part that may be terminated only as set forth in Section V.a. for Your breach. Licensor hereby authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. Licensor hereby waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures.
+- **Grant of Adapted Licensed Material by You**: You hereby receive an offer from the Licensor to exercise the Licensed Rights on the express condition that You do and hereby grant to every recipient of the Adapted Licensed Material an irrevocable offer to exercise the Licensed Rights in the Adapted Licensed Material under the terms and conditions hereof pursuant to which such Adapted Licensed Material shall be licensed as Licensed Material to such recipient. You may not offer or impose any additional or different terms or conditions on the Licensed Material or apply any Effective Technological Measures to the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+- **Database Rights**: Where the Licensed Rights include Sui Generis Database Rights that apply to Your Use of the Licensed Material, this ORC License grants You the right to extract, reuse, reproduce, and Use all or a substantial portion of the contents of the database, and if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) shall constitute Adapted Licensed Material.
+- **Limitations**:
+  i. Nothing in this ORC License constitutes or may be construed as permission to assert or imply that You are, or that Your Use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution hereunder.
+  ii. Moral rights, such as the right of integrity, are not licensed under this ORC License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+  iii. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights and Use of the Licensed Material, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme.
+
+
+}}
+\\page
+
+{{license,wide
+
+**III. Required Notice.**
+
+:
+
+The grant of this ORC License to You is expressly conditioned on You including the notice statements described in subsections (a)–(d) below in a reasonable manner based on the medium, means, and context in which You Used the Licensed Material:
+
+- **ORC Notice**: The following statement designating the location and the terms of this ORC License:
+This product is licensed under the ORC License located at the Library of Congress at TX00[number TBD] and available online at various locations. All warranties are disclaimed as set forth therein.
+
+vbnet
+Copy code
+
+- **Attribution Notice**:
+i. A statement based on reasonable, good-faith efforts that identifies each Licensor or creator of the Licensed Material You Used and any others designated to receive attribution, including all upstream licensors of Licensed Material upon which Your Adapted Licensed Material is based or derived from, worded in any accurate and reasonable manner so requested by such parties. Such credit may be named, anonymous, or a reasonable pseudonym. For the avoidance of doubt, both Licensor and all parties similarly credited under Licensor’s attribution notice should be included in Your attribution notice unless otherwise reasonably indicated by such parties.
+ii. A statement indicating how You wish to be reasonably credited with respect to the Adapted Licensed Material licensed by You under this ORC License, including anonymously or by pseudonym if designated. Licensors and creators may update their name, anonymity designation, or pseudonym from time-to-time by notice to You and other known licensees hereunder; however, such change shall in no event require You to halt distribution of any Works You have produced or destroy any produced Works or Works-in-progress, but shall merely require You to use good faith efforts to implement the requested change on a going forward basis.
+
+- **Reserved Material Notice**: A statement based on reasonable, good-faith efforts that identifies the elements of Your Reserved Material, if any, contained in the Derivative Work in which You Use the Licensed Material. For avoidance of doubt, such designation neither limits Your rights in Your Reserved Material nor limits any downstream licensee’s Use of the Adapted Licensed Material. In the event of a conflict between Your designation of Reserved Material and the definition of Licensed Material, the definition shall control.
+
+- **Expressly Designated Licensed Material**: A statement that identifies any elements of Your content that would otherwise constitute Reserved Material contained in Your Derivative Work that You agree to offer to prospective licensees under the ORC License as Licensed Material pursuant to Section I.e.(1) above.
+
+- **Sample Notice**: By way of example only, the following notice would comply with the requirements of this ORC License:
+- **ORC Notice:** This product is licensed under the ORC License located at the Library of Congress at TX00[number TBD] and available online at various locations including [possible domain names may be inserted] and others. All warranties are disclaimed as set forth therein.
+
+- **Attribution:** This product is based on the following Licensed Material: [Title of Work], [Copyright Notice], [Author Credit Information]. [Title of Additional Work], [Copyright Notice], [Author Credit Information], [Etc.]. If you use our Licensed Material in your own published works, please credit us as follows: [Title of This Work], [Copyright Notice], [Your Author Credit Information].
+
+- **Reserved Material:** Reserved Material elements in this product include, but may not be limited to: The Skeleton Krew, The Horrible Nation of Funeralia, The Order of Ossuaries & Edgelords, and all elements designated as Reserved Material under the ORC License.
+
+- **Expressly Designated Licensed Material:** The following elements are owned by the Licensor and would otherwise constitute Reserved Material and are hereby designated as Licensed Material: The Bardic Order of the Singing Skull and associated characters, locations, and titles.
+
+:
+
+**IV. Warranty & Limitation of Liability.**
+
+:
+
+Licensor warrants, represents, acknowledges, and agrees that upon publication of Required Notice in a Licensor Work, Licensor may not thereafter withdraw, modify, or revoke such offer to license the Licensed Material hereunder as to any existing licensee or any prospective licensee, and Licensor’s offer to license such Licensed Material is irrevocable. Licensor licenses the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You. To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this ORC License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages.
+
+}}
+\\page
+{{license,wide
+
+Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You. The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+:
+
+**V. Other Terms & Conditions.**
+
+- **Termination & Remedies**: Your license to Use the Licensed Material will terminate automatically if You fail to comply with the terms and condition of this ORC License. Your license will be reinstated, effective as of the date of termination, if You cure such violation on a going forward basis (without the obligation to destroy inventory on hand) within 60 days of Your discovery of the violation or if Licensor waives such violation in writing. No such termination shall affect, limit, or disrupt the rights of any Licensor or downstream licensee of any Licensed Material under any ORC License. Only the Licensor and Licensor’s upstream licensors under this ORC License (which You are deemed to be in privity herewith) may bring enforcement action against You hereunder. This constitutes a limitation on Licensor remedies with respect to the license grant in the Licensed Material hereunder; however, this ORC License neither limits Licensor’s remedies in any way with respect to Licensor’s Reserved Material, nor does it limit Licensor’s right to offer the Licensed Material or Reserved Material under separate terms or conditions.
+- **Modifications**: This ORC License may not be amended, superseded, modified, updated, repealed, revoked, or deauthorized. Neither You nor Licensor may modify the terms of this ORC License; however, You may enter into a separate agreement of Your own making provided such agreement does not seek to modify the terms hereof. This ORC License does not, and shall not be interpreted to reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this ORC License.
+- **Construction**: This ORC License is published simultaneously with an answers and explanations document (“AxE”) that is filed under the same US Copyright registration as this ORC License. One purpose of the AxE is to provide a general indication of the drafters’ intentions in interpreting the ORC License and in the event of a dispute, the AxE is intended to be admissible to and used by any adjudicating body for such purpose. The ORC License may be translated into other languages. You and Licensor acknowledge and agree that if there is any conflict between this ORC License, the AxE, and such translated version, the terms of the English language ORC License registered by Azora Law PLLC with the US Copyright Office shall control. Subsequent versions of the AxE shall not be admissible for purposes of determining the drafters’ intentions with respect to the ORC License. To the extent possible, if any provision of this ORC License is deemed unenforceable by a court of law, it shall be automatically reformed to the minimum extent necessary to make it enforceable on a case-by-case basis. If such provision cannot be reformed, it shall be severed from this ORC License without affecting the enforceability of the remaining terms and conditions. No term or condition of this ORC License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor. Nothing in this ORC License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+}}
+      `;
+	},
+}

--- a/themes/V3/Blank/snippets/licenseWotC.gen.js
+++ b/themes/V3/Blank/snippets/licenseWotC.gen.js
@@ -1,0 +1,141 @@
+/* eslint-disable max-lines */
+const _ = require('lodash');
+
+module.exports = {
+	ogl1a : function () {
+		return `
+{{license,wide
+THIS LICENSE IS APPROVED FOR GENERAL USE. PERMISSION TO DISTRIBUTE THIS LICENSE IS MADE BY WIZARDS OF THE COAST!
+
+### OPEN GAME LICENSE Version 1.0a
+      
+The following text is the property of Wizards of the Coast, Inc. and is Copyright 2000 Wizards of the Coast, Inc ("Wizards"). All Rights Reserved.
+1. **Definitions:** 
+
+**(a)**:: **"Contributors"** means the copyright and/or trademark owners who have contributed Open Game Content; 
+**(b)**:: **"Derivative Material"** means copyrighted material including derivative works and translations (including into other computer languages), potation, modification, correction, addition, extension, upgrade, improvement, compilation, abridgment or other form in which an existing work may be recast, transformed or adapted; 
+**(c)**:: **"Distribute"** means to reproduce, license, rent, lease, sell, broadcast, publicly display, transmit or otherwise distribute; 
+**(d)**::**"Open Game Content"** means the game mechanic and includes the methods, procedures, processes and routines to the extent such content does not embody the Product Identity and is an enhancement over the prior art and any additional content clearly identified as Open Game Content by the Contributor, and means any work covered by this License, including translations and derivative works under copyright law, but specifically excludes Product Identity. 
+**(e)**:: **"Product Identity"** means product and product line names, logos and identifying marks including trade dress; artifacts; creatures characters; stories, storylines, plots, thematic elements, dialogue, incidents, language, artwork, symbols, designs, depictions, likenesses, formats, poses, concepts, themes and graphic, photographic and other visual or audio representations; names and descriptions of characters, spells, enchantments, personalities, teams, personas, likenesses and special abilities; places, locations, environments, creatures, equipment, magical or supernatural abilities or effects, logos, symbols, or graphic designs; and any other trademark or registered trademark clearly identified as Product identity by the owner of the Product Identity, and which specifically excludes the Open Game Content; 
+**(f)**:: **"Trademark"** means the logos, names, mark, sign, motto, designs that are used by a Contributor to identify itself or its products or the associated products contributed to the Open Game License by the Contributor 
+**(g)**:: **"Use"**, **"Used"** or **"Using"** means to use, Distribute, copy, edit, format, modify, translate and otherwise create Derivative Material of Open Game Content. 
+**(h)**:: **"You"** or **"Your"** means the licensee in terms of this agreement.
+  
+  
+2. **The License:** This License applies to any Open Game Content that contains a notice indicating that the Open Game Content may only be Used under and in terms of this License. You must affix such a notice to any Open Game Content that you Use. No terms may be added to or subtracted from this License except as described by the License itself. No other terms or conditions may be applied to any Open Game Content distributed using this License.
+3. **Offer and Acceptance:** By Using the Open Game Content You indicate Your acceptance of the terms of this License.
+4. **Grant and Consideration:** In consideration for agreeing to use this License, the Contributors grant You a perpetual, worldwide, royalty-free, non-exclusive license with the exact terms of this License to Use, the Open Game Content.
+5. **Representation of Authority to Contribute:** If You are contributing original material as Open Game Content, You represent that Your Contributions are Your original creation and/or You have sufficient rights to grant the rights conveyed by this License.
+6. **Notice of License Copyright:** You must update the COPYRIGHT NOTICE portion of this License to include the exact text of the COPYRIGHT NOTICE of any Open Game Content You are copying, modifying or distributing, and You must add the title, the copyright date, and the copyright holder's name to the COPYRIGHT NOTICE of any original Open Game Content you Distribute.
+7. **Use of Product Identity:** You agree not to Use any Product Identity, including as an indication as to compatibility, except as expressly licensed in another, independent Agreement with the owner of each element of that Product Identity. You agree not to indicate compatibility or co-adaptability with any Trademark or Registered Trademark in conjunction with a work containing Open Game Content except as expressly licensed in another, independent Agreement with the owner of such Trademark or Registered Trademark. The use of any Product Identity in Open Game Content does not constitute a challenge to the ownership of that Product Identity. The owner of any Product Identity used in Open Game Content shall retain all rights, title and interest in and to that Product Identity.
+8. **Identification:** If you distribute Open Game Content You must clearly indicate which portions of the work that you are distributing are Open Game Content.
+
+}}
+\\page
+
+{{license,wide
+
+9. **Updating the License:** Wizards or its designated Agents may publish updated versions of this License. You may use any authorized version of this License to copy, modify and distribute any Open Game Content originally distributed under any version of this License.
+
+10. **Copy of this License:** You MUST include a copy of this License with every copy of the Open Game Content You Distribute.
+
+11. **Use of Contributor Credits:** You may not market or advertise the Open Game Content using the name of any Contributor unless You have written permission from the Contributor to do so.
+
+12. **Inability to Comply:** If it is impossible for You to comply with any of the terms of this License with respect to some or all of the Open Game Content due to statute, judicial order, or governmental regulation then You may not Use any Open Game Material so affected.
+
+13. **Termination:** This License will terminate automatically if You fail to comply with all terms herein and fail to cure such breach within 30 days of becoming aware of the breach. All sublicenses shall survive the termination of this License.
+
+14. **Reformation:** If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
+
+___
+
+*COPYRIGHT NOTICE Open Game License v 1.0a Copyright 2000, Wizards of the Coast, Inc.*
+
+___
+
+System Reference Document Copyright 2000-2003, Wizards of the Coast, Inc.; Authors Jonathan Tweet, Monte Cook, Skip Williams, Rich Baker, Andy Collins, David Noonan, Rich Redman, Bruce R. Cordell, John D. Rateliff, Thomas Reid, James Wyatt, based on original material by E. Gary Gygax and Dave Arneson.
+
+:
+
+END OF LICENSE
+
+}}`;
+	},
+
+	fcp : function () {
+		return `{{license,wide
+### Wizards of the Coast's Fan Content Policy
+                
+We (that’s ***Wizards of the Coast***) are continuously amazed at our Community’s creativity and engagement. We love that you enjoy creating and sharing Fan Content (that’s the stuff you make) and we want to encourage you to continue to create and share your stuff!
+ 
+You probably have a lot of questions about what you can and can’t do with Wizards’ intellectual property (IP), so we summoned our law mages to put together this [Fan Content Policy and FAQ](https://company.wizards.com/en/legal/fancontentpolicy). We hope that you understand that any restrictions in this Fan Content Policy are intended to protect Wizards and its games. We’ve got to protect our IP if we want to keep the lights on!
+ 
+In short, your use of Wizards’ IP in your Fan Content is governed by the same rules you learned on the playground: share freely, keep it clean, and don’t hurt others.
+ 
+That means we ask you follow these rules:
+ 
+1. **One word: F-R-E-E**. You can use Wizards’ IP (except for the restrictions listed in #3) to make Fan Content that you share with the community for free. Free means {{text-decoration:underline FREE}}:
+   
+- You can’t require payments, surveys, downloads, subscriptions, or email registration to access your Fan Content;
+   
+- You can’t sell or license your Fan Content to any third parties for any type of compensation; and
+   
+- Your Fan Content must be free for others (including Wizards) to view, access, share, and use without paying you anything, obtaining your approval, or giving you credit.
+ 
+___
+ 
+You can, however, subsidize your Fan Content by taking advantage of sponsorships, ad revenue, and donations—so long as it doesn’t interfere with the Community’s access to your Fan Content.
+ 
+ 
+2. **Tell the Community it’s unofficial**. Make it clear that your Fan Content is not endorsed or sponsored by Wizards—i.e., unofficial. Please include a note with your Fan Content explaining that:
+ 
+___
+ 
+“[Title of your Fan Content] is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.”
+ 
+3. **Don’t hurt others.** Please respect other people’s IP. If you don’t have the rights to use another person’s stuff in your Fan Content—don’t. If we learn that your Fan Content also includes other people’s IP (e.g., crossovers/mashups) without their permission, we may ask you to take it down.
+ 
+4. **Don’t hurt Wizards**. We ask that you refrain from doing any of the following:
+ 
+ 
+- **Don’t use Wizards’ logos and trademarks**. We’ve included a list of our most frequently asked-about trademarks in the FAQ;
+ 
+- **Don’t mess with the legal notices in our stuff**. If the Wizards IP you are incorporating into your Fan Content already has copyright notices, logos, trademarks, or other notices existing within it, don’t remove them;
+ 
+- **Don’t use Wizards’ IP in other games**. This includes your own or other people’s games or game components (e.g., rule books, tokens, figures), regardless of whether it is distributed for free;
+ 
+- **Don’t use Wizards’ Video or Music in your Fan Content**. We know our video trailers are awesome, but use of our videos and music are governed by contracts with third parties. Please don’t use any of our video or music content, unless you’re embedding a video from an authorized third-party’s website (e.g., Twitch or YouTube);
+   
+ 
+5. **No bad stuff**. We have the right to stop or restrict your use of Wizards’ IP at any time—for any reason or no reason—including when we think your use is inappropriate, offensive, damaging, or disparaging (and we’ll make that call in our sole discretion). If this happens, you must immediately take down your Fan Content or face the Demogorgon (yeah, the big bad is back from being on loan).
+ 
+6. **Practice safe sponsorship**. We understand that great Fan Content can sometimes require special equipment (e.g., videos, podcasts, prop fabrication). We are OK with you using third-party sponsors to subsidize costs if you follow a few rules:
+ 
+- Don’t use a sponsor that would be harmful to Wizards. Please don’t promote our competitors or endorse inappropriate or offensive sponsors;
+ 
+- Make it clear (verbally or visually) that they are acting as a sponsor only;
+ 
+- Keep any shout-outs, mentions, and credits to a reasonable length; and
+ 
+- Do not associate Wizards with your sponsor in any way.
+ 
+ 
+7. **Follow the law of the land**. It’s your Fan Content, so you are solely responsible for ensuring that your creations don’t violate the laws of your region, country, plane, or dimension. In addition to this Policy, your use of any Wizards’ IP must also comply with Wizards’ Terms of Use and Code of Conduct (together, the “Wizards Terms”). If there’s a conflict between anything in this Policy and the Wizards Terms, the Wizards Terms win. 
+ 
+}}
+ 
+ 
+\\page
+{{license,wide
+Those agreements include important legal terms (such as limitations of lability, indemnification, and dispute resolution), so please review them carefully.
+ 
+ 
+ 
+ **One last thing**—Please don’t pull us into any legal battles! Our lawyers are busy enough. If Wizards of the Coast, our partners, affiliates, or employees get hit with any legal claims, fees, or expenses related to your Fan Content, you’re responsible for paying all of our costs (including attorney’s fees) and any resulting judgment or settlement.
+ 
+ 
+ 
+}}
+`;
+	},
+};

--- a/themes/V3/Blank/style.less
+++ b/themes/V3/Blank/style.less
@@ -463,3 +463,32 @@ body {
 		}
 	}
 }
+
+//*******************************
+// * Ordered List Type Overrides
+// *****************************/
+.page{
+	.ol-ccby ol {
+		list-style-type: lower-alpha;
+	  }
+	  
+	  .ol-ccby ol ol{
+		padding-left: 0px !important;
+		list-style-type: greek;
+	  }
+	  
+	  .ol-ccby ol ol ol {
+		padding-left: 0px !important;
+		list-style-type: upper-alpha;
+	  }
+	  
+	  .ol-ccby ol ol ol ol {
+		padding-left: 0px !important;
+		list-style-type: lower-roman;
+	  }
+	  
+	  .ol-ccby p {
+		padding-left: 25px;
+		text-indent: 0em !important;
+	  }
+}


### PR DESCRIPTION
This extends the work done in PR 3090 to solve #1976

I reorganized things a little bit to use sub-menus and files per licensing organization. It makes it a bit easier to work around in though it's still awkward with the Creative Commons 

To Do:
  Creative Commons "deeds"
  Creative Commons image snippets
 layout tweaks ( sub-lists after rows with STRONG, in particular ) 

Maybe To Do:
  Various Publisher community licenses, such as the AGE Creators
Alliance, Super-Powered by M&M, various Drive Through RPG Content licenses, etc.