### PR TITLE
Navigator Node Error Fix

### DIFF
--- a/shared/naturalcrit/codeEditor/codeEditor.jsx
+++ b/shared/naturalcrit/codeEditor/codeEditor.jsx
@@ -7,7 +7,7 @@ const cx = require('classnames');
 const closeTag = require('./close-tag');
 
 let CodeMirror;
-if(typeof navigator !== 'undefined'){
+if(typeof window !== 'undefined'){
 	CodeMirror = require('codemirror');
 
 	//Language Modes


### PR DESCRIPTION
From Gitter chat: "The newest Node version added a "navigator" object -- Heroku must be grabbing that version automatically -- which conflicts with our check whether the page is on the server or in a browser"

This PR only changes that keyword in a specific check, fixing deployments.