### PR TITLE
Fix Google Drive Links in User Page for coauthors

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -242,6 +242,8 @@ app.get('/user/:username', async (req, res, next)=>{
 		console.log(err);
 	});
 
+	brews.forEach(brew => brew.stubbed = true); //All brews from MongoDB are "stubbed"
+
 	if(ownAccount && req?.account?.googleId){
 		const auth = await GoogleActions.authCheck(req.account, res);
 		let googleBrews = await GoogleActions.listGoogleBrews(auth)
@@ -249,12 +251,12 @@ app.get('/user/:username', async (req, res, next)=>{
 				console.error(err);
 			});
 
+		// If stub matches file from Google, use Google metadata over stub metadata
 		if(googleBrews && googleBrews.length > 0) {
 			for (const brew of brews.filter((brew)=>brew.googleId)) {
 				const match = googleBrews.findIndex((b)=>b.editId === brew.editId);
 				if(match !== -1) {
 					brew.googleId = googleBrews[match].googleId;
-					brew.stubbed = true;
 					brew.pageCount = googleBrews[match].pageCount;
 					brew.renderer = googleBrews[match].renderer;
 					brew.version = googleBrews[match].version;
@@ -263,6 +265,7 @@ app.get('/user/:username', async (req, res, next)=>{
 				}
 			}
 
+			//Remaining unstubbed google brews display current user as author
 			googleBrews = googleBrews.map((brew)=>({ ...brew, authors: [req.account.username] }));
 			brews = _.concat(brews, googleBrews);
 		}


### PR DESCRIPTION
User page generates links to Google Drive files based on whether it is marked as "stubbed". This was not being set correctly for Google Brews of which you are a co-author (not your own Google Drive account) or if your credentials are expired. The issue occurs because it was loading files from Google and *then* checking if they matched a file from Mongo. If you are not logged in to that account, it would fail to fetch those Google Drive files, thus there is nothing to compare to Mongo and they would all be marked as "unstubbed".

This now sets *every* file found on Mongo as "Stubbed", whether the Drive file belongs to the current user or not.
