### PR TITLE
Change local version history to use Indexed DB

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -70,10 +70,10 @@ const Snippetbar = createClass({
 
 		if(historyExists(this.props.brew) != this.state.historyExists){
 			this.setState({
-					historyExists : !this.state.historyExists
+				historyExists : !this.state.historyExists
 			});
 		};
-	
+
 	},
 
 	mergeCustomizer : function(oldValue, newValue, key) {

--- a/client/homebrew/utils/useIDB.js
+++ b/client/homebrew/utils/useIDB.js
@@ -1,0 +1,80 @@
+import {
+	get as iGet,
+	getMany as iGetMany,
+	set as iSet,
+	setMany as iSetMany,
+	update as iUpdate,
+	del as iDel,
+	keys,
+	createStore,
+	Store
+} from 'idb-keyval/dist/index.js'; // EcmaScript Module
+
+const HOMEBREWERY_DB = 'HOMEBREWERY-DB';
+const HOMEBREWERY_STORE = 'HOMEBREWERY-STORE';
+
+let hbStore;
+
+function init(){
+	if(hbStore) return true;
+	if(!hbStore && typeof window != 'undefined' && typeof window.indexedDB != 'undefined'){
+		hbStore = createStore(HOMEBREWERY_DB, HOMEBREWERY_STORE);
+		return true;
+	}
+	return false;
+}
+
+function checkFn(fn){
+	return init() && fn();
+};
+
+const get = checkFn(async (key)=>{
+	console.log('get:', key);
+	return iGet(key, hbStore);
+});
+
+const getMany = checkFn(async (keys)=>{
+	checkFn(async ()=>{
+		console.log('getMany:', keys);
+		return await iGetMany(keys, hbStore);
+	});
+});
+
+const set = checkFn(async (key, val)=>{
+	console.log('set:', key, val);
+	init();
+	return iSet(key, val, hbStore);
+});
+
+const setMany = checkFn(async (keyValArray)=>{
+	console.log('set:', keyValArray);
+	init();
+	return iSetMany(keyValArray, hbStore);
+});
+
+
+const update = checkFn(async (key, updateFn)=>{
+	init();
+	return iUpdate(key, updateFn, hbStore);
+});
+
+const remove = checkFn(async (key)=>{
+	console.log('remove:', key);
+	init();
+	return iDel(key, hbStore);
+});
+
+const list = checkFn(async ()=>{
+	init();
+	return await keys(hbStore);
+});
+
+module.exports = {
+	get,
+	getMany,
+	set,
+	setMany,
+	update,
+	remove,
+	list
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "express-async-handler": "^1.2.0",
         "express-static-gzip": "2.1.8",
         "fs-extra": "11.2.0",
+        "idb-keyval": "^6.2.1",
         "js-yaml": "^4.1.0",
         "jwt-simple": "^0.5.6",
         "less": "^3.13.1",
@@ -7450,6 +7451,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "express-async-handler": "^1.2.0",
     "express-static-gzip": "2.1.8",
     "fs-extra": "11.2.0",
+    "idb-keyval": "^6.2.1",
     "js-yaml": "^4.1.0",
     "jwt-simple": "^0.5.6",
     "less": "^3.13.1",


### PR DESCRIPTION
This PR resolves #3763.

This PR changes the history version to use the IndexedDB system rather than LocalStorage, as the maximum storage of IndexedDB is much larger than LocalStorage.

This PR is still currently a work in progress, as the IndexedDB interface is quite different to the LocalStorage interface.