### PR TITLE
Update brewRenderer.jsx

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -1,7 +1,7 @@
 /*eslint max-lines: ["warn", {"max": 300, "skipBlankLines": true, "skipComments": true}]*/
 require('./brewRenderer.less');
 const React = require('react');
-const { useState, useRef, useCallback } = React;
+const { useState, useRef, useCallback, useMemo } = React;
 const _ = require('lodash');
 
 const MarkdownLegacy = require('naturalcrit/markdownLegacy.js');
@@ -44,7 +44,7 @@ const BrewPage = (props)=>{
 
 
 //v=====--------------------< Brew Renderer Component >-------------------=====v//
-const renderedPages = [];
+let renderedPages = [];
 let rawPages      = [];
 
 const BrewRenderer = (props)=>{
@@ -110,6 +110,8 @@ const BrewRenderer = (props)=>{
 		return <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `${themeStyles} \n\n <style> ${cleanStyle} </style>` }} />;
 	};
 
+	const renderedStyle = useMemo(()=> renderStyle(), [props.style.length, props.themeBundle]);
+
 	const renderPage = (pageText, index)=>{
 		if(props.renderer == 'legacy') {
 			const html = MarkdownLegacy.render(pageText);
@@ -122,6 +124,7 @@ const BrewRenderer = (props)=>{
 	};
 
 	const renderPages = ()=>{
+		console.log("renderPages")
 		if(props.errors && props.errors.length)
 			return renderedPages;
 
@@ -138,6 +141,8 @@ const BrewRenderer = (props)=>{
 		});
 		return renderedPages;
 	};
+
+	renderedPages = useMemo(() => renderPages(), [props.text.length]);
 
 	const handleControlKeys = (e)=>{
 		if(!(e.ctrlKey || e.metaKey)) return;
@@ -214,9 +219,9 @@ const BrewRenderer = (props)=>{
 					{state.isMounted
 						&&
 						<>
-							{renderStyle()}
+							{renderedStyle}
 							<div className='pages' lang={`${props.lang || 'en'}`} style={{ zoom: `${state.zoom}%` }}>
-								{renderPages()}
+								{renderedPages}
 							</div>
 						</>
 					}

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -110,8 +110,6 @@ const BrewRenderer = (props)=>{
 		return <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `${themeStyles} \n\n <style> ${cleanStyle} </style>` }} />;
 	};
 
-	const renderedStyle = useMemo(()=> renderStyle(), [props.style.length, props.themeBundle]);
-
 	const renderPage = (pageText, index)=>{
 		if(props.renderer == 'legacy') {
 			const html = MarkdownLegacy.render(pageText);
@@ -141,8 +139,6 @@ const BrewRenderer = (props)=>{
 		});
 		return renderedPages;
 	};
-
-	renderedPages = useMemo(() => renderPages(), [props.text.length]);
 
 	const handleControlKeys = (e)=>{
 		if(!(e.ctrlKey || e.metaKey)) return;
@@ -183,6 +179,9 @@ const BrewRenderer = (props)=>{
 	if(global.config.deployment) {
 		styleObject.backgroundImage = `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='40px' width='200px'><text x='0' y='15' fill='white' font-size='20'>${global.config.deployment}</text></svg>")`;
 	}
+
+	const renderedStyle = useMemo(()=> renderStyle(), [props.style.length, props.themeBundle]);
+	renderedPages = useMemo(() => renderPages(), [props.text.length]);
 
 	return (
 		<>

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -314,7 +314,7 @@ const Editor = createClass({
 	},
 
 	brewJump : function(targetPage=this.props.currentEditorCursorPageNum, smooth=true){
-		if(!window || isJumping)
+		if(!window || !this.isText() || isJumping)
 			return;
 
 		// Get current brewRenderer scroll position and calculate target position
@@ -355,7 +355,7 @@ const Editor = createClass({
 	},
 
 	sourceJump : function(targetPage=this.props.currentBrewRendererPageNum, smooth=true){
-		if(!this.isText || isJumping)
+		if(!this.isText() || isJumping)
 			return;
 
 		const textSplit  = this.props.renderer == 'V3' ? /^\\page$/gm : /\\page/;


### PR DESCRIPTION
## Description
Supercedes #3829 

Does the same as #3829, but only memoizing the `renderPages()` and `renderStyle()` functions. Much simpler and avoids issues not updating the page counter for example. These functions only update when `text` changes length, or `style` changes length (or themes change), respectively

Greatly reduces lag during scrolling of the text editor panel, though further updates are possible (Editor.jsx also redraws the custom markdown highlighting, which we could similarly memoize or otherwise optimize).

## Related Issues or Discussions

- Closes #3830 

## QA Instructions

Take a large brew in the Edit Page and compare lag during scrolling of the text editor on this branch and on live HB. Example from Reddit: https://homebrewery.naturalcrit.com/share/NJBuzODSboxi

Test with editor/renderer sync on and off.

Confirm all other changes that should trigger a re-render of BrewRenderer still fire (changing theme, renderer, style content, text content, etc.)