### PR TITLE
Disable Global ToC Snippet

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -291,8 +291,9 @@ const SnippetGroup = createClass({
 		return _.map(snippets, (snippet)=>{
 			return <div className='snippet' key={snippet.name} onClick={(e)=>this.handleSnippetClick(e, snippet)}>
 				<i className={snippet.icon} />
-				<span className='name'title={snippet.name}>{snippet.name}</span>
+				<span className={`name${snippet.disabled ? ' disabled' : ''}`} title={snippet.name}>{snippet.name}</span>
 				{snippet.experimental && <span className='beta'>beta</span>}
+				{snippet.disabled     && <span className='beta' title="temporarily disabled due to large slowdown; under re-design">disabled</span>}
 				{snippet.subsnippets && <>
 					<i className='fas fa-caret-right'></i>
 					<div className='dropdown side'>

--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -179,6 +179,7 @@
 					}
 				}
 				.name { margin-right : auto; }
+				.disabled { text-decoration: line-through; }
 				.beta {
 					align-self    : center;
 					padding       : 4px 6px;

--- a/themes/V3/5ePHB/snippets.js
+++ b/themes/V3/5ePHB/snippets.js
@@ -157,24 +157,27 @@ module.exports = [
 					{
 						name        : 'Table of Contents Toggles',
 						icon        : 'fas fa-book',
-						gen         : `{{tocGlobalH4}}\n\n`,
-						subsnippets : [
-							{
-								name : 'Enable H1-H4 all pages',
-								icon : 'fas fa-dice-four',
-								gen  : `{{tocGlobalH4}}\n\n`,
-							},
-							{
-								name : 'Enable H1-H5 all pages',
-								icon : 'fas fa-dice-five',
-								gen  : `{{tocGlobalH5}}\n\n`,
-							},
-							{
-								name : 'Enable H1-H6 all pages',
-								icon : 'fas fa-dice-six',
-								gen  : `{{tocGlobalH6}}\n\n`,
-							},
-						]
+						//gen         : `{{tocGlobalH4}}\n\n`,
+						disabled    : true
+						// RELIES ON .PAGES:HAS() WHICH IS VERY SLOW
+						// WILL BE MOVED TO STYLE TAB SNIPPETS
+						// subsnippets : [
+						// 	{
+						// 		name : 'Enable H1-H4 all pages',
+						// 		icon : 'fas fa-dice-four',
+						// 		gen  : `{{tocGlobalH4}}\n\n`,
+						// 	},
+						// 	{
+						// 		name : 'Enable H1-H5 all pages',
+						// 		icon : 'fas fa-dice-five',
+						// 		gen  : `{{tocGlobalH5}}\n\n`,
+						// 	},
+						// 	{
+						// 		name : 'Enable H1-H6 all pages',
+						// 		icon : 'fas fa-dice-six',
+						// 		gen  : `{{tocGlobalH6}}\n\n`,
+						// 	},
+						// ]
 					}
 				]
 			},

--- a/themes/V3/5ePHB/style.less
+++ b/themes/V3/5ePHB/style.less
@@ -812,17 +812,20 @@ h6,
 
 // Brew level default inclusion changes.
 // These add Headers 'back' to inclusion.
-.pages:has(.tocGlobalH4) {
-	h4 {--TOC: include; }
-}
 
-.pages:has(.tocGlobalH5) {
-	h4, h5 {--TOC: include; }
-}
+//NOTE: DO NOT USE :HAS WITH .PAGES!!! EXTREMELY SLOW TO RENDER ON LARGE DOCS!
+//WILL BE MOVED TO A STYLE TAB SNIPPET INSTEAD
+// .pages:has(.tocGlobalH4) {
+// 	h4 {--TOC: include; }
+// }
 
-.pages:has(.tocGlobalH6) {
-	h4, h5, h6 {--TOC: include; }
-}
+// .pages:has(.tocGlobalH5) {
+// 	h4, h5 {--TOC: include; }
+// }
+
+// .pages:has(.tocGlobalH6) {
+// 	h4, h5, h6 {--TOC: include; }
+// }
 
 // Block level inclusion changes
 // These include either a single  (include) or a range (depth)


### PR DESCRIPTION
## Description
Supercedes #3833 

Fixes massive typing lag on large brews, stemming from an unexpectedly slow CSS rule in this commit: https://github.com/naturalcrit/homebrewery/commit/f8d170be87d411c4b5929f28838ede6a0c488546

```
.pages:has(.tocGlobalH4) {
	h4 {--TOC: include; }
}

.pages:has(.tocGlobalH5) {
	h4, h5 {--TOC: include; }
}

.pages:has(.tocGlobalH6) {
	h4, h5, h6 {--TOC: include; }
}
```

Chrome optimizes `:has()` by marking each child of a `:has()` container with a link to the parent element. When one of those children updates in the DOM, it also notifies the parent to re-check for any `:has()` matches. This results in *all* of the parent's children also being re-evaluated to ensure any `:has()` matches on children are up-to-date.

This is ok for individual `.page` elements, but applying to `.pages` means every keystroke triggers a massive Style Recalculation of *every element in the document*, which can take multiple tenths of a second. This, on top of the Markdown parsing we also have to do, results in considerable typing lag. Think ~40ms to ~300ms.

## Related Issues or Discussions

#3830 (Though this focuses on typing lag, not scrolling lag, they both suffer from the same long render step)

## QA Instructions, Screenshots, Recordings

Take a large brew in the Edit Page and compare lag during typing in the text editor on this branch and on live HB. Example from Reddit: https://homebrewery-pr-3834.herokuapp.com/new/NJBuzODSboxi
