### PR TITLE
Fix the `.list` node for the StringArrayEditor

### DIFF
--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -245,25 +245,24 @@
 		display   : flex;
 		flex      : 1 0;
 		flex-wrap : wrap;
+		align-items: center;
 
 		> * { flex : 0 0 auto; }
 
 		#groupedIcon {
 			#backgroundColors;
 			position   : relative;
-			top        : -0.3em;
-			right      : -0.3em;
-			display    : inline-block;
+			height: 100%;
+			display    : flex;
+			align-items: center;
+			justify-content: center;
 			min-width  : 20px;
-			height     : ~'calc(100% + 0.6em)';
 			color      : white;
 			text-align : center;
 			cursor     : pointer;
 	
 			i {
 				position  : relative;
-				top       : 50%;
-				transform : translateY(-50%);
 			}
 	
 			&:not(:last-child) { border-right : 1px solid black; }
@@ -272,7 +271,11 @@
 		}
 
 		.badge {
-			padding          : 0.3em;
+			display: flex;
+			align-items: center;
+			height: 2em;
+			gap: 3px;
+			padding-left: 6px;
 			margin           : 2px;
 			font-size        : 0.9em;
 			background-color : #DDDDDD;
@@ -282,7 +285,8 @@
 		}
 
 		.input-group {
-			height : ~'calc(.9em + 4px + .6em)';
+			height: 2em;
+			display: flex;
 
 			input { border-radius : 0.5em 0 0 0.5em; }
 
@@ -291,33 +295,17 @@
 			.value {
 				width     : 7.5vw;
 				min-width : 75px;
+				height: 100%;
+			}
+
+			.icon {
+				#groupedIcon;
+				right     : 1px;
 				height    : 100%;
 			}
 
-			.input-group {
-				height : ~'calc(.9em + 4px + .6em)';
+			.invalid:focus { background-color : pink; }
 
-				input { border-radius : 0.5em 0 0 0.5em; }
-
-				input:last-child { border-radius : 0.5em; }
-
-				.value {
-					width     : 7.5vw;
-					min-width : 75px;
-					height    : 100%;
-				}
-
-				.invalid:focus { background-color : pink; }
-
-				.icon {
-					#groupedIcon;
-					top       : -0.54em;
-					right     : 1px;
-					height    : 97%;
-
-					i { font-size : 1.125em; }
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
fixes the icon buttons on the stringArrayEditor/tagInput `.list` element so that they are inline, given the correct background, and aligned correctly.  Restores pink validation styling.


## Description

Here it is broken, on Live:
![image](https://github.com/user-attachments/assets/4d0f6465-d47b-453e-b476-38b55e4cd36c)


Here it is fixed:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/93ce3ee8-a0ae-4517-90eb-b444fe251b24">



## Related Issues or Discussions

- [gitter discussion](https://matrix.to/#/!IuzKyDJxDuanSbtTQt:gitter.im/$_08cnMbqx2srlhedAmE0h_skmtSEPFWyPmhxmFVqccs?via=gitter.im&via=matrix.org&via=integrations.ems.host)

## QA Instructions, Screenshots, Recordings

Try using the string array editor (aka "tags" and "authors" inputs) in the Properties Editor.  The three states should all display properly (non-editing 'badge', editing badge, and empty badge/input).

## Add'l comments

Likely the metadataEditor.less file could be overhauled more completely, but I'm just focused on fixing this one thing.  In my TagInput PR there are significant changes to the .less file so I don't want to muck about too much in there right now if i don't have to.
