### PR TITLE
fix lang on share page

### DIFF
--- a/client/homebrew/pages/sharePage/sharePage.jsx
+++ b/client/homebrew/pages/sharePage/sharePage.jsx
@@ -114,6 +114,7 @@ const SharePage = createClass({
 				<BrewRenderer
 					text={this.props.brew.text}
 					style={this.props.brew.style}
+					lang={this.props.brew.lang}
 					renderer={this.props.brew.renderer}
 					theme={this.props.brew.theme}
 					themeBundle={this.state.themeBundle}


### PR DESCRIPTION
One line fix, passing the lang prop to brewRenderer in sharePage.jsx L117

fixes #3776