### PR TITLE
Fix crash when match is undefined

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -337,7 +337,7 @@ const definitionListsMultiline = {
 		const definitions = [];
 		while (match = regex.exec(src)) {
 			if(match[1]) {
-				if(this.lexer.blockTokens(match[1].trim())[0].type !== 'paragraph') // DT must not be another block-level token besides <p>
+				if(this.lexer.blockTokens(match[1].trim())[0]?.type !== 'paragraph') // DT must not be another block-level token besides <p>
 					break;
 				definitions.push({
 					dt  : this.lexer.inlineTokens(match[1].trim()),


### PR DESCRIPTION
This PR resolves #3374.

This PR slightly changes the logic of the test to allow `undefined` results to not crash the render process.