### PR TITLE
Modify PrintPage to use new BrewRenderer methods

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -56,6 +56,7 @@ const BrewRenderer = (props)=>{
 		lang              : '',
 		errors            : [],
 		currentEditorPage : 0,
+		renderAllPages    : false,
 		useIFrame         : true,
 		frameMounted      : ()=>{},
 		...props
@@ -161,7 +162,7 @@ const BrewRenderer = (props)=>{
 		renderedPages[props.currentEditorPage] = renderPage(rawPages[props.currentEditorPage], props.currentEditorPage);
 
 		_.forEach(rawPages, (page, index)=>{
-			if((!props.useIFrame || isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){
+			if((props.renderAllPages || isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){
 				renderedPages[index] = renderPage(page, index); // Render any page not yet rendered, but only re-render those in PPR range
 			}
 		});

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -165,7 +165,7 @@ const BrewRenderer = (props)=>{
 		renderedPages[props.currentEditorPage] = renderPage(rawPages[props.currentEditorPage], props.currentEditorPage);
 
 		_.forEach(rawPages, (page, index)=>{
-			if((isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){
+			if((!props.frame || isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){
 				renderedPages[index] = renderPage(page, index); // Render any page not yet rendered, but only re-render those in PPR range
 			}
 		});

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -56,7 +56,7 @@ const BrewRenderer = (props)=>{
 		lang              : '',
 		errors            : [],
 		currentEditorPage : 0,
-		frame             : true,
+		useIFrame         : true,
 		frameMounted      : ()=>{},
 		...props
 	};
@@ -77,7 +77,7 @@ const BrewRenderer = (props)=>{
 	}
 
 	useEffect(()=>{ // Unmounting steps
-		!props.frame && frameDidMount();
+		!props.useIFrame && frameDidMount();
 		return ()=>{
 			window.removeEventListener('resize', updateSize);
 		};
@@ -161,7 +161,7 @@ const BrewRenderer = (props)=>{
 		renderedPages[props.currentEditorPage] = renderPage(rawPages[props.currentEditorPage], props.currentEditorPage);
 
 		_.forEach(rawPages, (page, index)=>{
-			if((!props.frame || isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){
+			if((!props.useIFrame || isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){
 				renderedPages[index] = renderPage(page, index); // Render any page not yet rendered, but only re-render those in PPR range
 			}
 		});
@@ -231,7 +231,7 @@ const BrewRenderer = (props)=>{
 				: null}
 
 			{/*render in iFrame so broken code doesn't crash the site.*/}
-			{props.frame ?
+			{props.useIFrame ?
 				<Frame id='BrewRenderer' initialContent={INITIAL_CONTENT}
 					style={{ width: '100%', height: '100%', visibility: state.visibility }}
 					contentDidMount={frameDidMount}

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -57,7 +57,7 @@ const PrintPage = createClass({
 		}
 	},
 
-	frameMounted : function() {
+	showPrintDialog : function() {
 		if(this.props.query.dialog) window.print();
 	},
 
@@ -73,7 +73,7 @@ const PrintPage = createClass({
 				lang={this.state.brew.lang}
 				currentEditorPage={1}
 				useIFrame={false}
-				frameMounted={this.frameMounted}
+				frameMounted={this.showPrintDialog}
 				renderAllPages={true}
 			/>
 		</div>;

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -3,8 +3,6 @@ const React = require('react');
 const createClass = require('create-react-class');
 const _     = require('lodash');
 const cx    = require('classnames');
-const MarkdownLegacy = require('naturalcrit/markdownLegacy.js');
-const Markdown = require('naturalcrit/markdown.js');
 
 const BrewRenderer = require('../../brewRenderer/brewRenderer.jsx');
 
@@ -60,34 +58,6 @@ const PrintPage = createClass({
 
 	frameMounted : function() {
 		if(this.props.query.dialog) window.print();
-	},
-
-	renderStyle : function() {
-		if(!this.state.brew.style) return;
-		//return <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `<style>@layer styleTab {\n${this.state.brew.style}\n} </style>` }} />;
-		return <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `<style>\n${this.state.brew.style}\n</style>` }} />;
-	},
-
-	renderPages : function(){
-		if(this.state.brew.renderer == 'legacy') {
-			return _.map(this.state.brew.text.split('\\page'), (pageText, index)=>{
-				return <div
-					className='phb page'
-					id={`p${index + 1}`}
-					dangerouslySetInnerHTML={{ __html: MarkdownLegacy.render(pageText) }}
-					key={index} />;
-			});
-		} else {
-			return _.map(this.state.brew.text.split(/^\\page$/gm), (pageText, index)=>{
-				pageText += `\n\n&nbsp;\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
-				return (
-					<div className='page' id={`p${index + 1}`} key={index} >
-						<div className='columnWrapper' dangerouslySetInnerHTML={{ __html: Markdown.render(pageText) }} />
-					</div>
-				);
-			});
-		}
-
 	},
 
 	render : function(){

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -3,11 +3,10 @@ const React = require('react');
 const createClass = require('create-react-class');
 const _     = require('lodash');
 const cx    = require('classnames');
-const { Meta } = require('vitreum/headtags');
 const MarkdownLegacy = require('naturalcrit/markdownLegacy.js');
 const Markdown = require('naturalcrit/markdown.js');
 
-const Themes = require('themes/themes.json');
+const BrewRenderer = require('../../brewRenderer/brewRenderer.jsx');
 
 const BREWKEY = 'homebrewery-new';
 const STYLEKEY = 'homebrewery-new-style';
@@ -34,7 +33,7 @@ const PrintPage = createClass({
 				style    : this.props.brew.style    || undefined,
 				renderer : this.props.brew.renderer || 'legacy',
 				theme    : this.props.brew.theme    || '5ePHB',
-				lang	 : this.props.brew.lang     || 'en'
+				lang   	 : this.props.brew.lang     || 'en'
 			}
 		};
 	},
@@ -52,12 +51,14 @@ const PrintPage = createClass({
 						style    : styleStorage,
 						renderer : metaStorage?.renderer || 'legacy',
 						theme    : metaStorage?.theme    || '5ePHB',
-						lang	 : metaStorage?.lang	 || 'en'
+						lang   	 : metaStorage?.lang	 || 'en'
 					}
 				};
 			});
 		}
+	},
 
+	frameMounted : function() {
 		if(this.props.query.dialog) window.print();
 	},
 
@@ -90,22 +91,18 @@ const PrintPage = createClass({
 	},
 
 	render : function(){
-		const rendererPath = this.state.brew.renderer == 'V3' ? 'V3' : 'Legacy';
-		const themePath    = this.state.brew.theme ?? '5ePHB';
-		const baseThemePath = Themes[rendererPath][themePath].baseTheme;
-
-		return <div>
-			<Meta name='robots' content='noindex, nofollow' />
-			<link href={`/themes/${rendererPath}/Blank/style.css`} type="text/css" rel='stylesheet'/>
-			{baseThemePath &&
-				<link href={`/themes/${rendererPath}/${baseThemePath}/style.css`} type="text/css" rel='stylesheet'/>
-			}
-			<link href={`/themes/${rendererPath}/${themePath}/style.css`} type="text/css" rel='stylesheet'/>
-			{/* Apply CSS from Style tab */}
-			{this.renderStyle()}
-			<div className='pages' ref='pages' lang={this.state.brew.lang}>
-				{this.renderPages()}
-			</div>
+		return <div className='printPage'>
+			<BrewRenderer
+				text={this.state.brew.text}
+				style={this.state.brew.style}
+				renderer={this.state.brew.renderer}
+				theme={this.state.brew.theme}
+				errors={undefined}
+				lang={this.state.brew.lang}
+				currentEditorPage={1}
+				frame={false}
+				frameMounted={this.frameMounted}
+			/>
 		</div>;
 	}
 });

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -72,6 +72,7 @@ const PrintPage = createClass({
 				currentEditorPage={1}
 				useIFrame={false}
 				frameMounted={this.frameMounted}
+				renderAllPages={true}
 			/>
 		</div>;
 	}

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -70,7 +70,7 @@ const PrintPage = createClass({
 				errors={undefined}
 				lang={this.state.brew.lang}
 				currentEditorPage={1}
-				frame={false}
+				useIFrame={false}
 				frameMounted={this.frameMounted}
 			/>
 		</div>;

--- a/client/homebrew/pages/printPage/printPage.jsx
+++ b/client/homebrew/pages/printPage/printPage.jsx
@@ -3,6 +3,7 @@ const React = require('react');
 const createClass = require('create-react-class');
 const _     = require('lodash');
 const cx    = require('classnames');
+const { Meta } = require('vitreum/headtags');
 
 const BrewRenderer = require('../../brewRenderer/brewRenderer.jsx');
 
@@ -62,6 +63,7 @@ const PrintPage = createClass({
 
 	render : function(){
 		return <div className='printPage'>
+			<Meta name='robots' content='noindex, nofollow' />
 			<BrewRenderer
 				text={this.state.brew.text}
 				style={this.state.brew.style}

--- a/client/homebrew/pages/printPage/printPage.less
+++ b/client/homebrew/pages/printPage/printPage.less
@@ -1,3 +1,20 @@
-.printPage{
+@media print {
+    .printPage{
+        .brewRenderer .pages {
+            margin: 0px;
+            &>.page {
+            box-shadow: unset;
+            }
+        }
+    }
+}
 
+.printPage{
+    .brewRenderer {
+        overflow-y: unset;
+        height: 100%;
+    }
+    .pageInfo {
+        display: none;
+    }
 }


### PR DESCRIPTION
This PR resolves #3435.

This PR modifies the Print Page to use the BrewRenderer to render the pages for printing. This ensures that the Print Page output will always match the Share and Edit Page visual outputs - previously it used a duplicated section of code that was not updated when the BrewRenderer was changed.

Some modifications have also been made to the BrewRenderer, including the option to not render inside an iFrame (defaults to iFrame on), and a method to indicate to Print Page when the print event should fire (i.e. on completion of document rendering).

iFrame rendering would be preferable but while it is possible to create functions to print the iFrame content directly, I have been unable to get printing via Ctrl+P or selecting Print from the browser menu to work correctly. For this reason, the brew renders outside of a frame on Print Page.