### PR TITLE
FIx missing arrows

### DIFF
--- a/shared/naturalcrit/splitPane/splitPane.jsx
+++ b/shared/naturalcrit/splitPane/splitPane.jsx
@@ -19,7 +19,8 @@ const SplitPane = createClass({
 			windowWidth       : 0,
 			isDragging        : false,
 			moveSource        : false,
-			moveBrew          : false
+			moveBrew          : false,
+			showMoveArrows    : true
 		};
 	},
 


### PR DESCRIPTION
During last changes to vault, Calc mistakenly removed the state that originally controls the presence of the arrows. Restoring the state fixes this issue and makes the arrows work fine again.