### PR TITLE
Updated Table of Contents snippet

### DIFF
--- a/themes/V3/5ePHB/snippets/tableOfContents.gen.js
+++ b/themes/V3/5ePHB/snippets/tableOfContents.gen.js
@@ -78,7 +78,7 @@ module.exports = function(props){
 
 	return dedent`
 		{{toc,wide
-		# Table Of Contents
+		# Contents
 
 		${markdown}
 		}}


### PR DESCRIPTION
Fix for #3344 
I changed it to "Contents" following the 5e books (I checked and they use only "Contents" instead of "Table of Contents"). 
If "Table of Contents" is preferred, I can simply change it. 