### PR TITLE
All Snippet entries that have subsnippets but not generators.

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -70,7 +70,9 @@ const Snippetbar = createClass({
 	mergeCustomizer : function(oldValue, newValue, key) {
 		if(key == 'snippets') {
 			const result = _.reverse(_.unionBy(_.reverse(newValue), _.reverse(oldValue), 'name')); // Join snippets together, with preference for the child theme over the parent theme
-			return _.filter(result, 'gen'); //Only keep snippets with a 'gen' property.
+			return _.filter(result, function(snip) {
+				return(snip.hasOwnProperty('gen') || snip.hasOwnProperty('subsnippets'));
+			});
 		}
 	},
 

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -70,9 +70,7 @@ const Snippetbar = createClass({
 	mergeCustomizer : function(oldValue, newValue, key) {
 		if(key == 'snippets') {
 			const result = _.reverse(_.unionBy(_.reverse(newValue), _.reverse(oldValue), 'name')); // Join snippets together, with preference for the child theme over the parent theme
-			return _.filter(result, function(snip) {
-				return(snip.hasOwnProperty('gen') || snip.hasOwnProperty('subsnippets'));
-			});
+			return result.filter(snip.gen || snip.subsnippets);
 		}
 	},
 


### PR DESCRIPTION
The Snippet menu builder excludes any entries without `gen` functions/strings.

This change allows snippet to be included if they lack and `gen` but contain `subsnippets`

