### PR TITLE
Add definition list test: ensure inline has priority over multiline

### DIFF
--- a/tests/markdown/definition-lists.test.js
+++ b/tests/markdown/definition-lists.test.js
@@ -82,4 +82,10 @@ describe('Multiline Definition Lists', ()=>{
 		const rendered = Markdown.render(source).trim();
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<h2 id="header">Header</h2>\n<dl><dt></dt><dd>Definition 1 of a single-line DL</dd>\n<dt></dt><dd>Definition 1 of another single-line DL</dd>\n</dl>');
 	});
+
+	test('Inline DL has priority over Multiline', function() {
+		const source = 'Term 1 :: Inline definition 1\n:: Inline definition 2 (no DT)';
+		const rendered = Markdown.render(source).trim();
+		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<dl><dt>Term 1</dt><dd>Inline definition 1</dd>\n<dt></dt><dd>Inline definition 2 (no DT)</dd>\n</dl>');
+	});
 });


### PR DESCRIPTION
This PR adds a test to ensure that inline definition list declarations are given priority over multiline definition list declarations, as per the Gitter chat (captured below):

![image](https://github.com/naturalcrit/homebrewery/assets/19826659/3163fbc3-8434-4657-a29b-9b7e16b28712)

This PR takes the example, as given by @calculuschild and adds it as a test to the file `definition-lists.test.js`.