### PR TITLE
A temporary, imperfect fix for the jump hotkeys

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -85,7 +85,8 @@ const Editor = createClass({
 	},
 
 	handleControlKeys : function(e){
-		if(!(e.ctrlKey || e.metaKey)) return;
+		console.log(e);
+		if(!(e.ctrlKey && e.metaKey)) return;
 		const LEFTARROW_KEY = 37;
 		const RIGHTARROW_KEY = 39;
 		if (e.shiftKey && (e.keyCode == RIGHTARROW_KEY)) this.brewJump();

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -85,7 +85,6 @@ const Editor = createClass({
 	},
 
 	handleControlKeys : function(e){
-		console.log(e);
 		if(!(e.ctrlKey && e.metaKey)) return;
 		const LEFTARROW_KEY = 37;
 		const RIGHTARROW_KEY = 39;


### PR DESCRIPTION
This changes the binding to CTRL-SHIFT-META+Arrow.

It's possibly not the best final combo, but it should revert any existing breakage and was my last intended combination for the task.