### PR TITLE
Fix sanitizeScriptTags when content is null

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -104,8 +104,9 @@ const BrewRenderer = (props)=>{
 
 	const sanitizeScriptTags = (content)=>{
 		return content
-			.replace(/<script/ig, '&lt;script')
-			.replace(/<\/script>/ig, '&lt;/script&gt;');
+			?.replace(/<script/ig, '&lt;script')
+			.replace(/<\/script>/ig, '&lt;/script&gt;')
+			|| '';
 	};
 
 	const renderPageInfo = ()=>{


### PR DESCRIPTION
This PR resolves #3315.

This PR modifies the sanitizeScriptTags function to properly handle the null case, which will preventing website crashing to a white screen when the content window is empty.