### PR TITLE
Update gitattributes to stop JSON from constantly appearing as modified

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 package-lock.json binary
+
+*.json text eol=lf


### PR DESCRIPTION
This PR resolves #3703.

This PR modifies the `.gitattributes` file to add the line `*.json text eol=lf`, prevent line end encoding in JSON files from being changed on commit or pull.
Initial testing shows that this change prevents the JSON files from constantly appearing in the modified files list.