### PR TITLE
Speed up typing lag

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -106,8 +106,8 @@ const BrewRenderer = (props)=>{
 
 	const renderStyle = ()=>{
 		const cleanStyle = props.style; //DOMPurify.sanitize(props.style, purifyConfig);
-		const themeStyles = props.themeBundle?.joinedStyles ?? '<style>@import url("/themes/V3/Blank/style.css");</style>';
-		return <div style={{ display: 'none' }} dangerouslySetInnerHTML={{ __html: `${themeStyles} \n\n <style> ${cleanStyle} </style>` }} />;
+		const themeStyles = props.themeBundle?.joinedStyles ?? '@import url("/themes/V3/Blank/style.css");';
+		return `${themeStyles}\n\n${cleanStyle}`;
 	};
 
 	const renderPage = (pageText, index)=>{
@@ -202,7 +202,7 @@ const BrewRenderer = (props)=>{
 			<ToolBar onZoomChange={handleZoom} currentPage={props.currentBrewRendererPageNum}  totalPages={rawPages.length}/>
 
 			{/*render in iFrame so broken code doesn't crash the site.*/}
-			<Frame id='BrewRenderer' initialContent={INITIAL_CONTENT}
+			<Frame id='BrewRenderer' initialContent={INITIAL_CONTENT} head={<style>{renderedStyle}</style>}
 				style={{ width: '100%', height: '100%', visibility: state.visibility }}
 				contentDidMount={frameDidMount}
 				onClick={()=>{emitClick();}}
@@ -217,7 +217,6 @@ const BrewRenderer = (props)=>{
 					{state.isMounted
 						&&
 						<>
-							{renderedStyle}
 							<div className='pages' lang={`${props.lang || 'en'}`} style={{ zoom: `${state.zoom}%` }}>
 								{renderedPages}
 							</div>

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -44,7 +44,7 @@ const fetchThemeBundle = async (obj, renderer, theme)=>{
 	if(!res) return;
 
 	const themeBundle = res.body;
-	themeBundle.joinedStyles = themeBundle.styles.map((style)=>`<style>${style}</style>`).join('\n\n');
+	themeBundle.joinedStyles = themeBundle.styles.map((style)=>`${style}`).join('\n\n');
 	obj.setState((prevState)=>({
 		...prevState,
 		themeBundle : themeBundle


### PR DESCRIPTION
## Description
Simple change to move injected Theme and Style tab `<style>` blocks into the BrewRenderer iFrame `<head>` instead of a `<div>` inside the document. For whatever reason, this seems to drastically reduce the total time spent "Recalculating Styles", which occurs every time the brewRenderer pages are output.

**Before:**
![image](https://github.com/user-attachments/assets/d1120bfb-296b-4d67-b4b4-588f78cc2d79)

**After:**
![image](https://github.com/user-attachments/assets/405db33c-9365-4e1f-9abd-d8e4b113a50e)

## Related Issues or Discussions
#3830 (Though this focuses on typing lag, not scrolling lag, they both suffer from the same long render step)

## QA Instructions

Take a large brew in the Edit Page and compare lag during typing in the text editor on this branch and on live HB. Example from Reddit: [homebrewery.naturalcrit.com/share/NJBuzODSboxi](https://homebrewery.naturalcrit.com/share/NJBuzODSboxi)

Confirm Style tab and Theme selection still update live and work as expected.
