### PR TITLE
MustacheDivs do not account for prefixed spaces when generating text

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -96,7 +96,7 @@ const mustacheDivs = {
 			while (delim = blockRegex.exec(match[0])?.[0].trim()) {
 				if(!tags) {
 					tags = `${processStyleTags(delim.substring(2))}`;
-					endTags = delim.length;
+					endTags = delim.length + src.indexOf(delim);
 				}
 				if(delim.startsWith('{{')) {
 					blockCount++;


### PR DESCRIPTION
This PR resolves #3192.

This PR adds functionality to include the delimiter's position in the `endTags` location index.