### PR TITLE
Set Focus on Editor after Tab Switches

### DIFF
--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -82,6 +82,7 @@ const Editor = createClass({
 		if(prevProps.moveSource !== this.props.moveSource) {
 			this.sourceJump();
 		};
+		this.codeEditor.current?.codeMirror.focus();
 	},
 
 	handleControlKeys : function(e){

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -82,7 +82,6 @@ const Editor = createClass({
 		if(prevProps.moveSource !== this.props.moveSource) {
 			this.sourceJump();
 		};
-		this.codeEditor.current?.codeMirror.focus();
 	},
 
 	handleControlKeys : function(e){
@@ -114,7 +113,10 @@ const Editor = createClass({
 		this.props.setMoveArrows(newView === 'text');
 		this.setState({
 			view : newView
-		}, this.updateEditorSize);	//TODO: not sure if updateeditorsize needed
+		}, ()=>{
+			this.codeEditor.current?.codeMirror.focus();
+			this.updateEditorSize();
+		});	//TODO: not sure if updateeditorsize needed
 	},
 
 	getCurrentPage : function(){


### PR DESCRIPTION
This sets the focus on the editor (and thus reveals cursor position) between editor changes (style to text to meta and back).

It *does not* store the cursor position between page reloads.  All it does is set focus.

One side-effect is that this is *setting focus whenever the page loads*.  Some people have expressed fondness for the editor having focus right away on page load, but I'm sure some will be surprised since it is a change from the existing load behavior (where no focus is set at all).  

