### PR TITLE
Memoize BrewRenderer

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -1,7 +1,7 @@
 /*eslint max-lines: ["warn", {"max": 300, "skipBlankLines": true, "skipComments": true}]*/
 require('./brewRenderer.less');
 const React = require('react');
-const { useState, useRef, useCallback } = React;
+const { useState, useRef, useCallback, memo } = React;
 const _ = require('lodash');
 
 const MarkdownLegacy = require('naturalcrit/markdownLegacy.js');
@@ -47,7 +47,7 @@ const BrewPage = (props)=>{
 const renderedPages = [];
 let rawPages      = [];
 
-const BrewRenderer = (props)=>{
+const BrewRenderer = memo((props)=>{
 	props = {
 		text                       : '',
 		style                      : '',
@@ -224,6 +224,19 @@ const BrewRenderer = (props)=>{
 			</Frame>
 		</>
 	);
-};
+}, arePropsEqual);
+
+//Only re-render brewRenderer if arePropsEqual == true
+function arePropsEqual(oldProps, newProps) {
+	return (
+		oldProps.text.length  === newProps.text.length &&
+		oldProps.style.length === newProps.style.length &&
+		oldProps.renderer     === newProps.renderer &&
+		oldProps.theme        === newProps.theme &&
+		oldProps.errors       === newProps.errors &&
+		oldProps.themeBundle  === newProps.themeBundle &&
+		oldProps.lang         === newProps.lang
+	);
+}
 
 module.exports = BrewRenderer;

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -229,13 +229,13 @@ const BrewRenderer = memo((props)=>{
 //Only re-render brewRenderer if arePropsEqual == true
 function arePropsEqual(oldProps, newProps) {
 	return (
-		oldProps.text.length  === newProps.text.length &&
-		oldProps.style.length === newProps.style.length &&
-		oldProps.renderer     === newProps.renderer &&
-		oldProps.theme        === newProps.theme &&
-		oldProps.errors       === newProps.errors &&
-		oldProps.themeBundle  === newProps.themeBundle &&
-		oldProps.lang         === newProps.lang
+		oldProps?.text?.length  === newProps?.text?.length &&
+		oldProps?.style?.length === newProps?.style?.length &&
+		oldProps?.renderer      === newProps?.renderer &&
+		oldProps?.theme         === newProps?.theme &&
+		oldProps?.errors        === newProps?.errors &&
+		oldProps?.themeBundle   === newProps?.themeBundle &&
+		oldProps?.lang          === newProps?.lang
 	);
 }
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -355,7 +355,7 @@ const Editor = createClass({
 	},
 
 	sourceJump : function(targetPage=this.props.currentBrewRendererPageNum, smooth=true){
-		if(!this.isText || isJumping)
+		if(!this.isText() || isJumping)
 			return;
 
 		const textSplit  = this.props.renderer == 'V3' ? /^\\page$/gm : /\\page/;


### PR DESCRIPTION
## Description
Memoizes the `brewRenderer.jsx` component. Normally, any time a parent component updates, it re-renders all it's child components as well because it re-sends their props. Scrolling sends a new "currentPage" to the editor/new/home page, which triggers a re-render.

This PR adds a `memo` marker to BrewRenderer, and an equality function to specify the condition when a render should be triggered. This prevents unnecessary markdown parsing, etc. when simply scrolling around; only props that actually affect the render output will trigger a render.

Greatly reduces lag during scrolling of the text editor panel, though further updates are possible (Editor.jsx also redraws the custom markdown highlighting, which we could similarly memoize or otherwise optimize).

**NOTE:** The equality function makes liberal use of `?.` optional chaining because `/new` seems to not have some of the initial props set. Might be a sign of something to check in `/new` but not of immediate urgency to get this fix out.

## Related Issues or Discussions

- Closes #3830 

## QA Instructions

Take a large brew in the Edit Page and compare lag during scrolling of the text editor on this branch and on live HB. Example from Reddit: https://homebrewery.naturalcrit.com/share/NJBuzODSboxi

Test with editor/renderer sync on and off.

Confirm all other changes that should trigger a re-render of BrewRenderer still fire (changing theme, renderer, style content, text content, etc.)