### PR TITLE
Tweak color of Brew Renderer background text

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -176,7 +176,7 @@ const BrewRenderer = (props)=>{
 	const styleObject = {};
 
 	if(global.config.deployment) {
-		styleObject.backgroundImage = `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='40px' width='200px'><text x='0' y='15' fill='white' font-size='20'>${global.config.deployment}</text></svg>")`;
+		styleObject.backgroundImage = `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='40px' width='200px'><text x='0' y='15' fill='%23fff7' font-size='20'>${global.config.deployment}</text></svg>")`;
 	}
 
 	return (


### PR DESCRIPTION
This PR resolves #3814.

This PR alters the text color in the BrewRenderer background to #fff7 (from #ffff), in order to reduce the contrast and not distract from the actual content.