### PR TITLE
Render all pages

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -20,17 +20,17 @@ const PAGE_HEIGHT = 1056;
 const PPR_THRESHOLD = 50;
 
 const BrewPage = createClass({
-	displayName : `BrewPage`,
+	displayName     : `BrewPage`,
 	getDefaultProps : function() {
 		return {
 			contents : '',
-			index : 0
-		}
+			index    : 0
+		};
 	},
 	render : function() {
 		return <div className='page' id={`p${this.props.index + 1}`} >
 			<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: this.props.contents }} />
-		</div>
+		</div>;
 	}
 });
 
@@ -70,8 +70,8 @@ const BrewRenderer = createClass({
 												</head><body style='overflow: hidden'><div></div></body></html>`
 		};
 	},
-	height     : 0,
-	lastRender : <div></div>,
+	height        : 0,
+	lastRender    : <div></div>,
 	renderedPages : [],
 
 	componentWillUnmount : function() {

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -19,6 +19,21 @@ const Themes = require('themes/themes.json');
 const PAGE_HEIGHT = 1056;
 const PPR_THRESHOLD = 50;
 
+const BrewPage = createClass({
+	displayName : `BrewPage`,
+	getDefaultProps : function() {
+		return {
+			contents : '',
+			index : 0
+		}
+	},
+	render : function() {
+		return <div className='page' id={`p${this.props.index + 1}`} >
+			<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: this.props.contents }} />
+		</div>
+	}
+});
+
 const BrewRenderer = createClass({
 	displayName     : 'BrewRenderer',
 	getDefaultProps : function() {
@@ -57,6 +72,7 @@ const BrewRenderer = createClass({
 	},
 	height     : 0,
 	lastRender : <div></div>,
+	renderedPages : [],
 
 	componentWillUnmount : function() {
 		window.removeEventListener('resize', this.updateSize);
@@ -152,23 +168,21 @@ const BrewRenderer = createClass({
 			return <div className='phb page' id={`p${index + 1}`} dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(cleanPageText) }} key={index} />;
 		else {
 			cleanPageText += `\n\n&nbsp;\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
+			const html = Markdown.render(cleanPageText);
 			return (
-				<div className='page' id={`p${index + 1}`} key={index} >
-					<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: Markdown.render(cleanPageText) }} />
-				</div>
+				<BrewPage index={index} key={index} contents={html} />
 			);
 		}
 	},
 
 	renderPages : function(){
 		if(this.state.usePPR){
-			return _.map(this.state.pages, (page, index)=>{
-				if(this.shouldRender(page, index) && typeof window !== 'undefined'){
-					return this.renderPage(page, index);
-				} else {
-					return this.renderDummyPage(index);
+			_.forEach(this.state.pages, (page, index)=>{
+				if((this.shouldRender(page, index) || !this.renderedPages[index]) && typeof window !== 'undefined'){
+					this.renderedPages[index] = this.renderPage(page, index); // Render any page not yet rendered, but only re-render those in PPR range
 				}
 			});
+			return this.renderedPages;
 		}
 		if(this.props.errors && this.props.errors.length) return this.lastRender;
 		this.lastRender = _.map(this.state.pages, (page, index)=>{


### PR DESCRIPTION
Fixes #1923

Partial replacement for #3089 , which has revealed itself as perhaps too complicated for what it is trying to solve.

Currently, Partial Page Rendering mode for large brews only renders brews surrounding the currently-viewed page. Other pages are rendered as empty "dummy" pages for speed. This breaks internal links as per #1923 .

Turns out, the main slowdown isn't having all those pages in memory, but using `dangerouslySetInnerHTML` to inject our rendered Markdown into each page, because React always re-renders a component in that case. "Dummy" pages were always unchanged after the first render, and so did not consume any render time.

This PR simply adds a new small component called `BrewPage` which is passed in its rendered markdown as a prop which is *then* passed to `dangerouslySetInnerHTML`. Since React only re-renders components if the props or state changes, this means `dangerouslySetInnerHTML` will only fire if we pass in new HTML.

This PR renders all pages once, so they are present in memory and can be linked to. After that point, they are only updated if PPR mode determines they are in view. Dummy pages are no longer used for PPR mode (and can probably be removed altogether from the `renderPages()` function.

What this does *not* solve (yet):

- Unique auto-generated IDs
- Variables

However I think this, combined with breaking the markdown parsing process into a separate Tokenize and Render step will eventually solve those.