### PR TITLE
Allow Markdown/Style to update on any text change

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -179,8 +179,8 @@ const BrewRenderer = (props)=>{
 		styleObject.backgroundImage = `url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' version='1.1' height='40px' width='200px'><text x='0' y='15' fill='%23fff7' font-size='20'>${global.config.deployment}</text></svg>")`;
 	}
 
-	const renderedStyle = useMemo(()=> renderStyle(), [props.style?.length, props.themeBundle]);
-	renderedPages = useMemo(() => renderPages(), [props.text?.length]);
+	const renderedStyle = useMemo(()=> renderStyle(), [props.style, props.themeBundle]);
+	renderedPages = useMemo(() => renderPages(), [props.text]);
 
 	return (
 		<>


### PR DESCRIPTION
## Description
We previously memoized the BrewRenderer Markdown / Style outputs to avoid needless re-computation during unrelated updates (scrolling, clicking, etc.). This had great success in reducing lag, but the check for when to re-calculate was only when `text.length` or `style.length` changes. This had the unintended consequence of preventing certain edge cases from updating the rendered output. Specifically:

- Select-and-dragging text. This moves text around but doesn't change text length.
- Pasting over text with new text of the same length, such as pasting a new image link that happens to be the same size.

## Related Issues or Discussions

- https://www.reddit.com/r/homebrewery/comments/1g62oqk/preview_not_updating_when_dragging_text/
- https://www.reddit.com/r/homebrewery/comments/1g5n8uu/comment/lsihj17/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

## QA Instructions, Screenshots, Recordings

On a large brew:

- [ ] Scrolling / clicking does not have lag
- [ ] Typing in the Markdown tab does not have lag
- [ ] Pasting new text with the same size over old text does update the rendered output
- [ ] Select-and-drag does update the rendered output
