### PR TITLE
Add zoom property to BrewRenderer print styling

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.less
+++ b/client/homebrew/brewRenderer/brewRenderer.less
@@ -39,6 +39,7 @@
 		overflow-y  : unset;
 		.pages {
 			margin : 0px;
+			zoom: 100% !important;
 			& > .page { box-shadow : unset; }
 		}
 	}


### PR DESCRIPTION
This PR fixes #3744.

This PR adds the `zoom` property to the `@media print` rules for the BrewRenderer, preventing the `zoom` property set in inline styles (by the BrewRenderer toolbar) from affecting the print output.