### PR TITLE
Make a lot of Markdown tests pass

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -45,7 +45,7 @@ const mustacheSpans = {
 			let delim;
 			while (delim = inlineRegex.exec(match[0])) {
 				if(!tags) {
-					tags = ` ${processStyleTags(delim[0].substring(2))}`;
+					tags = `${processStyleTags(delim[0].substring(2))}`;
 					endTags = delim[0].length;
 				}
 				if(delim[0].startsWith('{{')) {
@@ -95,7 +95,7 @@ const mustacheDivs = {
 			let delim;
 			while (delim = blockRegex.exec(match[0])?.[0].trim()) {
 				if(!tags) {
-					tags = ` ${processStyleTags(delim.substring(2))}`;
+					tags = `${processStyleTags(delim.substring(2))}`;
 					endTags = delim.length;
 				}
 				if(delim.startsWith('{{')) {
@@ -139,7 +139,7 @@ const mustacheInjectInline = {
 			if(!lastToken || lastToken.type == 'mustacheInjectInline')
 				return false;
 
-			const tags = ` ${processStyleTags(match[1])}`;
+			const tags = `${processStyleTags(match[1])}`;
 			lastToken.originalType = lastToken.type;
 			lastToken.type         = 'mustacheInjectInline';
 			lastToken.tags         = tags;
@@ -175,7 +175,7 @@ const mustacheInjectBlock = {
 					return false;
 
 				lastToken.originalType = 'mustacheInjectBlock';
-				lastToken.tags         = ` ${processStyleTags(match[1])}`;
+				lastToken.tags         = `${processStyleTags(match[1])}`;
 				return {
 					type : 'mustacheInjectBlock', // Should match "name" above
 					raw  : match[0],              // Text to consume from the source
@@ -363,7 +363,7 @@ const processStyleTags = (string)=>{
 	const id      = _.remove(tags, (tag)=>tag.startsWith('#')).map((tag)=>tag.slice(1))[0];
 	const classes = _.remove(tags, (tag)=>!tag.includes(':'));
 	const styles  = tags.map((tag)=>tag.replace(/:"?([^"]*)"?/g, ':$1;'));
-	return `${classes.join(' ')}" ${id ? `id="${id}"` : ''} ${styles.length ? `style="${styles.join(' ')}"` : ''}`;
+	return `${classes.length ? ` ${classes.join(' ')}` : ''}"${id ? ` id="${id}"` : ''}${styles.length ? ` style="${styles.join(' ')}"` : ''}`;
 };
 
 module.exports = {

--- a/tests/markdown/mustache-syntax.test.js
+++ b/tests/markdown/mustache-syntax.test.js
@@ -13,109 +13,94 @@ String.prototype.trimReturns = function(){
 // Remove the `.failing()` method once you have fixed the issue.
 
 describe('Inline: When using the Inline syntax {{ }}', ()=>{
-	it.failing('Renders a mustache span with text only', function() {
+	it('Renders a mustache span with text only', function() {
 		const source = '{{ text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text only, but with spaces', function() {
+	it('Renders a mustache span with text only, but with spaces', function() {
 		const source = '{{ this is a text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block">this is a text</span>');
 	});
 
-	it.failing('Renders an empty mustache span', function() {
+	it('Renders an empty mustache span', function() {
 		const source = '{{}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block"></span>');
 	});
 
-	it.failing('Renders a mustache span with just a space', function() {
+	it('Renders a mustache span with just a space', function() {
 		const source = '{{ }}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block"></span>');
 	});
 
-	it.failing('Renders a mustache span with a few spaces only', function() {
+	it('Renders a mustache span with a few spaces only', function() {
 		const source = '{{     }}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block"></span>');
 	});
 
-	it.failing('Renders a mustache span with text and class', function() {
+	it('Renders a mustache span with text and class', function() {
 		const source = '{{my-class text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds two extra \s before closing `>` in opening tag.
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block my-class">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and two classes', function() {
+	it('Renders a mustache span with text and two classes', function() {
 		const source = '{{my-class,my-class2 text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds two extra \s before closing `>` in opening tag.
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block my-class my-class2">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text with spaces and class', function() {
+	it('Renders a mustache span with text with spaces and class', function() {
 		const source = '{{my-class this is a text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds two extra \s before closing `>` in opening tag
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block my-class">this is a text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and id', function() {
+	it('Renders a mustache span with text and id', function() {
 		const source = '{{#my-span text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s before closing `>` in opening tag, and another after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" id="my-span">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and two ids', function() {
+	it('Renders a mustache span with text and two ids', function() {
 		const source = '{{#my-span,#my-favorite-span text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s before closing `>` in opening tag, and another after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" id="my-span">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and css property', function() {
+	it('Renders a mustache span with text and css property', function() {
 		const source = '{{color:red text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="color:red;">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and two css properties', function() {
+	it('Renders a mustache span with text and two css properties', function() {
 		const source = '{{color:red,padding:5px text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="color:red; padding:5px;">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and css property which contains quotes', function() {
+	it('Renders a mustache span with text and css property which contains quotes', function() {
 		const source = '{{font-family:"trebuchet ms" text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="font-family:trebuchet ms;">text</span>');
 	});
 
-	it.failing('Renders a mustache span with text and two css properties which contains quotes', function() {
+	it('Renders a mustache span with text and two css properties which contains quotes', function() {
 		const source = '{{font-family:"trebuchet ms",padding:"5px 10px" text}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="font-family:trebuchet ms; padding:5px 10px;">text</span>');
 	});
 
 
-	it.failing('Renders a mustache span with text with quotes and css property which contains quotes', function() {
+	it('Renders a mustache span with text with quotes and css property which contains quotes', function() {
 		const source = '{{font-family:"trebuchet ms" text "with quotes"}}';
 		const rendered = Markdown.render(source);
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="font-family:trebuchet ms;">text “with quotes”</span>');
 	});
 
@@ -129,21 +114,19 @@ describe('Inline: When using the Inline syntax {{ }}', ()=>{
 //  BLOCK SYNTAX
 
 describe(`Block: When using the Block syntax {{tags\\ntext\\n}}`, ()=>{
-	it.failing('Renders a div with text only', function() {
+	it('Renders a div with text only', function() {
 		const source = dedent`{{
 		text
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block"><p>text</p></div>`);
 	});
 
-	it.failing('Renders an empty div', function() {
+	it('Renders an empty div', function() {
 		const source = dedent`{{
 
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds extra \s after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block"></div>`);
 	});
 
@@ -151,52 +134,46 @@ describe(`Block: When using the Block syntax {{tags\\ntext\\n}}`, ()=>{
 		const source = dedent`{{
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// this actually renders in HB as '{{ }}'...
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<p>{{}}</p>`);
 	});
 
-	it.failing('Renders a div with a single class', function() {
+	it('Renders a div with a single class', function() {
 		const source = dedent`{{cat
 
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds two extra \s before closing `>` in opening tag
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat"></div>`);
 	});
 
-	it.failing('Renders a div with a single class and text', function() {
+	it('Renders a div with a single class and text', function() {
 		const source = dedent`{{cat
 		Sample text.
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds two extra \s before closing `>` in opening tag
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat"><p>Sample text.</p></div>`);
 	});
 
-	it.failing('Renders a div with two classes and text', function() {
+	it('Renders a div with two classes and text', function() {
 		const source = dedent`{{cat,dog
 		Sample text.
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds two extra \s before closing `>` in opening tag
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat dog"><p>Sample text.</p></div>`);
 	});
 
-	it.failing('Renders a div with a style and text', function() {
+	it('Renders a div with a style and text', function() {
 		const source = dedent`{{color:red
 		Sample text.
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds two extra \s before closing `>` in opening tag
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block" style="color:red;"><p>Sample text.</p></div>`);
 	});
 
-	it.failing('Renders a div with a class, style and text', function() {
+	it('Renders a div with a class, style and text', function() {
 		const source = dedent`{{cat,color:red
 		Sample text.
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds extra \s after the class attribute
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat" style="color:red;"><p>Sample text.</p></div>`);
 	});
 
@@ -208,12 +185,11 @@ describe(`Block: When using the Block syntax {{tags\\ntext\\n}}`, ()=>{
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block cat" id="dog" style="color:red;"><p>Sample text.</p></div>`);
 	});
 
-	it.failing('Renders a div with a single ID', function() {
+	it('Renders a div with a single ID', function() {
 		const source = dedent`{{#cat,#dog
 		Sample text.
 		}}`;
 		const rendered = Markdown.render(source).trimReturns();
-		// FIXME: adds extra \s before closing `>` in opening tag, and another after class names
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<div class="block" id="cat"><p>Sample text.</p></div>`);
 	});
 });


### PR DESCRIPTION
Lots of our Markdown tests were failing due to small whitespace differences. These are now changed to remove `it.failing` because they actually pass now.