### PR TITLE
Fix ToC generator snippet

### DIFF
--- a/themes/V3/5ePHB/snippets/tableOfContents.gen.js
+++ b/themes/V3/5ePHB/snippets/tableOfContents.gen.js
@@ -8,14 +8,14 @@ const getTOC = (pages)=>{
 		if(curDepth == targetDepth) {
 			child.push({
 				title    : title,
-				page     : page + 1,
+				page     : page,
 				children : []
 			});
 		} else {
 			if(child.length == 0) {
 				child.push({
 					title    : null,
-					page     : page + 1,
+					page     : page,
 					children : []
 				});
 			}


### PR DESCRIPTION
This PR resolves #3548.

This PR removes the `+ 1` from the `page` portion of the ToC generation snippet, correcting the "off by one" error.