### PR TITLE
Catch IndexedDB errors

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -228,8 +228,8 @@ const EditPage = createClass({
 			htmlErrors : Markdown.validate(prevState.brew.text)
 		}));
 
-		await updateHistory(this.state.brew);
-		await versionHistoryGarbageCollection();
+		await updateHistory(this.state.brew).catch(console.error);
+		await versionHistoryGarbageCollection().catch(console.error);
 
 		const transfer = this.state.saveGoogle == _.isNil(this.state.brew.googleId);
 


### PR DESCRIPTION
This PR adds a `.catch()` to the IndexedDB `await` calls inside the Edit Page's `save` function.

In the event that the new Version History functions strike an error somehow, that error can cause the entire save function to silently fail. This change adds catch blocks that will surface the error to the browser console but crucially, **NOT** cause the save function to fail.