### PR TITLE
Fix tests post v3.14.0

### DIFF
--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -408,8 +408,8 @@ brew`);
 			expect(sent).not.toEqual(googleBrew);
 			expect(result.text).toBeUndefined();
 			expect(result.textBin).toBeUndefined();
-			expect(result.renderer).toBeUndefined();
-			expect(result.pageCount).toBeUndefined();
+			expect(result.renderer).toBe('v3');
+			expect(result.pageCount).toBe(1);
 		});
 	});
 
@@ -540,9 +540,9 @@ brew`);
 				description : '',
 				editId      : expect.any(String),
 				gDrive      : false,
-				pageCount   : undefined,
+				pageCount   : 1,
 				published   : false,
-				renderer    : undefined,
+				renderer    : 'V3',
 				lang        : 'en',
 				shareId     : expect.any(String),
 				googleId    : expect.any(String),


### PR DESCRIPTION
Add expected values for `pageCount` and `renderer`.

The current tests expect these properties to be undefined, but after v3.14.0 the tests are returning values of `1` and `v3`, respectively.

Until this or a similar change is merged, no new PRs will be able to be merged as they will be unable to pass CI testing.