### PR TITLE
Fix Table of Contents uppercasing

### DIFF
--- a/themes/V3/5ePHB/snippets/tableOfContents.gen.js
+++ b/themes/V3/5ePHB/snippets/tableOfContents.gen.js
@@ -35,7 +35,7 @@ const getTOC = (pages)=>{
 		const ToCExclude = getComputedStyle(heading).getPropertyValue('--TOC');
 
 		if(ToCExclude != 'exclude') {
-			recursiveAdd(heading.innerText.trim(), onPage, headerDepth.indexOf(heading.tagName), res);
+			recursiveAdd(heading.textContent.trim(), onPage, headerDepth.indexOf(heading.tagName), res);
 		}
 	});
 	return res;


### PR DESCRIPTION
This PR resolves #3572.

This PR changes the Table of Contents generation snippet to use the `textContent` property of the HTML element, rather than the `innerText` property, as `innerText` has been found to incorrectly include styling from `text-transform`, which is undesirable.