### PR TITLE
Color simplification and Darkbrewery snippet color fix

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -4,6 +4,8 @@
 	position         : relative;
 	height           : @menuHeight;
 	background-color : #ddd;
+	color			 : black;
+
 	.editors{
 		position        : absolute;
 		display         : flex;
@@ -34,7 +36,7 @@
 				font-size : 0.75em;
 				color     : grey;
 				&.active{
-					color : black;
+					color : inherit;
 				}
 			}
 			&.redo{
@@ -42,29 +44,23 @@
 				font-size : 0.75em;
 				color     : grey;
 				&.active{
-					color : black;
+					color : inherit;
 				}
 			}
 			&.foldAll{
 				.tooltipLeft('Fold All');
 				font-size : 0.75em;
-				color     : grey;
-				&.active{
-					color : black;
-				}
+				color     : inherit;
 			}
 			&.unfoldAll{
 				.tooltipLeft('Unfold All');
 				font-size : 0.75em;
-				color     : grey;
-				&.active{
-					color : black;
-				}
+				color     : inherit;
 			}
 			&.editorTheme{
 				.tooltipLeft('Editor Themes');
 				font-size : 0.75em;
-				color     : black;
+				color     : inherit;
 				&.active{
 					color : white;
 					background-color: black;

--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -67,7 +67,7 @@
 				}
 			}
 			&.divider {
-				background: linear-gradient(#000, #000) no-repeat center/1px 100%;
+				background: linear-gradient(currentColor, currentColor) no-repeat center/1px 100%;
 				width: 5px;
 				&:hover{
 					background-color: inherit;
@@ -110,7 +110,7 @@
 		.tooltipLeft("Edit Brew Properties");
 	}
 	.snippetGroup{
-		border-right   : 1px solid black;
+		border-right   : 1px solid currentColor;
 		&:hover{
 			&>.dropdown{
 				visibility : visible;


### PR DESCRIPTION
Minor changes, allowing for the color change to take effect:

### Before:
<img width="402" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/91662974/d9b46428-5622-4109-8b73-d96d5b5e0f88">

### After:
<img width="396" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/91662974/5bac70da-3951-4261-a7d8-a28f9d0ebcb6">