### PR TITLE
Align snippet menu icons and names

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -130,6 +130,8 @@
 					height       : 1.2em;
 					margin-right : 8px;
 					font-size    : 1.2em;
+					min-width: 25px;
+					text-align: center;
 					& ~ i {
 						margin-right : 0;
 						margin-left  : 5px;
@@ -138,7 +140,7 @@
 					&.font {
 						height : auto;
 						&::before {
-							font-size : 1.4em;
+							font-size : 1em;
 							content   : 'ABC';
 						}
 

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -326,27 +326,27 @@ module.exports = [
 				gen	 : dedent`{{font-family:CodeLight Dummy Text}}`
 			},
 			{
-				name : 'Scaly Sans Remake',
+				name : 'Scaly Sans',
 				icon : 'font ScalySansRemake',
 				gen	 : dedent`{{font-family:ScalySansRemake Dummy Text}}`
 			},
 			{
-				name : 'Book Insanity Remake',
+				name : 'Book Insanity',
 				icon : 'font BookInsanityRemake',
 				gen	 : dedent`{{font-family:BookInsanityRemake Dummy Text}}`
 			},
 			{
-				name : 'Mr Eaves Remake',
+				name : 'Mr Eaves',
 				icon : 'font MrEavesRemake',
 				gen	 : dedent`{{font-family:MrEavesRemake Dummy Text}}`
 			},
 			{
-				name: 'Solbera Imitation Remake',
+				name: 'Solbera Imitation',
 				icon: 'font SolberaImitationRemake',
 				gen: dedent`{{font-family:SolberaImitationRemake Dummy Text}}`
 			  },
 			  {
-				name: 'Scaly Sans Small Caps Remake',
+				name: 'Scaly Sans Small Caps',
 				icon: 'font ScalySansSmallCapsRemake',
 				gen: dedent`{{font-family:ScalySansSmallCapsRemake Dummy Text}}`
 			  },


### PR DESCRIPTION
(edit:  sorry Eric, there is no pre-existing issue that this addresses)

This PR does a small tweak of the CSS for the snippet menus in an effort to align the left edge of the snippet names across the entire menu.  It sets a min-width for the icons.  It also reduces the size of the font snippet "icons"....partially to make it easier to align them, and also because I think the larger current font size looks a little silly (they are much larger than other fontawesome icons).  I left the font size change as a separate commit, though, because maybe someone likes the clarity of the larger font.   Overall, I think there are some other improvements to the menus that could be done, but these are were easy changes to do.

| before | after |
|:---:|:----:|
| <img width="213" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/aa33285b-f8c0-4bd1-acad-c173580a64bd"> | <img width="213" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/434e2d5c-52d4-4cc5-9816-c9c60c65f30c"> |

I also think that we can leave off "remake" off the font names-- seems like irrelevant information for *most* users.  Or maybe, put that part in a span and style it so it's a lighter gray.