### PR TITLE
Raise timeout to 10 s.

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -29,7 +29,7 @@ const { printCurrentBrew, fetchThemeBundle } = require('../../../../shared/helpe
 
 const googleDriveIcon = require('../../googleDrive.svg');
 
-const SAVE_TIMEOUT = 3000;
+const SAVE_TIMEOUT = 10000;
 
 const EditPage = createClass({
 	displayName     : 'EditPage',


### PR DESCRIPTION
## Description

Simply raises the autosave delay from 3s to 10s. A smaller increment might work, but might as well aim high to try fixing the 429 status issue. We can move it back down to something a little less if this works.