### PR TITLE
Add D100 Support for DiceFont

### DIFF
--- a/themes/fonts/iconFonts/diceFont.less
+++ b/themes/fonts/iconFonts/diceFont.less
@@ -111,4 +111,32 @@
 	&.solid-small-dot-d6-4::before { content : '\f18c'; }
 	&.solid-small-dot-d6-5::before { content : '\f18d'; }
 	&.solid-small-dot-d6-6::before { content : '\f18e'; }
+
+	@tens_runes: '\f100',
+	'\f101',
+	'\f103',
+	'\f104',
+	'\f105',
+	'\f106',
+	'\f107',
+	'\f108',
+	'\f109',
+	'\f10a',
+	'\f101';
+
+	&.d100-0::before {
+		@zeros: (extract(@tens_runes, 1));
+		@zeros_dice: @zeros@zeros;
+		content : (@zeros_dice)
+	}
+	each(range(99), {
+		&.d100-@{value}::before {
+			@ones: mod(@value,10);
+			@tens: if(@ones > 0, ceil((@value / 10)), (ceil((@value / 10))+1));
+			@tens_dice: extract(@tens_runes, (@tens));
+			@ones_dice: extract(@tens_runes, (@ones + 1));
+			@final_dice: @tens_dice@ones_dice;
+			content: (@final_dice);
+		}
+	})
 }


### PR DESCRIPTION
In response to issue [#3347](https://github.com/naturalcrit/homebrewery/issues/3347). 

Hey all, this is my first time contributing to open source. Please let me know if there's ways to improve this. This was also my first time using Less, but I think I was able to get this functionality working as intended. 

New CSS class names are supported using the "df d100-##" format. As such, they the "##" will be parsed as if it were a number 0-99. The numbers will be parsed, and then use the diceFont fonts to display two d-10s with the corresponding percentile dice result. 

Let me know if there's anything else that should be changed.

Here are some examples:

```html
<div class="df d100-0"></div>
<div class="df d100-1"></div>
<div class="df d100-2"></div>
<div class="df d100-3"></div>
<div class="df d100-4"></div>
<div class="df d100-5"></div>
<div class="df d100-6"></div>
<div class="df d100-7"></div>
<div class="df d100-8"></div>
<div class="df d100-9"></div>
```

![image](https://github.com/naturalcrit/homebrewery/assets/54973032/5cca6264-22ca-414e-b73a-e5b0134009a8)