### PR TITLE
Migrate .tocGlobalH? toggles

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "git://github.com/naturalcrit/homebrewery.git"
   },
   "scripts": {
-    "dev": "node scripts/dev.js",
-    "quick": "node scripts/quick.js",
-    "build": "node scripts/buildHomebrew.js && node scripts/buildAdmin.js",
-    "builddev": "node scripts/buildHomebrew.js --dev",
+    "dev": "node --experimental-require-module scripts/dev.js",
+    "quick": "node --experimental-require-module scripts/quick.js",
+    "build": "node --experimental-require-module scripts/buildHomebrew.js && node --experimental-require-module scripts/buildAdmin.js",
+    "builddev": "node --experimental-require-module scripts/buildHomebrew.js --dev",
     "lint": "eslint --fix",
     "lint:dry": "eslint",
     "stylelint": "stylelint --fix **/*.{less}",
@@ -38,10 +38,10 @@
     "test:hard-breaks": "jest tests/markdown/hard-breaks.test.js --verbose --noStackTrace",
     "test:emojis": "jest tests/markdown/emojis.test.js --verbose --noStackTrace",
     "test:route": "jest tests/routes/static-pages.test.js --verbose",
-    "phb": "node scripts/phb.js",
+    "phb": "node --experimental-require-module scripts/phb.js",
     "prod": "set NODE_ENV=production && npm run build",
     "postinstall": "npm run build",
-    "start": "node server.js"
+    "start": "node --experimental-require-module server.js"
   },
   "author": "stolksdorf",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "git://github.com/naturalcrit/homebrewery.git"
   },
   "scripts": {
-    "dev": "node --experimental-require-module scripts/dev.js",
-    "quick": "node --experimental-require-module scripts/quick.js",
-    "build": "node --experimental-require-module scripts/buildHomebrew.js && node --experimental-require-module scripts/buildAdmin.js",
-    "builddev": "node --experimental-require-module scripts/buildHomebrew.js --dev",
+    "dev": "node scripts/dev.js",
+    "quick": "node scripts/quick.js",
+    "build": "node scripts/buildHomebrew.js && node scripts/buildAdmin.js",
+    "builddev": "node scripts/buildHomebrew.js --dev",
     "lint": "eslint --fix",
     "lint:dry": "eslint",
     "stylelint": "stylelint --fix **/*.{less}",
@@ -38,10 +38,10 @@
     "test:hard-breaks": "jest tests/markdown/hard-breaks.test.js --verbose --noStackTrace",
     "test:emojis": "jest tests/markdown/emojis.test.js --verbose --noStackTrace",
     "test:route": "jest tests/routes/static-pages.test.js --verbose",
-    "phb": "node --experimental-require-module scripts/phb.js",
+    "phb": "node scripts/phb.js",
     "prod": "set NODE_ENV=production && npm run build",
     "postinstall": "npm run build",
-    "start": "node --experimental-require-module server.js"
+    "start": "node server.js"
   },
   "author": "stolksdorf",
   "license": "MIT",

--- a/themes/V3/5ePHB/snippets.js
+++ b/themes/V3/5ePHB/snippets.js
@@ -154,31 +154,6 @@ module.exports = [
 						]
 					},
 
-					{
-						name        : 'Table of Contents Toggles',
-						icon        : 'fas fa-book',
-						//gen         : `{{tocGlobalH4}}\n\n`,
-						disabled    : true
-						// RELIES ON .PAGES:HAS() WHICH IS VERY SLOW
-						// WILL BE MOVED TO STYLE TAB SNIPPETS
-						// subsnippets : [
-						// 	{
-						// 		name : 'Enable H1-H4 all pages',
-						// 		icon : 'fas fa-dice-four',
-						// 		gen  : `{{tocGlobalH4}}\n\n`,
-						// 	},
-						// 	{
-						// 		name : 'Enable H1-H5 all pages',
-						// 		icon : 'fas fa-dice-five',
-						// 		gen  : `{{tocGlobalH5}}\n\n`,
-						// 	},
-						// 	{
-						// 		name : 'Enable H1-H6 all pages',
-						// 		icon : 'fas fa-dice-six',
-						// 		gen  : `{{tocGlobalH6}}\n\n`,
-						// 	},
-						// ]
-					}
 				]
 			},
 			{
@@ -217,6 +192,28 @@ module.exports = [
 							line-height: 1em;
 						}\n\n`
 			},
+			{
+				name        : 'Table of Contents Toggles',
+				icon        : 'fas fa-book',
+				disabled    : false,
+				subsnippets : [
+					{
+						name : 'Enable H1-H4 all pages',
+						icon : 'fas fa-dice-four',
+						gen  : `\n.pages {\n h4 {--TOC: include; }\n}\n\n`,
+					},
+					{
+						name : 'Enable H1-H5 all pages',
+						icon : 'fas fa-dice-five',
+						gen  : `\n.pages {\n h4, h5 {--TOC: include; }\n}\n\n`,
+					},
+					{
+						name : 'Enable H1-H6 all pages',
+						icon : 'fas fa-dice-six',
+						gen  : `\n.pages {\n h4, h5, h6 {--TOC: include; }\n}\n\n`,
+					},
+				]
+			}
 		]
 	},
 

--- a/themes/V3/5ePHB/style.less
+++ b/themes/V3/5ePHB/style.less
@@ -814,18 +814,6 @@ h6,
 // These add Headers 'back' to inclusion.
 
 //NOTE: DO NOT USE :HAS WITH .PAGES!!! EXTREMELY SLOW TO RENDER ON LARGE DOCS!
-//WILL BE MOVED TO A STYLE TAB SNIPPET INSTEAD
-// .pages:has(.tocGlobalH4) {
-// 	h4 {--TOC: include; }
-// }
-
-// .pages:has(.tocGlobalH5) {
-// 	h4, h5 {--TOC: include; }
-// }
-
-// .pages:has(.tocGlobalH6) {
-// 	h4, h5, h6 {--TOC: include; }
-// }
 
 // Block level inclusion changes
 // These include either a single  (include) or a range (depth)


### PR DESCRIPTION
Based on OH DEAR GOD THE LAG! discoveries related to the global toggles, these are being moved from a markup tag to a styles tab insert.

Verifications

 - [ ] Ensure ToC Toggles menu shows up on Styles tab
 - [ ] Ensure H4 inclusions insert correctly.
 - [ ] Ensure H4, H5 inclusions insert correctly.
 - [ ] Ensure H4,H5, H6 inclusions insert correctly.
 - [ ] Generate a ToC without any of these toggles enabled
 - [ ] Generate a ToC with the H4 inclusion toggle with H4, H5, and H6 Headers in the document. Ensure only H4s are added
 - [ ] Generate a ToC with the H4 and H5 inclusion toggle with H4, H5, and H6 Headers in the document. Ensure only H4s  and H5s are added
 - [ ] Generate a ToC with the H4, H5, and H6 inclusion toggle with H4, H5, and H6 Headers in the document. Ensure all headers are present.