### PR TITLE
Stop Ink Friendly snippet making text unselectable in output PDF

### DIFF
--- a/themes/V3/5ePHB/snippets.js
+++ b/themes/V3/5ePHB/snippets.js
@@ -349,7 +349,7 @@ module.exports = [
 					/* Ink Friendly */
 					*:is(.page,.monster,.note,.descriptive) {
 						background : white !important;
-						filter : drop-shadow(0px 0px 3px #888) !important;
+						box-shadow : 0px 0px 3px #888 !important;
 					}
 
 					.page img {

--- a/themes/V3/5ePHB/snippets.js
+++ b/themes/V3/5ePHB/snippets.js
@@ -349,7 +349,7 @@ module.exports = [
 					/* Ink Friendly */
 					*:is(.page,.monster,.note,.descriptive) {
 						background : white !important;
-						box-shadow : 0px 0px 3px #888 !important;
+						box-shadow : 1px 4px 14px #888 !important;
 					}
 
 					.page img {


### PR DESCRIPTION
This PR resolves #3563.

This PR changes the Ink Friendly snippet to use `box-shadow` instead of `filter`. This should achieve the same visual effect while not rendering the output PDF as an image.