### PR TITLE
Unset text-decoration on Brew Item links

### DIFF
--- a/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
+++ b/client/homebrew/pages/basePages/listPage/brewItem/brewItem.less
@@ -119,11 +119,12 @@
 		text-align       : center;
 		a{
 			.animate(opacity);
-			display   : block;
-			margin    : 8px 0px;
-			opacity   : 0.6;
-			font-size : 1.3em;
-			color     : white;
+			display         : block;
+			margin          : 8px 0px;
+			opacity         : 0.6;
+			font-size       : 1.3em;
+			color           : white;
+			text-decoration : unset;
 			&:hover{
 				opacity : 1;
 			}


### PR DESCRIPTION
The styling has changed, adding a `text-decoration: underline;` to `a` with links (that is, that have a `href` set).

This PR resolves #3568.

This PR adds styling to `.BrewItem .links a`, adding `text-decoration: unset;` which prevents the errant underline from appearing.