### PR TITLE
1px adjustment to Editor height

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -81,7 +81,7 @@ const Editor = createClass({
 	updateEditorSize : function() {
 		if(this.refs.codeEditor) {
 			let paneHeight = this.refs.main.parentNode.clientHeight;
-			paneHeight -= SNIPPETBAR_HEIGHT + 1;
+			paneHeight -= SNIPPETBAR_HEIGHT;
 			this.refs.codeEditor.codeMirror.setSize(null, paneHeight);
 		}
 	},


### PR DESCRIPTION
This removes a `+ 1` from the editor height calculation, so that the editor height reaches to the bottom of the window rather than leave a 1px gap, visible here:

<img width="115" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/8b3a03f6-f748-4886-a16e-b8b2fee4d5cb">

<img width="115" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/c77c994b-0b9a-422c-8f61-03f7f633fb2f">


I'm not sure if that 1px was there for a reason, but it was set 3 years ago when adding the style editor.

after the fix:

<img width="115" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/ee0da256-b2b0-4312-850f-4a9dbff67090">
