### PR TITLE
Experimental Header Navigation

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -31,12 +31,8 @@
 			visibility: hidden;
 		}
 	}
-	
-
-
-
-
 }
+
 .pane { position : relative; }
 .pageInfo {
 	position         : absolute;
@@ -65,6 +61,32 @@
 	background-color : #333333;
 }
 
+.headerNav {
+	position: fixed;
+	top: 0px;
+	left: 0px;
+	padding: 5px 10px;
+	background-color: #ccc;
+	border-radius: 5px;
+	max-height: 100vh;
+	overflow-y: auto;	
+	.navIcon {
+		cursor: pointer;
+	}
+	p {
+		padding: 2px;
+		a {
+			color: inherit;
+			text-decoration: none;
+			cursor: pointer;
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+}
+
+
 @media print {
 	.brewRenderer {
 		height: 100%;
@@ -75,5 +97,8 @@
 				box-shadow: unset;
 			}
 		}
+	}
+	.headerNav {
+		visibility: hidden;
 	}
 }


### PR DESCRIPTION
This PR adds a button to the BrewRenderer. When clicked, this exposes the header navigation window, which lists all of the elements with IDs in the document.
It generates this information by calling `querySelectorAll('[id]')` to acquire a list of all elements that have an `id` attribute, then parsing these for the following conditions:

- has the class `page` - depth: 0; text: 'Page' + page number
- is `h1` through `h6` - depth: heading value, i.e. h1 => 1, h6 => 6; text: `innerText` value
- all other elements - depth: 7; text: `innerText` value

From one of the documents in my local install DB:

**CLOSED:**
![image](https://github.com/user-attachments/assets/f17ea8f0-ce0c-4f88-b3c9-d1def7b36a29)

**OPEN:**
![image](https://github.com/user-attachments/assets/72bddd47-1f1f-4af8-a109-b77da8c8cbbd)

**HOVERING OVER "PAGE 2:**
![image](https://github.com/user-attachments/assets/bd4ad7f7-89c6-40ad-b18c-5c42e83deeb8)
