### PR TITLE
Add additional styles to SolberaImitationRemake font declaration

### DIFF
--- a/themes/fonts/5e/fonts.less
+++ b/themes/fonts/5e/fonts.less
@@ -74,8 +74,9 @@
 @font-face {
 	font-family: SolberaImitationRemake; //Tweaked 5e version
 	src: url('../../../fonts/5e/Solbera Imitation Tweak.woff2');
-	font-weight: normal;
+	font-weight: 100 1000;
 	font-style: normal;
+	font-style: italic;
 }
 
 /* Cover Page */


### PR DESCRIPTION
This PR resolves #3551.

This PR adds extra styling declarations to the existing SolberaImitationRemake declaration in the `fonts.less` file.

Result:
![347699415-a0fdd7bd-4e73-46af-a232-905e85e72847](https://github.com/naturalcrit/homebrewery/assets/19826659/e0a1c2eb-9b59-4ede-b54b-d43e1d5ddd7f)
