### PR TITLE
Fix var name substring clash #3613

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -462,7 +462,7 @@ const replaceVar = function(input, hoist=false, allowUnresolved=false) {
 		mathVars?.forEach((variable)=>{
 			const foundVar = lookupVar(variable, globalPageNumber, hoist);
 			if(foundVar && foundVar.resolved && foundVar.content && !isNaN(foundVar.content)) // Only subsitute math values if fully resolved, not empty strings, and numbers
-				replacedLabel = replacedLabel.replaceAll(variable, foundVar.content);
+				replacedLabel = replacedLabel.replaceAll(new RegExp(`/(?<!\\w)(${variable})(?!\\w)`, 'g'), foundVar.content);
 		});
 
 		try {

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -462,7 +462,7 @@ const replaceVar = function(input, hoist=false, allowUnresolved=false) {
 		mathVars?.forEach((variable)=>{
 			const foundVar = lookupVar(variable, globalPageNumber, hoist);
 			if(foundVar && foundVar.resolved && foundVar.content && !isNaN(foundVar.content)) // Only subsitute math values if fully resolved, not empty strings, and numbers
-				replacedLabel = replacedLabel.replaceAll(new RegExp(`/(?<!\\w)(${variable})(?!\\w)`, 'g'), foundVar.content);
+				replacedLabel = replacedLabel.replaceAll(new RegExp(`(?<!\\w)(${variable})(?!\\w)`, 'g'), foundVar.content);
 		});
 
 		try {

--- a/tests/markdown/variables.test.js
+++ b/tests/markdown/variables.test.js
@@ -371,3 +371,17 @@ describe('Cross-page variables', ()=>{
 		expect(rendered, `Input:\n${[source0, source1].join('\n\\page\n')}`, { showPrefix: false }).toBe('<p>two</p><p>one</p>\\page<p>two</p>');
 	});
 });
+
+describe('Variable name as a subset of a function or other variable name', ()=>{
+	it('Variable name as a subset of a function', function() {
+		const source = `[a]: -1\n\n$[abs(a)]`;
+		const rendered = Markdown.render(source).trimReturns();
+		expect(rendered).toBe('<p>1</p>');
+	});
+
+	it('Variable name as a subset of another variable name', function() {
+		const source = `[ab]: 2\n\n[aba]: 8\n\n[ba]: 4\n\n$[ab + aba + ba]`;
+		const rendered = Markdown.render(source).trimReturns();
+		expect(rendered).toBe('<p>14</p>');
+	});
+});


### PR DESCRIPTION
This PR resolves #3613.

This PR changes the regex of the variable name replacement, to ensure that names that are substrings of math functions or other variables are not unintentionally replaced.

CURRENT:
```
[a]:-4

$[abs(a)]
```
**OUTPUT:** `$[abs(a)]`

![image](https://github.com/user-attachments/assets/5217170e-f0a2-4589-9eef-212deb3a22e3)

PR:
```
[a]:-4

$[abs(a)]
```
**OUTPUT:** `4`

![image](https://github.com/user-attachments/assets/61bf4370-6e7d-42f1-98d3-a342fa079012)