### PR TITLE
Primitives for inline variables

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -163,6 +163,7 @@ const BrewRenderer = createClass({
 	renderPages : function(){
 		if(this.state.usePPR){
 			return _.map(this.state.pages, (page, index)=>{
+				if(index == 0) { Markdown.resetBrewVars(); }
 				if(this.shouldRender(page, index) && typeof window !== 'undefined'){
 					return this.renderPage(page, index);
 				} else {

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -370,12 +370,13 @@ Marked.use(MarkedExtendedTables(), MarkedGFMHeadingId(), MarkedSmartypantsLite()
 renderer.link = function (href, title, text) {
 	let self = false;
 
-	if(!globalLinks[text]) {
-		return `[${text}]`;
+	if(!href.length) {
+		if(!globalLinks[text]) {
+			return `[${text}]`;
+		}
+		href = globalLinks[text].href;
+		title = globalLinks[text].title;
 	}
-
-	href = globalLinks[text].href;
-	title = globalLinks[text].title;
 
 	if((href) && (href[0] == '#')) {
 		self = true;

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -370,7 +370,7 @@ Marked.use(MarkedExtendedTables(), MarkedGFMHeadingId(), MarkedSmartypantsLite()
 renderer.link = function (href, title, text) {
 	let self = false;
 
-	if(!href.length) {
+	if(!href?.length) {
 		if(!globalLinks[text]) {
 			return `[${text}]`;
 		}
@@ -474,6 +474,9 @@ const processStyleTags = (string)=>{
 const globalLinks = {};
 
 module.exports = {
+	resetBrewVars : ()=>{
+		globalLinks = {};
+	},
 	marked : Marked,
 	render : (rawBrewText)=>{
 		rawBrewText = rawBrewText.replace(/^\\column$/gm, `\n<div class='columnSplit'></div>\n`)


### PR DESCRIPTION
This is experimental code based on some of the existing reflink pattern.

Due to the huge number of variations in link blocks, I went with double [] instead of single.

Example Brew code:

```
[a]:b
[[$b="this is a ;"]]


[[$b]]

With the quiet macro

[[a; $g="Hello";:q ]]

Without the quiet macro

[[a; $g="Hello" ]]

[[a]]

```

```
this is a ;

    this is a ;

    With the quiet macro

    Without the quiet macro

    Hello

    b
```

Just a start. Fails are few things, like, I can't seem to make it bold...