### PR TITLE
Fix for Brew title parsed as markdown on Error pages. e.g. images will be rendered.

### DIFF
--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -2,7 +2,12 @@ const dedent = require('dedent-tabs').default;
 
 const loginUrl = 'https://www.naturalcrit.com/login';
 
+const lazySantizize = (s)=>{
+	return s.replace('<', '&lt;');
+};
+
 const errorIndex = (props)=>{
+	const cleanBrewTitle = lazySantizize(props.brew.brewTitle);
 	return {
 		// Default catch all
 		'00' : dedent`
@@ -73,7 +78,7 @@ const errorIndex = (props)=>{
 		**Properties** tab, and adding your username to the "invited authors" list. You can
 		then try to access this document again.
 		
-		**Brew Title:** ${props.brew.brewTitle || 'Unable to show title'}
+		**Brew Title:** ${cleanBrewTitle || 'Unable to show title'}
 
 		**Current Authors:** ${props.brew.authors?.map((author)=>{return `${author}`;}).join(', ') || 'Unable to list authors'}
 		
@@ -86,7 +91,7 @@ const errorIndex = (props)=>{
 		You must be logged in to one of the accounts listed as an author of this brew.
 		User is not logged in. Please log in [here](${loginUrl}).
 		
-		**Brew Title:** ${props.brew.brewTitle || 'Unable to show title'}
+		**Brew Title:** ${cleanBrewTitle || 'Unable to show title'}
 
 		**Current Authors:** ${props.brew.authors?.map((author)=>{return `${author}`;}).join(', ') || 'Unable to list authors'}`,
 

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -3,7 +3,19 @@ const dedent = require('dedent-tabs').default;
 const loginUrl = 'https://www.naturalcrit.com/login';
 
 const lazySantizize = (s)=>{
-	return s.replace('<', '&lt;');
+	const replaceStrings = {
+	  '&' : '&amp;',
+	  '<' : '&lt;',
+	  '>' : '&gt;',
+	  '[' : '\[',
+	  ']' : '\]',
+	  '{' : '\{',
+	  '}' : '\}',
+	  ':' : '\:'
+	};
+	for (const replaceStr in replaceStrings) {
+		s = s.replaceAll(replaceStr, replaceStrings[replaceStr]);
+	}
 };
 
 const errorIndex = (props)=>{


### PR DESCRIPTION
This resolves issue #3231 by performing a non-destructive lazy sanitize on HTML tags that might exist in the props.brew.brewTitle when passed to an error page.