### PR TITLE
Changes to terminal output on server start

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,8 +12,9 @@ DB.connect(config).then(()=>{
 		const cyan = '\x1b[36m'; // Cyan color
 		const underline = '\x1b[4m'; // Underlined style
 
-		console.log(`\n\tserver on port: ${PORT}`);
-		console.log(`\t${underline}${bright}${cyan}Open in browser: http://localhost:${PORT}${reset}`)
+		console.log(`\n\tserver started at: ${new Date().toLocaleString()}`);
+		console.log(`\tserver on port: ${PORT}`);
+		console.log(`\t${bright + cyan}Open in browser: ${reset}${underline + bright + cyan}http://localhost:${PORT}${reset}\n\n`)
 
 	});
 });

--- a/server.js
+++ b/server.js
@@ -7,6 +7,13 @@ DB.connect(config).then(()=>{
 	// before launching server
 	const PORT = process.env.PORT || config.get('web_port') || 8000;
 	server.app.listen(PORT, ()=>{
-		console.log(`server on port: ${PORT}`);
+		const reset = '\x1b[0m'; // Reset to default style
+		const bright = '\x1b[1m'; // Bright (bold) style
+		const cyan = '\x1b[36m'; // Cyan color
+		const underline = '\x1b[4m'; // Underlined style
+
+		console.log(`\n\tserver on port: ${PORT}`);
+		console.log(`\t${underline}${bright}${cyan}Open in browser: http://localhost:${PORT}${reset}`)
+
 	});
 });

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -7,7 +7,9 @@ const config = require('./config.js');
 
 let serviceAuth;
 if(!config.get('service_account')){
-	console.log('No Google Service Account in config files - Google Drive integration will not be available.');
+	const reset = '\x1b[0m'; // Reset to default style
+	const yellow = '\x1b[33m'; // yellow color
+	console.warn(`\n${yellow}No Google Service Account in config files - Google Drive integration will not be available.${reset}`);
 } else  {
 	const keys = typeof(config.get('service_account')) == 'string' ?
 		JSON.parse(config.get('service_account')) :
@@ -18,7 +20,7 @@ if(!config.get('service_account')){
 		serviceAuth.scopes = ['https://www.googleapis.com/auth/drive'];
 	} catch (err) {
 		console.warn(err);
-		console.log('Please make sure the Google Service Account is set up properly in your config files.');
+		console.warn('Please make sure the Google Service Account is set up properly in your config files.');
 	}
 }
 


### PR DESCRIPTION
This simply modifies the terminal output when running the build + start scripts in the repo.  It adds the URL of the server, so in local development the user will get "http://localhost:3000" which they can `cmd`/`ctrl` `click` to open the local Homebrewery in their browser. And, it just adds a smidgen of color to highlight that URL and the Google Service Account error.

It could be improved if I could find out how to take the nodejs errors like "DEP0040: ...punycode..." and further style them or move them so that the Service Account error would come after them.  I looked and I looked and couldn't find how to intercept those errors (in a meaningful way).

<img width="868" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/1afd73f2-0a2f-43cd-a640-3de3b7821f7f">
