### PR TITLE
Use a brew as a theme, prep work for user sharable theming.

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -255,7 +255,7 @@ const api = {
 				res.set('Content-Type', 'text/css');
 			}
 			const parentTheme = themeParent ? `@import /api/css/${req.params.engine}/${themeParent}\n` : '';
-			return res.status(200).send(`${parentTheme}@import /themes/${req.params.engine}/${req.params.id}\n`);
+			return res.status(200).send(`${parentTheme}@import /themes/${req.params.engine}/${req.params.id}/style.css\n`);
 		}
 	},
 	updateBrew : async (req, res)=>{

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -219,10 +219,10 @@ const api = {
 			req.brew.style = req.brew.text.slice(7, index - 1);
 			req.brew.text = req.brew.text.slice(index + 5);
 		}
-		return res.status(200).send(JSON.stringify({
+		return res.status(200).send({
 			parent : req.brew.theme,
 			theme  : req.brew.style
-		}));
+		});
 	},
 	getBrewThemeAsCSS : async (req, res)=>{
 		req.brew.text = req.brew.text.replaceAll('\r\n', '\n');
@@ -238,7 +238,9 @@ const api = {
 			req.brew.style = req.brew.text.slice(7, index - 1);
 			req.brew.text = req.brew.text.slice(index + 5);
 		}
-		res.setHeader('Content-Type', 'text/css');
+		if(res.hasOwnProperty('set')) {
+			res.set('Content-Type', 'text/css');
+		}
 		return res.status(200).send(req.brew.style);
 	},
 	getBrewThemeWithCSS : async (req, res)=>{
@@ -255,9 +257,11 @@ const api = {
 			req.brew.style = req.brew.text.slice(7, index - 1);
 			req.brew.text = req.brew.text.slice(index + 5);
 		}
-		res.setHeader('Content-Type', 'text/css');
+		if(res.hasOwnProperty('set')) {
+			res.set('Content-Type', 'text/css');
+		}
 		const parentThemeImport = `@import /themes/${req.brew.renderer}/${req.brew.theme}/styles.css\n\n`;
-		return res.status(200).send(`${req.brew.renderer != 'legacy' ? '' : parentThemeImport}${req.brew.style}`);
+		return res.status(200).send(`${req.brew.renderer == 'legacy' ? '' : parentThemeImport}${req.brew.style}`);
 	},
 	updateBrew : async (req, res)=>{
 		// Initialize brew from request and body, destructure query params, and set the initial value for the after-save method

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -220,8 +220,9 @@ const api = {
 			req.brew.text = req.brew.text.slice(index + 5);
 		}
 		return res.status(200).send({
-			parent : req.brew.theme,
-			theme  : req.brew.style
+			parent    : req.brew.theme,
+			theme     : req.brew.style,
+			themeName : req.brew.title
 		});
 	},
 	getBrewThemeAsCSS : async (req, res)=>{
@@ -241,7 +242,7 @@ const api = {
 		if(res.hasOwnProperty('set')) {
 			res.set('Content-Type', 'text/css');
 		}
-		return res.status(200).send(req.brew.style);
+		return res.status(200).send(`// From Theme: ${req.brew.title}\n\n${req.brew.style}`);
 	},
 	getBrewThemeWithCSS : async (req, res)=>{
 		req.brew.text = req.brew.text.replaceAll('\r\n', '\n');
@@ -260,7 +261,7 @@ const api = {
 		if(res.hasOwnProperty('set')) {
 			res.set('Content-Type', 'text/css');
 		}
-		const parentThemeImport = `@import /themes/${req.brew.renderer}/${req.brew.theme}/styles.css\n\n`;
+		const parentThemeImport = `// From Theme: ${req.brew.title}\n\n@import /themes/${req.brew.renderer}/${req.brew.theme}/styles.css\n\n`;
 		return res.status(200).send(`${req.brew.renderer == 'legacy' ? '' : parentThemeImport}${req.brew.style}`);
 	},
 	updateBrew : async (req, res)=>{

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -205,6 +205,60 @@ const api = {
 
 		res.status(200).send(saved);
 	},
+	getBrewTheme : async (req, res)=>{
+		req.brew.text = req.brew.text.replaceAll('\r\n', '\n');
+		if(req.brew.text.startsWith('```metadata')) {
+			const index = req.brew.text.indexOf('```\n\n');
+			const metadataSection = req.brew.text.slice(12, index - 1);
+			const metadata = yaml.load(metadataSection);
+			Object.assign(req.brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']));
+			req.brew.text = req.brew.text.slice(index + 5);
+		}
+		if(req.brew.text.startsWith('```css')) {
+			const index = req.brew.text.indexOf('```\n\n');
+			req.brew.style = req.brew.text.slice(7, index - 1);
+			req.brew.text = req.brew.text.slice(index + 5);
+		}
+		return res.status(200).send(JSON.stringify({
+			parent : req.brew.theme,
+			theme  : req.brew.style
+		}));
+	},
+	getBrewThemeAsCSS : async (req, res)=>{
+		req.brew.text = req.brew.text.replaceAll('\r\n', '\n');
+		if(req.brew.text.startsWith('```metadata')) {
+			const index = req.brew.text.indexOf('```\n\n');
+			const metadataSection = req.brew.text.slice(12, index - 1);
+			const metadata = yaml.load(metadataSection);
+			Object.assign(req.brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']));
+			req.brew.text = req.brew.text.slice(index + 5);
+		}
+		if(req.brew.text.startsWith('```css')) {
+			const index = req.brew.text.indexOf('```\n\n');
+			req.brew.style = req.brew.text.slice(7, index - 1);
+			req.brew.text = req.brew.text.slice(index + 5);
+		}
+		res.setHeader('Content-Type', 'text/css');
+		return res.status(200).send(req.brew.style);
+	},
+	getBrewThemeWithCSS : async (req, res)=>{
+		req.brew.text = req.brew.text.replaceAll('\r\n', '\n');
+		if(req.brew.text.startsWith('```metadata')) {
+			const index = req.brew.text.indexOf('```\n\n');
+			const metadataSection = req.brew.text.slice(12, index - 1);
+			const metadata = yaml.load(metadataSection);
+			Object.assign(req.brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']));
+			req.brew.text = req.brew.text.slice(index + 5);
+		}
+		if(req.brew.text.startsWith('```css')) {
+			const index = req.brew.text.indexOf('```\n\n');
+			req.brew.style = req.brew.text.slice(7, index - 1);
+			req.brew.text = req.brew.text.slice(index + 5);
+		}
+		res.setHeader('Content-Type', 'text/css');
+		const parentThemeImport = `@import /themes/${req.brew.renderer}/${req.brew.theme}/styles.css\n\n`;
+		return res.status(200).send(`${req.brew.renderer != 'legacy' ? '' : parentThemeImport}${req.brew.style}`);
+	},
 	updateBrew : async (req, res)=>{
 		// Initialize brew from request and body, destructure query params, and set the initial value for the after-save method
 		const brewFromClient = api.excludePropsFromUpdate(req.body);
@@ -365,5 +419,9 @@ router.put('/api/:id', asyncHandler(api.getBrew('edit', true)), asyncHandler(api
 router.put('/api/update/:id', asyncHandler(api.getBrew('edit', true)), asyncHandler(api.updateBrew));
 router.delete('/api/:id', asyncHandler(api.deleteBrew));
 router.get('/api/remove/:id', asyncHandler(api.deleteBrew));
+router.get('/api/theme/:id', asyncHandler(api.getBrew('edit', true)),  asyncHandler(api.getBrewTheme));
+router.get('/api/css/:id', asyncHandler(api.getBrew('edit', true)),  asyncHandler(api.getBrewThemeAsCSS));
+router.get('/api/csstheme/:id', asyncHandler(api.getBrew('edit', true)),  asyncHandler(api.getBrewThemeWithCSS));
+
 
 module.exports = api;

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -569,6 +569,78 @@ brew`);
 		});
 	});
 
+	describe('getBrewTheme', ()=>{
+		it('should collect parent theme and brew style', async ()=>{
+			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
+			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', style: 'I Have a style!' }));
+			const brewResults = {
+				authors     : [],
+				createdAt   : undefined,
+				description : '',
+				editId      : undefined,
+				gDrive      : false,
+				lang        : 'en',
+				pageCount   : 1,
+				published   : false,
+				renderer    : 'legacy',
+				shareId     : undefined,
+				style       : 'I Have a style!',
+				systems     : [],
+				tags        : [],
+				text        : '',
+				theme       : '5ePHB',
+				thumbnail   : '',
+				title       : 'test brew',
+				trashed     : false,
+				updatedAt   : undefined,
+				views       : 0
+			};
+			const fn = api.getBrew('share', true);
+			const req = { brew: {} };
+			const next = jest.fn();
+			await fn(req, null, next);
+
+			api.getBrewTheme(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(req.brew).toStrictEqual(brewResults);
+			expect(res.status).toHaveBeenCalledWith(200);
+			expect(sent.parent).toBe('5ePHB');
+			expect(sent.theme).toBe('I Have a style!');
+		});
+	});
+
+	describe('getBrewAsThemeCSS', ()=>{
+		it('should collect the brew style - returning as css', async ()=>{
+			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
+			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', style: 'I Have a style!' }));
+			const fn = api.getBrew('share', true);
+			const req = { brew: {} };
+			const next = jest.fn();
+			await fn(req, null, next);
+
+			api.getBrewThemeAsCSS(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(sent).toBe('I Have a style!');
+			expect(res.status).toHaveBeenCalledWith(200);
+		});
+	});
+
+	describe('getBrewThemeWithCSS', ()=>{
+		it('should collect parent theme and brew style - returning as css with parent imported.', async ()=>{
+			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
+			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', renderer: 'V3', style: 'I Have a style!' }));
+			const fn = api.getBrew('share', true);
+			const req = { brew: {} };
+			const next = jest.fn();
+			await fn(req, null, next);
+
+			api.getBrewThemeWithCSS(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(sent).toBe(`@import /themes/V3/5ePHB/styles.css\n\nI Have a style!`);
+			expect(res.status).toHaveBeenCalledWith(200);
+		});
+	});
+
 	describe('deleteBrew', ()=>{
 		it('should handle case where fetching the brew returns an error', async ()=>{
 			api.getBrew = jest.fn(()=>async ()=>{ throw { message: 'err', HBErrorCode: '02' }; });

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -569,64 +569,8 @@ brew`);
 		});
 	});
 
-	describe('getBrewTheme', ()=>{
-		it('should collect parent theme and brew style', async ()=>{
-			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
-			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', style: 'I Have a style!' }));
-			const brewResults = {
-				authors     : [],
-				createdAt   : undefined,
-				description : '',
-				editId      : undefined,
-				gDrive      : false,
-				lang        : 'en',
-				pageCount   : 1,
-				published   : false,
-				renderer    : 'legacy',
-				shareId     : undefined,
-				style       : 'I Have a style!',
-				systems     : [],
-				tags        : [],
-				text        : '',
-				theme       : '5ePHB',
-				thumbnail   : '',
-				title       : 'test brew',
-				trashed     : false,
-				updatedAt   : undefined,
-				views       : 0
-			};
-			const fn = api.getBrew('share', true);
-			const req = { brew: {} };
-			const next = jest.fn();
-			await fn(req, null, next);
-
-			api.getBrewTheme(req, res);
-			const sent = res.send.mock.calls[0][0];
-			expect(req.brew).toStrictEqual(brewResults);
-			expect(res.status).toHaveBeenCalledWith(200);
-			expect(sent.parent).toBe('5ePHB');
-			expect(sent.theme).toBe('I Have a style!');
-		});
-	});
-
-	describe('getBrewAsThemeCSS', ()=>{
-		it('should collect the brew style - returning as css', async ()=>{
-			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
-			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', style: 'I Have a style!' }));
-			const fn = api.getBrew('share', true);
-			const req = { brew: {} };
-			const next = jest.fn();
-			await fn(req, null, next);
-
-			api.getBrewThemeAsCSS(req, res);
-			const sent = res.send.mock.calls[0][0];
-			expect(sent).toBe('I Have a style!');
-			expect(res.status).toHaveBeenCalledWith(200);
-		});
-	});
-
-	describe('getBrewThemeWithCSS', ()=>{
-		it('should collect parent theme and brew style - returning as css with parent imported.', async ()=>{
+	describe('getBrewThemeWithStaticParent', ()=>{
+		it('should collect parent theme and brew style - returning as css with static parent imported.', async ()=>{
 			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
 			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', renderer: 'V3', style: 'I Have a style!' }));
 			const fn = api.getBrew('share', true);
@@ -636,10 +580,66 @@ brew`);
 
 			api.getBrewThemeWithCSS(req, res);
 			const sent = res.send.mock.calls[0][0];
-			expect(sent).toBe(`@import /themes/V3/5ePHB/styles.css\n\nI Have a style!`);
+			expect(sent).toBe(`// From Theme: test brew\n\n@import /api/css/V3/5ePHB/styles.css\n\nI Have a style!`);
 			expect(res.status).toHaveBeenCalledWith(200);
 		});
 	});
+
+	describe('getBrewThemeWithUserParent', ()=>{
+		it('should collect parent theme and brew style - returning as css with user-theme parent imported.', async ()=>{
+			const toBrewPromise = (brew)=>new Promise((res)=>res({ toObject: ()=>brew }));
+			model.get = jest.fn(()=>toBrewPromise({ title: 'test brew', renderer: 'V3', theme: '#IamATheme', style: 'I Have a style!' }));
+			const fn = api.getBrew('share', true);
+			const req = { brew: {} };
+			const next = jest.fn();
+			await fn(req, null, next);
+
+			api.getBrewThemeWithCSS(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(sent).toBe(`// From Theme: test brew\n\n@import /api/css/IamATheme\n\nI Have a style!`);
+			expect(res.status).toHaveBeenCalledWith(200);
+		});
+	});
+
+	describe('getStaticTheme', ()=>{
+		it('should return an import of the theme without including a parent.', async ()=>{
+			const req = {
+				params : {
+					engine : 'V3',
+					id     : '5ePHB'
+				}
+			};
+			api.getStaticTheme(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(sent).toBe('@import /themes/V3/5ePHB\n');
+			expect(res.status).toHaveBeenCalledWith(200);
+		});
+		it('should return an import of the theme including a parent.', async ()=>{
+			const req = {
+				params : {
+					engine : 'V3',
+					id     : '5eDMG'
+				}
+			};
+			api.getStaticTheme(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(sent).toBe('@import /api/css/V3/5ePHB\n@import /themes/V3/5eDMG\n');
+			expect(res.status).toHaveBeenCalledWith(200);
+		});
+		it('should fail for an invalid static theme.', async()=>{
+			const req = {
+				params : {
+					engine : 'V3',
+					id     : '5eDMGGGG'
+				}
+			};
+			api.getStaticTheme(req, res);
+			const sent = res.send.mock.calls[0][0];
+			expect(sent).toBe('Invalid Theme - Engine: V3, Name: 5eDMGGGG');
+			expect(res.status).toHaveBeenCalledWith(404);
+		});
+	});
+
 
 	describe('deleteBrew', ()=>{
 		it('should handle case where fetching the brew returns an error', async ()=>{

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -611,7 +611,7 @@ brew`);
 			};
 			api.getStaticTheme(req, res);
 			const sent = res.send.mock.calls[0][0];
-			expect(sent).toBe('@import /themes/V3/5ePHB\n');
+			expect(sent).toBe('@import /themes/V3/5ePHB/style.css\n');
 			expect(res.status).toHaveBeenCalledWith(200);
 		});
 		it('should return an import of the theme including a parent.', async ()=>{
@@ -623,7 +623,7 @@ brew`);
 			};
 			api.getStaticTheme(req, res);
 			const sent = res.send.mock.calls[0][0];
-			expect(sent).toBe('@import /api/css/V3/5ePHB\n@import /themes/V3/5eDMG\n');
+			expect(sent).toBe('@import /api/css/V3/5ePHB\n@import /themes/V3/5eDMG/style.css\n');
 			expect(res.status).toHaveBeenCalledWith(200);
 		});
 		it('should fail for an invalid static theme.', async()=>{


### PR DESCRIPTION
This PR explores the idea of User themes being derived from brew documents. It does not address the notion of permissions ( beyond normal brew access ) or tagging a brew as a theme document. The only limitation it places is on the csstheme endpoint not including the theme if it uses the legacy renderer.

This has been implemented in three different ways to allow for comparison and discussion

- /api/css/:id : This returns the style frontmatter of the referenced document as a text/css document. 
- /api/theme/:id : This returns an object with the reference'd object's theme and style frontmatter.
- /api/csstheme/:id : This returns the stylye frontmatter of the referenced document as a text/css document and adds the theme as an @import ( if not using the legacy renderer )

I prepared the PR this way to make comparing and contrasting the different methods easier.

## Update

Based on revisiting earlier conversations on theme parenting, I have removed the first two options and renamed the path for the third as /css/. 

I have added an additional option for parental recursion on static themes. 

 - /api/css/[renderer]/[theme] will import the parent theme ( if present ) via the API path and the theme via its static path and . For example, /api/css/V3/5eDMG will result in 
 ```
 @import /api/css/V3/5ePHB
 @import /themes/V3/5eDMG/style.css
```