### PR TITLE
Snippetbar Rework: Popovers, Anchor Positioning, Enhancements

### DIFF
--- a/client/components/dialog.jsx
+++ b/client/components/dialog.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 const { useRef, useEffect } = React;
 
-function Dialog({ dismisskeys, closeText = 'Close', blocking = false, ...rest }) {
+function Dialog({ dismisskeys = [], closeText = 'Close', blocking = false, ...rest }) {
 	const dialogRef = useRef(null);
 
 	useEffect(()=>{

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -13,6 +13,7 @@
 	height           : auto;
 	padding          : 2px 0;
 	font-family      : 'Open Sans', sans-serif;
+	font-size        : 13px;
 	color            : #CCCCCC;
 	background-color : #555555;
 	& > *:not(.toggleButton) {
@@ -90,10 +91,6 @@
 		width            : auto;
 		min-width        : 46px;
 		height           : 100%;
-		padding          : 0 0px;
-		font-weight      : unset;
-		color            : inherit;
-		background-color : unset;
 		&:hover { background-color : #444444; }
 		&:focus { outline : 1px solid #D3D3D3; }
 		&:disabled {

--- a/client/homebrew/editor/metadataEditor/metadataEditor.less
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.less
@@ -79,6 +79,7 @@
 				text-overflow : ellipsis;
 			}
 			button {
+				.colorButton();
 				padding          : 0px 5px;
 				color            : white;
 				background-color : black;
@@ -138,16 +139,16 @@
 		margin-bottom : 15px;
 		button { width : 100%; }
 		button.publish {
-			.button(@blueLight);
+			.colorButton(@blueLight);
 		}
 		button.unpublish {
-			.button(@silver);
+			.colorButton(@silver);
 		}
 	}
 
 	.delete.field .value {
 		button {
-			.button(@red);
+			.colorButton(@red);
 		}
 	}
 	.authors.field .value {

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -207,59 +207,54 @@ const Snippetbar = createClass({
 	renderEditorButtons : function(){
 		if(!this.props.showEditButtons) return;
 
-		const foldButtons = <>
-			<div className={`editorTool foldAll ${this.props.view !== 'meta' && this.props.foldCode ? 'active' : ''}`}
-				onClick={this.props.foldCode} >
-				<i className='fas fa-compress-alt' />
-			</div>
-			<div className={`editorTool unfoldAll ${this.props.view !== 'meta' && this.props.unfoldCode ? 'active' : ''}`}
-				onClick={this.props.unfoldCode} >
-				<i className='fas fa-expand-alt' />
-			</div>
-		</>;
+		return (
+			<div className='tools'>
+				<div className='historyTools group'>
+					<button id='show-history' type='button' className='tool' popovertarget='history-menu' style={{ anchorName: '--history-menu' }}>
+						<i className='fas fa-clock-rotate-left' />
+					</button>
+					{this.renderHistoryItems()}
+					<button id='undo' type='button' disabled={!this.props.historySize.undo ? true : false} className='tool'
+						onClick={this.props.undo} >
+						<i className='fas fa-undo' />
+					</button>
+					<button id='redo'type='button' disabled={!this.props.historySize.redo ? true : false} className='tool'
+						onClick={this.props.redo} >
+						<i className='fas fa-redo' />
+					</button>
+				</div>
+				<div className='codeTools group'>
+					<button id='fold-all' type='button' disabled={(this.props.view === 'meta' || !this.props.foldCode) ? true : false} className='tool'
+						onClick={this.props.foldCode} >
+						<i className='fas fa-compress-alt' />
+					</button>
+					<button id='unfold-all' type='button' disabled={(this.props.view === 'meta' || !this.props.unfoldCode) ? true : false} className='tool'
+						onClick={this.props.unfoldCode} >
+						<i className='fas fa-expand-alt' />
+					</button>
+					<button id='show-themes' type='button' className={`tool${this.state.themeSelector ? ' active' : ''}`}
+						onClick={this.toggleThemeSelector} >
+						<i className='fas fa-palette' />
+						{this.state.themeSelector && this.renderThemeSelector()}
+					</button>
+				</div>
 
-		return <div className='editors'>
-			<div className='historyTools'>
-				<div className={`editorTool snippetGroup history ${this.state.historyExists ? 'active' : ''}`}
-					onClick={this.toggleHistoryMenu} >
-					<i className='fas fa-clock-rotate-left' />
-					{ this.state.showHistory && this.renderHistoryItems() }
-				</div>
-				<div className={`editorTool undo ${this.props.historySize.undo ? 'active' : ''}`}
-					onClick={this.props.undo} >
-					<i className='fas fa-undo' />
-				</div>
-				<div className={`editorTool redo ${this.props.historySize.redo ? 'active' : ''}`}
-					onClick={this.props.redo} >
-					<i className='fas fa-redo' />
-				</div>
-			</div>
-			<div className='codeTools'>
-				{foldButtons}
-				<div className={`editorTool editorTheme ${this.state.themeSelector ? 'active' : ''}`}
-					onClick={this.toggleThemeSelector} >
-					<i className='fas fa-palette' />
-					{this.state.themeSelector && this.renderThemeSelector()}
+				<div className='editors group' role='tablist'>
+					<button id='brew-tab' role='tab' type='button' className='tab' aria-selected={this.props.view === 'text'}
+						onClick={()=>this.props.onViewChange('text')}>
+						<i className='fa fa-beer' />
+					</button>
+					<button id='style-tab' role='tab' type='button' className='tab' aria-selected={this.props.view === 'style'}
+						onClick={()=>this.props.onViewChange('style')}>
+						<i className='fa fa-paint-brush' />
+					</button>
+					<button id='properties-tab' role='tab' type='button' className='tab' aria-selected={this.props.view === 'meta'}
+						onClick={()=>this.props.onViewChange('meta')}>
+						<i className='fas fa-info-circle' />
+					</button>
 				</div>
 			</div>
-
-
-			<div className='tabs'>
-				<div className={cx('text', { selected: this.props.view === 'text' })}
-					onClick={()=>this.props.onViewChange('text')}>
-					<i className='fa fa-beer' />
-				</div>
-				<div className={cx('style', { selected: this.props.view === 'style' })}
-					onClick={()=>this.props.onViewChange('style')}>
-					<i className='fa fa-paint-brush' />
-				</div>
-				<div className={cx('meta', { selected: this.props.view === 'meta' })}
-					onClick={()=>this.props.onViewChange('meta')}>
-					<i className='fas fa-info-circle' />
-				</div>
-			</div>
-
-		</div>;
+		);
 	},
 
 	render : function(){
@@ -294,28 +289,36 @@ const SnippetGroup = createClass({
 	},
 	renderSnippets : function(snippets){
 		return _.map(snippets, (snippet)=>{
-			return <div className='snippet' key={snippet.name} onClick={(e)=>this.handleSnippetClick(e, snippet)}>
-				<i className={snippet.icon} />
-				<span className={`name${snippet.disabled ? ' disabled' : ''}`} title={snippet.name}>{snippet.name}</span>
-				{snippet.experimental && <span className='beta'>beta</span>}
-				{snippet.disabled     && <span className='beta' title='temporarily disabled due to large slowdown; under re-design'>disabled</span>}
-				{snippet.subsnippets && <>
-					<i className='fas fa-caret-right'></i>
-					<div className='dropdown side'>
-						{this.renderSnippets(snippet.subsnippets)}
-					</div></>}
-			</div>;
+			if(snippet.subsnippets){
+				return (
+					<>
+						<button className='snippet menu-trigger' key={snippet.name} popovertarget={`${_.kebabCase(snippet.name)}-menu`} style={{ anchorName: `--${_.kebabCase(snippet.name)}-menu` }}>
+							<span className={`name${snippet.disabled ? ' disabled' : ''}`} title={snippet.name}>{snippet.name}</span><i className='fas fa-caret-right'></i>
+						</button>
+						<div id={`${_.kebabCase(snippet.name)}-menu`} className='dropdown side' popover='auto' style={{ positionAnchor: `--${_.kebabCase(snippet.name)}-menu` }}>
+							{this.renderSnippets(snippet.subsnippets)}
+						</div>
+					</>
+				);
+			} else {
+				return <div className='snippet' key={snippet.name} onClick={(e)=>this.handleSnippetClick(e, snippet)}>
+					<i className={snippet.icon} />
+					<span className={`name${snippet.disabled ? ' disabled' : ''}`} title={snippet.name}>{snippet.name}</span>
+					{snippet.experimental && <span className='beta'>beta</span>}
+					{snippet.disabled     && <span className='beta' title='temporarily disabled due to large slowdown; under re-design'>disabled</span>}
+				</div>;
+			}
 
 		});
 	},
 
 	render : function(){
-		return <div className='snippetGroup snippetBarButton'>
-			<div className='text'>
+		return <div className='snippet-menu' style={{ anchorName: `--${_.kebabCase(this.props.groupName)}-menu` }}>
+			<button popovertarget={`${_.kebabCase(this.props.groupName)}-menu`}>
 				<i className={this.props.icon} />
 				<span className='groupName'>{this.props.groupName}</span>
-			</div>
-			<div className='dropdown'>
+			</button>
+			<div id={`${_.kebabCase(this.props.groupName)}-menu`} className='dropdown' popover='auto' style={{ positionAnchor: `--${_.kebabCase(this.props.groupName)}-menu` }}>
 				{this.renderSnippets(this.props.snippets)}
 			</div>
 		</div>;

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -4,6 +4,7 @@ const React = require('react');
 const createClass = require('create-react-class');
 const _     = require('lodash');
 const cx    = require('classnames');
+const moment = require('moment');
 
 import { loadHistory } from '../../utils/versionHistory.js';
 
@@ -181,27 +182,26 @@ const Snippetbar = createClass({
 	renderHistoryItems : function() {
 		if(!this.state.historyExists) return;
 
-		return <div className='dropdown'>
-			{_.map(this.state.historyItems, (item, index)=>{
-				if(item.noData || !item.savedAt) return;
+		return (
+			<div id='history-menu' className='dropdown' popover='auto' style={{ positionAnchor: '--history-menu' }}>
+				<div className='menu-group'>Restore from...</div>
+				{this.state.historyItems.map((item, index)=>{
+					if(item.noData || !item.savedAt) return null;
 
-				const saveTime = new Date(item.savedAt);
-				const diffMs = new Date() - saveTime;
-				const diffSecs = Math.floor(diffMs / 1000);
+					const saveTime = moment(item.savedAt);
+					const diffString = saveTime.fromNow();
 
-				let diffString = `about ${diffSecs} seconds ago`;
-
-				if(diffSecs > 60) diffString = `about ${Math.floor(diffSecs / 60)} minutes ago`;
-				if(diffSecs > (60 * 60)) diffString = `about ${Math.floor(diffSecs / (60 * 60))} hours ago`;
-				if(diffSecs > (24 * 60 * 60)) diffString = `about ${Math.floor(diffSecs / (24 * 60 * 60))} days ago`;
-				if(diffSecs > (7 * 24 * 60 * 60)) diffString = `about ${Math.floor(diffSecs / (7 * 24 * 60 * 60))} weeks ago`;
-
-				return <div className='snippet' key={index} onClick={()=>{this.replaceContent(item);}} >
-					<i className={`fas fa-${index+1}`} />
-					<span className='name' title={saveTime.toISOString()}>v{item.version} : {diffString}</span>
-				</div>;
-			})}
-		</div>;
+					return (
+						<div className='snippet' key={index} onClick={()=>this.replaceContent(item)}>
+							<i className='fas fa-trash-arrow-up' />
+							<span className='name' title={`Restore version from ${moment(saveTime).format('YYYY/MM/DD HH:mm:ss')}`}>
+								v{item.version} : {diffString}
+							</span>
+						</div>
+					);
+				})}
+			</div>
+		);
 	},
 
 	renderEditorButtons : function(){

--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -10,165 +10,206 @@
 	height           : auto;
 	color            : black;
 	background-color : #DDDDDD;
-
-	.snippets {
-		display         : flex;
-		justify-content : flex-start;
-		min-width       : 327.58px;
+	text-transform: uppercase;
+	font-size      : 0.625em;
+	font-weight    : 800;
+	box-shadow: 0 0px 4px -1px black;
+	border-bottom: 1px solid #666;
+	z-index: 500;
+	i {
+		font-size: 1.4em;
 	}
 
-	.editors {
+	// styling for dropdown menus.  Is a *mixin*, defined but not printed here,
+	// only printed within their snippetbar groups.
+	.dropdown() {
+		@supports (inset-block-start: anchor(bottom)){
+			inset-block-start: anchor(bottom);
+			inset-inline-start: anchor(left);
+			position-try: flip-inline;
+		}
+		z-index          : 1000;
+		padding          : 2px;
+		background-color : #DDDDDD;
+		box-shadow: 0 3px 5px -4px black;
+		border: 1px solid #666;
+		&:popover-open {
+			display: grid; 
+			grid-template-columns: 25px 1fr max-content auto;
+		}
+
+		.menu-group {
+			grid-column: ~'1 / -1';
+			padding: 3px;
+			border-bottom: 1px solid #BBBB;
+		}
+
+		.dropdown {
+			margin: 5px;
+			@supports (inset-block-start: anchor(bottom)){
+				inset-block-start: anchor(top);
+				inset-inline-start: anchor(right);
+				position-try: flip-inline;
+			}
+
+		}
+	}
+
+	.snippet() {
+		display: grid; 
+		grid-column: ~"1 / -1";
+		grid-template-columns: inherit; 
+		align-items : center;
+		gap : 8px;
+		min-width   : max-content;
+		padding     : 7px 5px;
+		cursor      : pointer;
+		.animate(background-color);
+		&:has(+ .dropdown:popover-open){
+			background: #999999;
+		}
+	}
+
+
+	.highlight(@color: #999999) {
+		&:hover, &[aria-selected='true'], &:has(+ .dropdown:popover-open){ background-color : @color; color: whitesmoke}
+	}
+
+	// group that holds all non-snippet buttons.
+	.tools {
 		display         : flex;
 		justify-content : flex-end;
 		min-width       : 225px;
+		container       : tools ;
 
-		&:only-child { margin-left : auto; }
+		&:only-child { margin-left : auto; }  // When on Properties tab, keep tools pushed to right side.
 
-		>div {
+		// subgroups for tools (history, code folding/theme, editor tabs)
+		> .group {
 			display         : flex;
 			flex            : 1;
 			justify-content : space-around;
 
-			&:first-child { border-left : none; }
+			.dropdown {
+				.dropdown();
 
-			& > div {
-				position    : relative;
-				width       : @menuHeight;
-				height      : @menuHeight;
-				line-height : @menuHeight;
-				text-align  : center;
-				cursor      : pointer;
-				&:hover,&.selected { background-color : #999999; }
-				&.text {
-					.tooltipLeft('Brew Editor');
+
+				.snippet {
+					.snippet();
+					i {
+						justify-self: center;
+						grid-column: ~"1 / 2";
+					}
 				}
-				&.style {
-					.tooltipLeft('Style Editor');
+			}
+			
+			// any non-snippet button
+			& > button {
+				position     : relative;
+				height       : @menuHeight;
+				flex         : 1 0 auto;
+				cursor       : pointer;
+				.highlight();
+				&:disabled {
+					color: #999999;
 				}
-				&.meta {
-					.tooltipLeft('Properties');
-				}
-				&.undo {
-					.tooltipLeft('Undo');
-					font-size : 0.75em;
-					color     : grey;
-					&.active { color : inherit; }
-				}
-				&.redo {
-					.tooltipLeft('Redo');
-					font-size : 0.75em;
-					color     : grey;
-					&.active { color : inherit; }
-				}
-				&.foldAll {
-					.tooltipLeft('Fold All');
-					font-size : 0.75em;
-					color     : grey;
-					&.active { color : inherit; }
-				}
-				&.unfoldAll {
-					.tooltipLeft('Unfold All');
-					font-size : 0.75em;
-					color     : grey;
-					&.active { color : inherit; }
-				}
-				&.history {
-					.tooltipLeft('History');
+
+				// history tools
+				&#show-history { .tooltipLeft('History');
 					position  : relative;
-					font-size : 0.75em;
-					color     : grey;
-					border    : none;
-					&.active { color : inherit; }
+					&.active { background-color : #999999; }
 					& > .dropdown {
 						right : -1px;
 						& > .snippet { padding-right : 10px; }
 					}
 				}
-				&.editorTheme {
+				&#undo { .tooltipLeft('Undo'); }
+				&#redo { .tooltipLeft('Redo'); }
+
+				// code tools
+				&#fold-all { .tooltipLeft('Fold All'); }
+				&#unfold-all { .tooltipLeft('Unfold All'); }
+				&#show-themes {
 					.tooltipLeft('Editor Themes');
-					font-size : 0.75em;
 					color     : black;
 					&.active {
 						position         : relative;
 						background-color : #999999;
 					}
+					.themeSelector {
+						position         : absolute;
+						top              : 25px;
+						right            : 0;
+						z-index          : 10;
+						display          : flex;
+						align-items      : center;
+						justify-content  : center;
+						width            : 170px;
+						height           : inherit;
+						background-color : inherit;
+					}
 				}
-				&.divider {
-					width      : 5px;
-					background : linear-gradient(currentColor, currentColor) no-repeat center/1px 100%;
-					&:hover { background-color : inherit; }
+
+				// editor tabs
+				&#brew-tab { 
+					.highlight(@orangeLight);
+					.tooltipLeft('Brew Editor');
 				}
-			}
-			.themeSelector {
-				position         : absolute;
-				top              : 25px;
-				right            : 0;
-				z-index          : 10;
-				display          : flex;
-				align-items      : center;
-				justify-content  : center;
-				width            : 170px;
-				height           : inherit;
-				background-color : inherit;
-			}
+				&#style-tab { 
+					.highlight(@blueLight);
+					.tooltipLeft('Style Editor');
+				}
+				&#properties-tab { 
+					.highlight(@tealLight);
+					.tooltipLeft('Properties');
+				}				
+			}			
 		}		
 	}
-	.snippetBarButton {
-		display        : inline-block;
-		height         : @menuHeight;
-		padding        : 0px 5px;
-		font-size      : 0.625em;
-		font-weight    : 800;
-		line-height    : @menuHeight;
-		text-transform : uppercase;
-		text-wrap      : nowrap;
-		cursor         : pointer;
-		&:hover, &.selected { background-color : #999999; }
-		i {
-			margin-right   : 3px;
-			font-size      : 1.4em;
-			vertical-align : middle;
-		}
-	}
-	.toggleMeta {
-		position    : absolute;
-		top         : 0px;
-		right       : 0px;
-		border-left : 1px solid black;
-		.tooltipLeft('Edit Brew Properties');
-	}
-	.snippetGroup {
 
-		&:hover {
-			& > .dropdown { visibility : visible; }
-		}
+	// group that holds all snippet menus.
+	.snippets {
+		height          : @menuHeight;
+		display         : flex;
+		justify-content : flex-start;
+		min-width       : min-content;
+		text-wrap       : nowrap;
+
 		.dropdown {
-			position         : absolute;
-			top              : 100%;
-			z-index          : 1000;
-			padding          : 0px;
-			margin-left      : -5px;
-			visibility       : hidden;
-			background-color : #DDDDDD;
+			.dropdown();
+		}
+
+		.snippet-menu {
+			display        : inline-block;
+			height         : 100%;
+			padding        : 0px 5px;
+			cursor         : pointer;
+			.highlight();
+
+			button {
+				height: 100%;
+				display: flex;
+				align-items: center;
+				gap: 3px;
+			}
+
 			.snippet {
-				position    : relative;
-				display     : flex;
-				align-items : center;
-				min-width   : max-content;
-				padding     : 5px;
-				font-size   : 10px;
-				cursor      : pointer;
-				.animate(background-color);
-				i {
-					min-width    : 25px;
-					height       : 1.2em;
-					margin-right : 8px;
-					font-size    : 1.2em;
-					text-align   : center;
-					& ~ i {
-						margin-right : 0;
-						margin-left  : 5px;
+				.snippet();
+				
+
+				&.menu-trigger {
+					grid-column: ~"1 / -1";
+					i.fa-caret-right {
+						grid-column: ~"4 / 5";
+						min-width: unset;
+
 					}
+				}
+				
+				i {
+					justify-self: center;
+					grid-column: ~"1 / 2";
+
 					/* Fonts */
 					&.font {
 						height : auto;
@@ -177,6 +218,8 @@
 							content   : 'ABC';
 						}
 
+						// todo: figure out how to adapt this list based on each themes' snippets.js,
+						// so different themes can have different fonts in the Fonts menu.
 						&.OpenSans {font-family : 'OpenSans';}
 						&.CodeBold {font-family : 'CodeBold';}
 						&.CodeLight {font-family : 'CodeLight';}
@@ -196,13 +239,13 @@
 						&.TimesNewRoman {font-family : 'Times New Roman';}
 					}
 				}
-				.name { margin-right : auto; }
+				.name { grid-column: ~"2 / 3"; margin-right : auto; }
 				.disabled { text-decoration : line-through; }
 				.beta {
-					align-self    : center;
+					grid-column: ~"3 / 4";
 					padding       : 4px 6px;
 					margin-left   : 5px;
-					font-family   : monospace;
+					font-size     : 0.9em;
 					line-height   : 1em;
 					color         : white;
 					background    : grey;
@@ -210,23 +253,15 @@
 				}
 				&:hover {
 					background-color : #999999;
-					& > .dropdown {
-						visibility : visible;
-						&.side {
-							top         : 0%;
-							left        : 100%;
-							margin-left : 0;
-							box-shadow  : -1px 1px 2px 0px #999999;
-						}
-					}
 				}
 			}
 		}
 	}
+	
 }
-@container editor (width < 553px) {
+@container editor (width < 570px) {
 	.snippetBar {
-		.editors { 
+		.tools { 
 			flex            : 1;
 			justify-content : space-between;
 			border-bottom   : 1px solid;
@@ -235,7 +270,7 @@
 			flex            : 1;
 			justify-content : space-evenly; 
 		}
-		.editors > div.history > .dropdown { right : unset; }
+		.tools > div.history > .dropdown { right : unset; }
 	}
 }
 

--- a/shared/naturalcrit/styles/core.less
+++ b/shared/naturalcrit/styles/core.less
@@ -21,10 +21,7 @@ html,body, #reactRoot{
 *{
 	box-sizing : border-box;
 }
-button{
-	.button();
-}
-.button(@backgroundColor : @green){
+.colorButton(@backgroundColor : @green){
 	.animate(background-color);
 	display          : inline-block;
 	padding          : 0.6em 1.2em;

--- a/shared/naturalcrit/styles/reset.less
+++ b/shared/naturalcrit/styles/reset.less
@@ -1,4 +1,4 @@
-:where(html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video){
+:where(html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,button,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video){
   border:0;font-size:100%;font:inherit;vertical-align:baseline;margin:0;padding:0
 }
 
@@ -24,4 +24,10 @@
 
 :where(table){
   border-collapse:collapse;border-spacing:0
+}
+
+:where(button) {
+	background-color: unset;
+	text-transform: unset;
+	color: unset;
 }

--- a/themes/V3/5ePHB/snippets.js
+++ b/themes/V3/5ePHB/snippets.js
@@ -23,7 +23,6 @@ module.exports = [
 			{
 				name         : 'Table of Contents',
 				icon         : 'fas fa-book',
-				gen          : TableOfContentsGen,
 				experimental : true,
 				subsnippets  : [
 					{
@@ -33,10 +32,8 @@ module.exports = [
 						experimental : true
 					},
 					{
-						name : 'Table of Contents Individual Inclusion',
-						icon : 'fas fa-book',
-						gen  : dedent `\n{{tocInclude# CHANGE # to your header level
-							}}\n`,
+						name        : 'Table of Contents Individual Inclusion',
+						icon        : 'fas fa-book',
 						subsnippets : [
 							{
 								name : 'Individual Inclusion H1',
@@ -77,10 +74,8 @@ module.exports = [
 						]
 					},
 					{
-						name : 'Table of Contents Range Inclusion',
-						icon : 'fas fa-book',
-						gen  : dedent `\n{{tocDepthH3
-							}}\n`,
+						name        : 'Table of Contents Range Inclusion',
+						icon        : 'fas fa-book',
 						subsnippets : [
 							{
 								name : 'Include in ToC up to H3',
@@ -110,10 +105,8 @@ module.exports = [
 						]
 					},
 					{
-						name : 'Table of Contents Individual Exclusion',
-						icon : 'fas fa-book',
-						gen  : dedent `\n{{tocExcludeH1 \n
-							}}\n`,
+						name        : 'Table of Contents Individual Exclusion',
+						icon        : 'fas fa-book',
 						subsnippets : [
 							{
 								name : 'Individual Exclusion H1',
@@ -380,7 +373,6 @@ module.exports = [
 			{
 				name        : 'Class Tables',
 				icon        : 'fas fa-table',
-				gen         : ClassTableGen.full('classTable,frame,decoration,wide'),
 				subsnippets : [
 					{
 						name : 'Martial Class Table',
@@ -427,7 +419,6 @@ module.exports = [
 			{
 				name         : 'Rune Table',
 				icon         : 'fas fa-language',
-				gen          : scriptGen.dwarvish,
 				experimental : true,
 				subsnippets  : [
 					{

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -51,7 +51,6 @@ module.exports = [
 			{
 				name        : 'Footer',
 				icon        : 'fas fa-shoe-prints',
-				gen         : FooterGen.createFooterFunc(),
 				subsnippets : [
 					{
 						name : 'Footer from H1',
@@ -201,7 +200,6 @@ module.exports = [
 			{
 				name         : 'Watercolor Edge',
 				icon         : 'fac mask-edge',
-				gen          : ImageMaskGen.edge('bottom'),
 				experimental : true,
 				subsnippets  : [
 					{
@@ -229,7 +227,6 @@ module.exports = [
 			{
 				name         : 'Watercolor Corner',
 				icon         : 'fac mask-corner',
-				gen          : ImageMaskGen.corner,
 				experimental : true,
 				subsnippets  : [
 					{


### PR DESCRIPTION
## Description

### Background
This PR is primarily an effort to bring forward the use of the HTML attribute `popover` and the new [CSS Anchor Positioning API (view in Chrome)](https://developer.chrome.com/blog/anchor-positioning-api).  Right off the bat I'll say I'm not sure we want to go this route *right away*, because we are still waiting on Firefox to rollout anchor positioning.  [I'm eternally optimistic that it will be soon](https://bugzilla.mozilla.org/show_bug.cgi?id=1838746).  But hopefully this can at least be illustrative of how `popover` and anchoring can work together in a UI.  

<img width="818" alt="image" src="https://github.com/user-attachments/assets/26b581ef-4252-436e-9b71-e9f2642bb291">


Using the `popover` attribute in an element means that the element is rendered to a **top layer** root element, basically a sibling to the `<html>` element.  This means it is higher in the layers than any other item, and so can't be clipped/hidden behind anything except other elements that come after it in **top layer**.  In the DOM, the element is still wherever you put it in your code, and can be styled just as you would normally expect, with a couple of exceptions....it's just rendered above everything else.

Popovers do lose some ability to position them.  In Firefox, where Anchor Positioning isn't a thing yet, this makes it difficult to place things like the menus in the right spot because your only option is to use absolute positioning *in relation to the viewport*;  you cannot position it relative to a parent/ancestor.  In Chrome, you can use Anchor Positioning on popover elements, which pretty much covers all our bases.

<img width="818" alt="image" src="https://github.com/user-attachments/assets/3d5307cd-7c70-402a-956e-c63b6bea25d7">

Anchor positioning is for positioning an element in relation to another.  Notably, the two elements do not need to be related to each other in the DOM-- they don't need to be parent/child/sibling etc.  You just give an element an anchor name, and then reference that name in the other element's css anchor position property. To set where the anchored element is positioned in relation to the anchor, there are a few easy keyword-based properties that are basically "position the anchored element's left top corner against the anchor's right top corner".  You can do more with sizing, margins, etc.  Anchor positioning can dynamically keep an element within the viewport until the element would otherwise be totally out of view, or switch the positioning if the anchored element doesn't fit anymore, etc.  Anchored elements can even have different corners anchored to different elements.

### So what, ignore Firefox?
So the big downer is that because Firefox doesn't have Anchor Positioning yet, it's actually pretty difficult (as far as i can tell), to have a decent fallback.  Popover elements lack some positioning abilities that would help mitigate the issue.  As this PR currently stands at time of writing, the Firefox experience is pretty disappointing. Some options:

- Pretend Firefox doesn't exist and just fire this off now (this is the current state; i don't love it).
- Use a library (Floating-UI) as basically a polyfill for Firefox, and try to write the code such that when Firefox adds Anchor Positioning it is easy to remove the polyfill.  Floating-UI is a popular library for doing everything Anchor Positioning does, before AP was added to browsers and is the basis for other very popular UI libraries.
- Remove all the Anchor Positioning stuff and just use Floating-UI for everything.  
- Sit on this PR until Firefox catches up.

### This is a big PR, what's in here anyways?
This started off as a quick effort to show that Anchor Positioning and Popovers are the way to fix the "menus clipping behind the preview pane" problem.  But as I had to make a little adjustment here and there, things got out of hand.  Particularly with snippetBar.less, which has been significantly altered.

- snippetBar.jsx: Big changes to the html structure of snippets, menus, and the bar itself.  Lots of changing divs to buttons, setting style objects via JS (to match anchors to anchored elements).  Refactored the history items to use Moment.js which is already used in the repo.
- snippetBar.less:  Refactored a lot of duplicate or unneeded lines.  Widely implemented CSS Grid and subgrids in the snippet menus to make things line up better, such as when a submenu trigger doesn't have an associated left-hand icon.  Added a tinge of color to the editor tabs when they are hovered or active.
- reset.less, core.less: made some changes to the styling for buttons.  Update reset.less to include `button` so that UA styling is reset.  Update core.less so that not all buttons have the dramatic styling applied to them which later need to be overridden.
- Some other small changes to make everything work.  Should be decent-ish notes about those in the commit history.

Even if this PR is rejected, I think there is a lot of value in taking the changes to metadataEditor.less as their own thing and implementing them in another PR, which is what I should have done before I got carried away.

### What's left?
Fix the firefox issue.

And I still think there is opportunity for better display of the snippet bar, particularly around the editor tabs.  They should have full text labels since they are very important buttons and have the least intuitive icons (in my opinion).  But I think that can be tackled in a greater re-envisioning of the editor pane.

I may also take a crack at revising the snippet menu html structure again to handle better keyboard navigation.


## Related Issues or Discussions

- Closes #

## QA Instructions, Screenshots, Recordings

Right now, I'm mostly interested in what people think of how it actually works in the deployment.  Specifically, look at it in Chrome.  Also look in Firefox to see how crappy it is.  

I will update the reviewer checklist later.

### Reviewer Checklist

_Please replace the list below with specific features you want reviewers to look at._

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Feature A does X
  - [ ] Feature B does Y
- [ ] Verify old features have not broken
  - [ ] Feature Z can still be used
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments

<details><summary>Copy this list</summary></details>
