### PR TITLE
Fix user themes crashes

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -115,7 +115,8 @@ app.get('/legacy', (req, res, next)=>{
 app.get('/migrate', (req, res, next)=>{
 	req.brew = {
 		text     : migrateText,
-		renderer : 'V3'
+		renderer : 'V3',
+		theme    : '5ePHB'
 	},
 
 	req.ogMeta = { ...defaultMetaTags,
@@ -132,7 +133,8 @@ app.get('/changelog', async (req, res, next)=>{
 	req.brew = {
 		title    : 'Changelog',
 		text     : changelogText,
-		renderer : 'V3'
+		renderer : 'V3',
+		theme    : '5ePHB'
 	},
 
 	req.ogMeta = { ...defaultMetaTags,
@@ -149,7 +151,8 @@ app.get('/faq', async (req, res, next)=>{
 	req.brew = {
 		title    : 'FAQ',
 		text     : faqText,
-		renderer : 'V3'
+		renderer : 'V3',
+		theme    : '5ePHB'
 	},
 
 	req.ogMeta = { ...defaultMetaTags,

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -46,6 +46,9 @@ const api = {
 	},
 	//Get array of any of this user's brews tagged with `meta:theme`
 	getUsersBrewThemes : async (username)=>{
+		if(!username)
+			return {};
+
 		const fields = [
 			'title',
 			'tags',
@@ -251,16 +254,12 @@ const api = {
 		res.status(200).send(saved);
 	},
 	getThemeBundle : async(req, res)=>{
-		/*
-			getThemeBundle: Collects the theme and all parent themes
-				returns an object containing an array of css, in render order, and an array
-					of snippets ( currently empty )
-			Important parameter members:
-				req.params.id: This is the shareId ( User theme ) or name ( static theme )
-					loaded first.
-				req.params.renderer: This is the Markdown+ version for the static theme. If a
-					User theme the value will come from the User Theme metadata.
-		*/
+		/*	getThemeBundle: Collects the theme and all parent themes
+				returns an object containing an array of css, and an array of snippets, in render order
+
+				req.params.id       : The shareId ( User theme ) or name ( static theme )
+				req.params.renderer : The Markdown renderer used for this theme */
+
 		req.params.renderer = _.upperFirst(req.params.renderer);
 		let currentTheme;
 		const completeStyles   = [];


### PR DESCRIPTION
Do not fetch user themes if there is no user

Add themes to our reference pages (FAQ, migrate, changelog)

Along with this, a `tags` index has been created on the Mongo database.