### PR TITLE
Only check definition lists at start of line

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -297,7 +297,7 @@ const superSubScripts = {
 const definitionListsSingleLine = {
 	name  : 'definitionListsSingleLine',
 	level : 'block',
-	start(src) { return src.match(/^[^\n]*?::[^\n]*/m)?.index; },  // Hint to Marked.js to stop and check for a match
+	start(src) { return src.match(/\n[^\n]*?::[^\n]*/m)?.index; },  // Hint to Marked.js to stop and check for a match
 	tokenizer(src, tokens) {
 		const regex = /^([^\n]*?)::([^\n]*)(?:\n|$)/ym;
 		let match;
@@ -329,7 +329,7 @@ const definitionListsSingleLine = {
 const definitionListsMultiLine = {
 	name  : 'definitionListsMultiLine',
 	level : 'block',
-	start(src) { return src.match(/^[^\n]*\n::/m)?.index; },  // Hint to Marked.js to stop and check for a match
+	start(src) { return src.match(/\n[^\n]*\n::/m)?.index; },  // Hint to Marked.js to stop and check for a match
 	tokenizer(src, tokens) {
 		const regex = /(\n?\n?(?!::)[^\n]+?(?=\n::))|\n::(.(?:.|\n)*?(?=(?:\n::)|(?:\n\n)|$))/y;
 		let match;

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -294,8 +294,8 @@ const superSubScripts = {
 	}
 };
 
-const definitionListsInline = {
-	name  : 'definitionListsInline',
+const definitionListsSingleLine = {
+	name  : 'definitionListsSingleLine',
 	level : 'block',
 	start(src) { return src.match(/^[^\n]*?::[^\n]*/m)?.index; },  // Hint to Marked.js to stop and check for a match
 	tokenizer(src, tokens) {
@@ -312,7 +312,7 @@ const definitionListsInline = {
 		}
 		if(definitions.length) {
 			return {
-				type : 'definitionListsInline',
+				type : 'definitionListsSingleLine',
 				raw  : src.slice(0, endIndex),
 				definitions
 			};
@@ -326,8 +326,8 @@ const definitionListsInline = {
 	}
 };
 
-const definitionListsMultiline = {
-	name  : 'definitionListsMultiline',
+const definitionListsMultiLine = {
+	name  : 'definitionListsMultiLine',
 	level : 'block',
 	start(src) { return src.match(/^[^\n]*\n::/m)?.index; },  // Hint to Marked.js to stop and check for a match
 	tokenizer(src, tokens) {
@@ -353,7 +353,7 @@ const definitionListsMultiline = {
 		}
 		if(definitions.length) {
 			return {
-				type : 'definitionListsMultiline',
+				type : 'definitionListsMultiLine',
 				raw  : src.slice(0, endIndex),
 				definitions
 			};
@@ -617,7 +617,7 @@ function MarkedVariables() {
 //^=====--------------------< Variable Handling >-------------------=====^//
 
 Marked.use(MarkedVariables());
-Marked.use({ extensions: [definitionListsMultiline, definitionListsInline, superSubScripts, mustacheSpans, mustacheDivs, mustacheInjectInline] });
+Marked.use({ extensions: [definitionListsMultiLine, definitionListsSingleLine, superSubScripts, mustacheSpans, mustacheDivs, mustacheInjectInline] });
 Marked.use(mustacheInjectBlock);
 Marked.use({ renderer: renderer, tokenizer: tokenizer, mangle: false });
 Marked.use(MarkedExtendedTables(), MarkedGFMHeadingId(), MarkedSmartypantsLite());


### PR DESCRIPTION
Both DefinitonList markdown extensions "start" regex has been updated. Previous "start" regex used `^` instead of `\n`, which meant if the first character in a line failed to start a match, it would continue to check for the start of a DL in *every* character in the line, which slows things down a lot because most lines do not contain a DL.

Also, `DefinitonListsInline` has been renamed to `DefinitonListsSingleLine` to avoid confusion of "inline" vs "block" tokens.