### PR TITLE
Turn the Beta tags in the snippet menus into links

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -233,7 +233,7 @@ const SnippetGroup = createClass({
 			return <div className='snippet' key={snippet.name} onClick={(e)=>this.handleSnippetClick(e, snippet)}>
 				<i className={snippet.icon} />
 				<span className='name'title={snippet.name}>{snippet.name}</span>
-				{snippet.experimental && <span className='beta'>beta</span>}
+				{snippet.experimental && <span className='beta'><a href={snippet.experimental.url} target="_blank" rel="noopener noreferrer">beta</a></span>}
 				<i className='fas fa-caret-right' style={snippet.subsnippets ? null : { visibility : 'hidden' }}></i>
 				<div className='dropdown side'>
 					{snippet.subsnippets ? this.renderSnippets(snippet.subsnippets) : null}

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -234,11 +234,10 @@ const SnippetGroup = createClass({
 				<i className={snippet.icon} />
 				<span className='name'title={snippet.name}>{snippet.name}</span>
 				{snippet.experimental && <span className='beta'>beta</span>}
-				{snippet.subsnippets && <>
-					<i className='fas fa-caret-right'></i>
-					<div className='dropdown side'>
-						{this.renderSnippets(snippet.subsnippets)}
-					</div></>}
+				<i className='fas fa-caret-right' style={snippet.subsnippets ? null : { visibility : 'hidden' }}></i>
+				<div className='dropdown side'>
+					{snippet.subsnippets ? this.renderSnippets(snippet.subsnippets) : null}
+				</div>
 			</div>;
 
 		});

--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -171,8 +171,16 @@
 					font-family   : monospace;
 					line-height   : 1em;
 					color         : white;
-					background    : grey;
+					background-color    : grey;
 					border-radius : 12px;
+					transition: background-color 0.3s ease;
+					&:hover  {
+						background-color: rgb(190, 190, 190);
+						transition: background-color 0.3s ease;
+					}
+					a, a:visited {
+						color: inherit;
+					}
 				}
 				&:hover {
 					background-color : #999999;

--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -135,6 +135,7 @@
 					& ~ i {
 						margin-right : 0;
 						margin-left  : 5px;
+						min-width    : unset;
 					}
 					/* Fonts */
 					&.font {

--- a/themes/V3/5ePHB/snippets.js
+++ b/themes/V3/5ePHB/snippets.js
@@ -29,7 +29,7 @@ module.exports = [
 				name         : 'Index',
 				icon         : 'fas fa-bars',
 				gen          : indexGen,
-				experimental : true
+				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2755' }
 			}
 		]
 	},

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -168,13 +168,13 @@ module.exports = [
 				name         : 'Watercolor Center',
 				icon         : 'fac mask-center',
 				gen          : ImageMaskGen.center,
-				experimental : true,
+				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2373' },
 			},
 			{
 				name         : 'Watercolor Edge',
 				icon         : 'fac mask-edge',
 				gen          : ImageMaskGen.edge('bottom'),
-				experimental : true,
+				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2373' },
 				subsnippets  : [
 					{
 						name : 'Top',
@@ -202,7 +202,7 @@ module.exports = [
 				name         : 'Watercolor Corner',
 				icon         : 'fac mask-corner',
 				gen          : ImageMaskGen.corner,
-				experimental : true,
+				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2373' },
 				subsnippets  : [
 					{
 						name : 'Top-Left',

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -165,17 +165,15 @@ module.exports = [
 				gen  : WatercolorGen,
 			},
 			{
-				name         : 'Watercolor Center',
-				icon         : 'fac mask-center',
-				gen          : ImageMaskGen.center,
-				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2373' },
+				name : 'Watercolor Center',
+				icon : 'fac mask-center',
+				gen  : ImageMaskGen.center,
 			},
 			{
-				name         : 'Watercolor Edge',
-				icon         : 'fac mask-edge',
-				gen          : ImageMaskGen.edge('bottom'),
-				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2373' },
-				subsnippets  : [
+				name        : 'Watercolor Edge',
+				icon        : 'fac mask-edge',
+				gen         : ImageMaskGen.edge('bottom'),
+				subsnippets : [
 					{
 						name : 'Top',
 						icon : 'fac position-top',
@@ -199,11 +197,10 @@ module.exports = [
 				]
 			},
 			{
-				name         : 'Watercolor Corner',
-				icon         : 'fac mask-corner',
-				gen          : ImageMaskGen.corner,
-				experimental : { url: 'https://github.com/naturalcrit/homebrewery/pull/2373' },
-				subsnippets  : [
+				name        : 'Watercolor Corner',
+				icon        : 'fac mask-corner',
+				gen         : ImageMaskGen.corner,
+				subsnippets : [
 					{
 						name : 'Top-Left',
 						icon : 'fac position-top-left',
@@ -307,8 +304,8 @@ module.exports = [
 	/**************** FONTS *************/
 	{
 		groupName : 'Fonts',
-		icon	  : 'fas fa-keyboard',
-		view	  : 'text',
+		icon   	  : 'fas fa-keyboard',
+		view   	  : 'text',
 		snippets  : [
 			{
 				name : 'Open Sans',
@@ -341,59 +338,59 @@ module.exports = [
 				gen	 : dedent`{{font-family:MrEavesRemake Dummy Text}}`
 			},
 			{
-				name: 'Solbera Imitation',
-				icon: 'font SolberaImitationRemake',
-				gen: dedent`{{font-family:SolberaImitationRemake Dummy Text}}`
+				name : 'Solbera Imitation',
+				icon : 'font SolberaImitationRemake',
+				gen  : dedent`{{font-family:SolberaImitationRemake Dummy Text}}`
 			  },
 			  {
-				name: 'Scaly Sans Small Caps',
-				icon: 'font ScalySansSmallCapsRemake',
-				gen: dedent`{{font-family:ScalySansSmallCapsRemake Dummy Text}}`
+				name : 'Scaly Sans Small Caps',
+				icon : 'font ScalySansSmallCapsRemake',
+				gen  : dedent`{{font-family:ScalySansSmallCapsRemake Dummy Text}}`
 			  },
 			  {
-				name: 'Walter Turncoat',
-				icon: 'font WalterTurncoat',
-				gen: dedent`{{font-family:WalterTurncoat Dummy Text}}`
+				name : 'Walter Turncoat',
+				icon : 'font WalterTurncoat',
+				gen  : dedent`{{font-family:WalterTurncoat Dummy Text}}`
 			  },
 			  {
-				name: 'Lato',
-				icon: 'font Lato',
-				gen: dedent`{{font-family:Lato Dummy Text}}`
+				name : 'Lato',
+				icon : 'font Lato',
+				gen  : dedent`{{font-family:Lato Dummy Text}}`
 			  },
 			  {
-				name: 'Courier',
-				icon: 'font Courier',
-				gen: dedent`{{font-family:Courier Dummy Text}}`
+				name : 'Courier',
+				icon : 'font Courier',
+				gen  : dedent`{{font-family:Courier Dummy Text}}`
 			  },
 			  {
-				name: 'Nodesto Caps Condensed',
-				icon: 'font NodestoCapsCondensed',
-				gen: dedent`{{font-family:NodestoCapsCondensed Dummy Text}}`
+				name : 'Nodesto Caps Condensed',
+				icon : 'font NodestoCapsCondensed',
+				gen  : dedent`{{font-family:NodestoCapsCondensed Dummy Text}}`
 			  },
 			  {
-				name: 'Overpass',
-				icon: 'font Overpass',
-				gen: dedent`{{font-family:Overpass Dummy Text}}`
+				name : 'Overpass',
+				icon : 'font Overpass',
+				gen  : dedent`{{font-family:Overpass Dummy Text}}`
 			  },
 			  {
-				name: 'Davek',
-				icon: 'font Davek',
-				gen: dedent`{{font-family:Davek Dummy Text}}`
+				name : 'Davek',
+				icon : 'font Davek',
+				gen  : dedent`{{font-family:Davek Dummy Text}}`
 			  },
 			  {
-				name: 'Iokharic',
-				icon: 'font Iokharic',
-				gen: dedent`{{font-family:Iokharic Dummy Text}}`
+				name : 'Iokharic',
+				icon : 'font Iokharic',
+				gen  : dedent`{{font-family:Iokharic Dummy Text}}`
 			  },
 			  {
-				name: 'Rellanic',
-				icon: 'font Rellanic',
-				gen: dedent`{{font-family:Rellanic Dummy Text}}`
+				name : 'Rellanic',
+				icon : 'font Rellanic',
+				gen  : dedent`{{font-family:Rellanic Dummy Text}}`
 			  },
 			  {
-				name: 'Times New Roman',
-				icon: 'font TimesNewRoman',
-				gen: dedent`{{font-family:"Times New Roman" Dummy Text}}`
+				name : 'Times New Roman',
+				icon : 'font TimesNewRoman',
+				gen  : dedent`{{font-family:"Times New Roman" Dummy Text}}`
 			  }
 		]
 	},


### PR DESCRIPTION
This PR turns the "Beta" tags in the snippet menus into hyperlinks, so we can point curious users to more information about the snippet and it's beta status.  The snippets.js file changes each snippet object so that the `experimental` property takes an object with a single `url` property.  

<img width="245" alt="image" src="https://github.com/naturalcrit/homebrewery/assets/58999374/707c9159-2402-4459-a1b8-0987f9b660e0">

(ignore the red band, that is a browser extension)

this fixes #3395 