### PR TITLE
Add catch-all for invalid paths

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -420,6 +420,14 @@ if(isLocalEnvironment){
 	});
 }
 
+// Catch-all route for invalid routes
+app.use((req, res, next) => {
+	if (!req.route)
+		return res.redirect('/');
+
+	return next();
+});
+
 //Render the page
 const templateFn = require('./../client/template.js');
 const renderPage = async (req, res)=>{

--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,7 @@ const GoogleActions = require('./googleActions.js');
 const serveCompressedStaticAssets = require('./static-assets.mv.js');
 const sanitizeFilename = require('sanitize-filename');
 const asyncHandler = require('express-async-handler');
+const templateFn = require('./../client/template.js');
 
 const { DEFAULT_BREW } = require('./brewDefaults.js');
 
@@ -420,16 +421,16 @@ if(isLocalEnvironment){
 	});
 }
 
-// Catch-all route for invalid routes
-app.use((req, res, next) => {
-	if (!req.route)
-		return res.redirect('/');
-
-	return next();
-});
+//Send rendered page
+app.use(asyncHandler(async (req, res, next)=>{
+	if (!req.route) return res.redirect('/'); // Catch-all for invalid routes
+		
+	const page = await renderPage(req, res);
+	if(!page) return;
+	res.send(page);
+}));
 
 //Render the page
-const templateFn = require('./../client/template.js');
 const renderPage = async (req, res)=>{
 	// Create configuration object
 	const configuration = {
@@ -457,13 +458,6 @@ const renderPage = async (req, res)=>{
 		});
 	return page;
 };
-
-//Send rendered page
-app.use(asyncHandler(async (req, res, next)=>{
-	const page = await renderPage(req, res);
-	if(!page) return;
-	res.send(page);
-}));
 
 //v=====----- Error-Handling Middleware -----=====v//
 //Format Errors as plain objects so all fields will appear in the string sent


### PR DESCRIPTION
Fixes #3629 

`res.route` is the currently-matched route. If nothing has been matched by this point (route = undefined), we have an invalid route. In that case we need to redirect to the homepage at `/`. Eventually this could be a dedicated 404 page, but that can come later.

Would appreciate a second look just to verify this isn't breaking our normal routes, including API requests (saving/loading/etc.)