### PR TITLE
Revert toolbar positioning change

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -3,6 +3,7 @@
 .brewRenderer {
 	overflow-y    : scroll;
 	will-change   : transform;
+	padding-top   : 30px;
 	:where(.pages) {
 		margin : 30px 0px;
 		& > :where(.page) {

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -1,7 +1,7 @@
 @import (less) './client/icons/customIcons.less';
 
 .toolBar {
-	position         : relative;
+	position         : absolute;
 	z-index          : 1;
 	box-sizing       : border-box;
 	display          : flex;


### PR DESCRIPTION
For some reason, the change makes it so that the toolbar disappears behind the top navbar when you click to the page next/previous buttons.  

quick patch until it can be figured out better later.