### PR TITLE
Local snippet editor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/node:20.17.0
+      - image: cimg/node:20.18.0
       - image: mongo:4.4
 
     working_directory: ~/homebrewery

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -21,6 +21,7 @@ const DEFAULT_STYLE_TEXT = dedent`
 					color: black;
 				}`;
 
+const DEFAULT_SNIPPET_TEXT = ``;
 let isJumping = false;
 
 const Editor = createClass({
@@ -35,6 +36,7 @@ const Editor = createClass({
 			onTextChange  : ()=>{},
 			onStyleChange : ()=>{},
 			onMetaChange  : ()=>{},
+			onSnipChange  : ()=>{},
 			reportError   : ()=>{},
 
 			onCursorPageChange : ()=>{},
@@ -51,7 +53,7 @@ const Editor = createClass({
 	getInitialState : function() {
 		return {
 			editorTheme : this.props.editorTheme,
-			view        : 'text' //'text', 'style', 'meta'
+			view        : 'text' //'text', 'style', 'meta', 'snip'
 		};
 	},
 
@@ -61,6 +63,7 @@ const Editor = createClass({
 	isText  : function() {return this.state.view == 'text';},
 	isStyle : function() {return this.state.view == 'style';},
 	isMeta  : function() {return this.state.view == 'meta';},
+	isSnip  : function() {return this.state.view == 'snip';},
 
 	componentDidMount : function() {
 
@@ -457,6 +460,20 @@ const Editor = createClass({
 					onChange={this.props.onMetaChange}
 					reportError={this.props.reportError}
 					userThemes={this.props.userThemes}/>
+			</>;
+		}
+
+		if(this.isSnip()){
+			return <>
+				<CodeEditor key='codeEditor'
+					ref={this.codeEditor}
+					language='gfm'
+					view={this.state.view}
+					value={this.props.brew.snippets ?? DEFAULT_SNIPPET_TEXT}
+					onChange={this.props.onSnipChange}
+					enableFolding={true}
+					editorTheme={this.state.editorTheme}
+					rerenderParent={this.rerenderParent} />
 			</>;
 		}
 	},

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -158,7 +158,7 @@ const Editor = createClass({
 
 	highlightCustomMarkdown : function(){
 		if(!this.codeEditor.current) return;
-		if(this.state.view === 'text')  {
+		if(this.state.view === 'text') {
 			const codeMirror = this.codeEditor.current.codeMirror;
 
 			codeMirror.operation(()=>{ // Batch CodeMirror styling

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -499,7 +499,7 @@ const Editor = createClass({
 					historySize={this.historySize()}
 					currentEditorTheme={this.state.editorTheme}
 					updateEditorTheme={this.updateEditorTheme}
-					snippetBundle={this.props.snippetBundle}
+					themeBundle={this.props.themeBundle}
 					cursorPos={this.codeEditor.current?.getCursorPosition() || {}}
 					updateBrew={this.props.updateBrew}
 				/>

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -6,6 +6,7 @@ const _     = require('lodash');
 const cx    = require('classnames');
 
 import { loadHistory } from '../../utils/versionHistory.js';
+import { brewSnippetsToJSON } from '../../../../shared/helpers.js';
 
 //Import all themes
 const ThemeSnippets = {};
@@ -114,6 +115,9 @@ const Snippetbar = createClass({
 
 			oldSnippets = _.keyBy(compiledSnippets, 'groupName');
 		}
+		const userSnippetsasJSON = brewSnippetsToJSON(this.props.brew.title, this.props.brew.snippets, this.props.snippetsBundle);
+		compiledSnippets.push(userSnippetsasJSON);
+
 		return compiledSnippets;
 	},
 

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -41,6 +41,7 @@ const Snippetbar = createClass({
 			unfoldCode        : ()=>{},
 			updateEditorTheme : ()=>{},
 			cursorPos         : {},
+			themeBundle       : [],
 			updateBrew        : ()=>{}
 		};
 	},
@@ -64,7 +65,7 @@ const Snippetbar = createClass({
 	},
 
 	componentDidUpdate : async function(prevProps, prevState) {
-		if(prevProps.renderer != this.props.renderer || prevProps.theme != this.props.theme || prevProps.snippetBundle != this.props.snippetBundle) {
+		if(prevProps.renderer != this.props.renderer || prevProps.theme != this.props.theme || prevProps.themeBundle != this.props.themeBundle) {
 			this.setState({
 				snippets : this.compileSnippets()
 			});
@@ -101,15 +102,12 @@ const Snippetbar = createClass({
 	},
 
 	compileSnippets : function() {
-		console.log('compileSnippets');
 		let compiledSnippets = [];
 
 		let oldSnippets = _.keyBy(compiledSnippets, 'groupName');
 
-		console.log(this.props.themesBundle);
-
-		if( this.props.themesBundle) {
-			for (let snippets of this.props?.themesBundle?.snippets) {
+		if(this.props.themeBundle.snippets) {
+			for (let snippets of this.props.themeBundle.snippets) {
 				if(typeof(snippets) == 'string')	// load staticThemes as needed; they were sent as just a file name
 					snippets = ThemeSnippets[snippets];
 
@@ -119,8 +117,8 @@ const Snippetbar = createClass({
 				oldSnippets = _.keyBy(compiledSnippets, 'groupName');
 			}
 		}
-		console.log(this.props.themesBundle);
-		const userSnippetsasJSON = brewSnippetsToJSON(this.props.brew.title, this.props.brew.snippets, this.props?.themesBundle?.snippets);
+
+		const userSnippetsasJSON = brewSnippetsToJSON(this.props.brew.title, this.props.brew.snippets, this.props.themeBundle.snippets);
 		compiledSnippets.push(userSnippetsasJSON);
 
 		return compiledSnippets;
@@ -265,6 +263,10 @@ const Snippetbar = createClass({
 				<div className={cx('meta', { selected: this.props.view === 'meta' })}
 					onClick={()=>this.props.onViewChange('meta')}>
 					<i className='fas fa-info-circle' />
+				</div>
+				<div className={cx('snip', { selected: this.props.view === 'snip' })}
+					onClick={()=>this.props.onViewChange('snip')}>
+					<i className='fas fa-th-list' />
 				</div>
 			</div>
 

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -65,7 +65,10 @@ const Snippetbar = createClass({
 	},
 
 	componentDidUpdate : async function(prevProps, prevState) {
-		if(prevProps.renderer != this.props.renderer || prevProps.theme != this.props.theme || prevProps.themeBundle != this.props.themeBundle) {
+		if(prevProps.renderer != this.props.renderer ||
+			prevProps.theme != this.props.theme ||
+			prevProps.themeBundle != this.props.themeBundle ||
+			prevProps.brew.snippets != this.props.brew.snippets) {
 			this.setState({
 				snippets : this.compileSnippets()
 			});

--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -41,7 +41,6 @@ const Snippetbar = createClass({
 			unfoldCode        : ()=>{},
 			updateEditorTheme : ()=>{},
 			cursorPos         : {},
-			snippetBundle     : [],
 			updateBrew        : ()=>{}
 		};
 	},
@@ -102,20 +101,26 @@ const Snippetbar = createClass({
 	},
 
 	compileSnippets : function() {
+		console.log('compileSnippets');
 		let compiledSnippets = [];
 
 		let oldSnippets = _.keyBy(compiledSnippets, 'groupName');
 
-		for (let snippets of this.props.snippetBundle) {
-			if(typeof(snippets) == 'string')	// load staticThemes as needed; they were sent as just a file name
-				snippets = ThemeSnippets[snippets];
+		console.log(this.props.themesBundle);
 
-			const newSnippets = _.keyBy(_.cloneDeep(snippets), 'groupName');
-			compiledSnippets = _.values(_.mergeWith(oldSnippets, newSnippets, this.mergeCustomizer));
+		if( this.props.themesBundle) {
+			for (let snippets of this.props?.themesBundle?.snippets) {
+				if(typeof(snippets) == 'string')	// load staticThemes as needed; they were sent as just a file name
+					snippets = ThemeSnippets[snippets];
 
-			oldSnippets = _.keyBy(compiledSnippets, 'groupName');
+				const newSnippets = _.keyBy(_.cloneDeep(snippets), 'groupName');
+				compiledSnippets = _.values(_.mergeWith(oldSnippets, newSnippets, this.mergeCustomizer));
+
+				oldSnippets = _.keyBy(compiledSnippets, 'groupName');
+			}
 		}
-		const userSnippetsasJSON = brewSnippetsToJSON(this.props.brew.title, this.props.brew.snippets, this.props.snippetsBundle);
+		console.log(this.props.themesBundle);
+		const userSnippetsasJSON = brewSnippetsToJSON(this.props.brew.title, this.props.brew.snippets, this.props?.themesBundle?.snippets);
 		compiledSnippets.push(userSnippetsasJSON);
 
 		return compiledSnippets;

--- a/client/homebrew/editor/snippetbar/snippetbar.less
+++ b/client/homebrew/editor/snippetbar/snippetbar.less
@@ -48,6 +48,9 @@
 				&.meta {
 					.tooltipLeft('Properties');
 				}
+				&.snip {
+					.tooltipLeft('Snippets');
+				}
 				&.undo {
 					.tooltipLeft('Undo');
 					font-size : 0.75em;

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -61,7 +61,6 @@ const EditPage = createClass({
 			currentEditorCursorPageNum : 1,
 			currentBrewRendererPageNum : 1,
 			displayLockMessage         : this.props.brew.lock || false,
-			snippetsBundle             : {},
 			themeBundle                : {}
 		};
 	},
@@ -138,6 +137,19 @@ const EditPage = createClass({
 
 		this.setState((prevState)=>({
 			brew       : { ...prevState.brew, text: text },
+			isPending  : true,
+			htmlErrors : htmlErrors,
+		}), ()=>{if(this.state.autoSave) this.trySave();});
+	},
+
+	handleSnipChange : function(snippet){
+		console.log('Snip Change!');
+		//If there are errors, run the validator on every change to give quick feedback
+		let htmlErrors = this.state.htmlErrors;
+		if(htmlErrors.length) htmlErrors = Markdown.validate(snippet);
+
+		this.setState((prevState)=>({
+			brew       : { ...prevState.brew, snippets: snippet },
 			isPending  : true,
 			htmlErrors : htmlErrors,
 		}), ()=>{if(this.state.autoSave) this.trySave();});
@@ -438,11 +450,12 @@ const EditPage = createClass({
 					onTextChange={this.handleTextChange}
 					onStyleChange={this.handleStyleChange}
 					onMetaChange={this.handleMetaChange}
+					onSnipChange={this.handleSnipChange}
 					reportError={this.errorReported}
 					renderer={this.state.brew.renderer}
 					userThemes={this.props.userThemes}
 					snippets={this.props.snippets}
-					snippetBundle={this.state.themeBundle.snippets}
+					themeBundle={this.state.themeBundle}
 					updateBrew={this.updateBrew}
 					onCursorPageChange={this.handleEditorCursorPageChange}
 					onViewPageChange={this.handleEditorViewPageChange}

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -143,7 +143,6 @@ const EditPage = createClass({
 	},
 
 	handleSnipChange : function(snippet){
-		console.log('Snip Change!');
 		//If there are errors, run the validator on every change to give quick feedback
 		let htmlErrors = this.state.htmlErrors;
 		if(htmlErrors.length) htmlErrors = Markdown.validate(snippet);

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -61,6 +61,7 @@ const EditPage = createClass({
 			currentEditorCursorPageNum : 1,
 			currentBrewRendererPageNum : 1,
 			displayLockMessage         : this.props.brew.lock || false,
+			snippetsBundle             : {},
 			themeBundle                : {}
 		};
 	},
@@ -440,6 +441,7 @@ const EditPage = createClass({
 					reportError={this.errorReported}
 					renderer={this.state.brew.renderer}
 					userThemes={this.props.userThemes}
+					snippets={this.props.snippets}
 					snippetBundle={this.state.themeBundle.snippets}
 					updateBrew={this.updateBrew}
 					onCursorPageChange={this.handleEditorCursorPageChange}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "description": "Create authentic looking D&D homebrews using only markdown",
   "version": "3.16.0",
   "engines": {
-    "npm": "^10.2.x",
-    "node": "^20.17.x"
+    "npm": "^10.8.x",
+    "node": "^20.18.x"
   },
   "repository": {
     "type": "git",

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -296,7 +296,7 @@ const api = {
 				splitTextStyleAndMetadata(currentTheme);
 
 				// If there is anything in the snippets or style members, append them to the appropriate array
-				if(currentTheme?.snippets) completeSnippets.push(JSON.parse(currentTheme.snippets));
+				if(currentTheme?.snippets) completeSnippets.push({ name: currentTheme.title, snippets: currentTheme.snippets });
 				if(currentTheme?.style) completeStyles.push(`/* From Brew: ${req.protocol}://${req.get('host')}/share/${req.params.id} */\n\n${currentTheme.style}`);
 
 				req.params.id       = currentTheme.theme;
@@ -304,9 +304,7 @@ const api = {
 			}
 			//=== Static Themes ===//
 			else {
-				const localSnippets = `${req.params.renderer}_${req.params.id}`; // Just log the name for loading on client
 				const localStyle    = `@import url(\"/themes/${req.params.renderer}/${req.params.id}/style.css\");`;
-				completeSnippets.push(localSnippets);
 				completeStyles.push(`/* From Theme ${req.params.id} */\n\n${localStyle}`);
 
 				req.params.id = Themes[req.params.renderer][req.params.id].baseTheme;

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -170,6 +170,12 @@ const api = {
 				`\`\`\`\n\n` +
 				`${text}`;
 		}
+		if(brew.snippets !== undefined) {
+			text = `\`\`\`snippets\n` +
+				`${brew.snippets || ''}\n` +
+				`\`\`\`\n\n` +
+				`${text}`;
+		}
 		const metadata = _.pick(brew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme']);
 		text = `\`\`\`metadata\n` +
 			`${yaml.dump(metadata)}\n` +

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -304,7 +304,9 @@ const api = {
 			}
 			//=== Static Themes ===//
 			else {
+				const localSnippets = `${req.params.renderer}_${req.params.id}`; // Just log the name for loading on client
 				const localStyle    = `@import url(\"/themes/${req.params.renderer}/${req.params.id}/style.css\");`;
+				completeSnippets.push(localSnippets);
 				completeStyles.push(`/* From Theme ${req.params.id} */\n\n${localStyle}`);
 
 				req.params.id = Themes[req.params.renderer][req.params.id].baseTheme;

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -627,8 +627,6 @@ brew`);
 					`/* From Theme 5ePHB */\n\n@import url("/themes/V3/5ePHB/style.css");`
 				],
 				snippets : [
-					'V3_Blank',
-					'V3_5ePHB'
 				]
 			});
 		});

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -1,6 +1,65 @@
 const _ = require('lodash');
 const yaml = require('js-yaml');
 const request = require('../client/homebrew/utils/request-middleware.js');
+const dedent = require('dedent');
+
+// Convert the templates from a brew to a Snippets Structure.
+const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets)=>{
+	const textSplit  = /^\\page/gm;
+	const mpAsSnippets = [];
+	// Snippets from Themes first.
+	if(themeBundleSnippets) {
+		for (let themes of themeBundleSnippets) {
+			const userSnippets = [];
+			for (let snips of themes.snippets.split(textSplit)) {
+				const name = snips.split('\n')[0];
+				if(name.length != 0) {
+					userSnippets.push({
+						name : name,
+						icon : '',
+						gen  : snips.split('\n').slice(0),
+					});
+				}
+			}
+			if(userSnippets.length > 0) {
+				mpAsSnippets.push({
+					name        : themes.name,
+					icon        : '',
+					gen         : '',
+					subsnippets : userSnippets
+				});
+			}
+		}
+	}
+	// Local Snippets
+	if(userBrewSnippets) {
+		const userSnippets = [];
+		for (let snips of userBrewSnippets.split(textSplit)) {
+			let name = mp.split('\n')[0];
+			if(name.length != 0) {
+				userSnippets.push({
+					name : name,
+					icon : '',
+					gen  : snips.split('\n').slice(0),
+				});
+			}
+		}
+		if(userSnippets.length) {
+			mpAsSnippets.push({
+				name        : menuTitle,
+				icon        : '',
+				subsnippets : userSnippets
+			});
+		}
+	}
+
+	return {
+		groupName : 'Brew Snippets',
+		icon      : 'fas fa-th-list',
+		view      : 'text',
+		snippets  : mpAsSnippets
+	};
+};
 
 const splitTextStyleAndMetadata = (brew)=>{
 	brew.text = brew.text.replaceAll('\r\n', '\n');
@@ -55,4 +114,5 @@ module.exports = {
 	splitTextStyleAndMetadata,
 	printCurrentBrew,
 	fetchThemeBundle,
+	brewSnippetsToJSON
 };

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -8,9 +8,12 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets)=>{
 	const textSplit  = /^\\page/gm;
 	const mpAsSnippets = [];
 	// Snippets from Themes first.
+	//console.log(themeBundleSnippets);
 	if(themeBundleSnippets) {
+		console.log('Looping!');
 		for (let themes of themeBundleSnippets) {
 			const userSnippets = [];
+			console.log(themes);
 			for (let snips of themes.snippets.split(textSplit)) {
 				const name = snips.split('\n')[0];
 				if(name.length != 0) {
@@ -80,9 +83,9 @@ const splitTextStyleAndMetadata = (brew)=>{
 		brew.style = brew.text.slice(7, index - 1);
 		brew.text = brew.text.slice(index + 5);
 	}
-	// if(!brew?.snippets) {
+	if(!brew?.snippets) {
 		brew.snippets = `\\snippet Example\nI am an example user snippet\n`;
-	// }
+	}
 };
 
 const printCurrentBrew = ()=>{

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -8,29 +8,26 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets)=>{
 	const textSplit  = /^\\page/gm;
 	const mpAsSnippets = [];
 	// Snippets from Themes first.
-	//console.log(themeBundleSnippets);
 	if(themeBundleSnippets) {
-		console.log('Looping!');
 		for (let themes of themeBundleSnippets) {
-			const userSnippets = [];
-			console.log(themes);
-			for (let snips of themes.snippets.split(textSplit)) {
-				const name = snips.split('\n')[0];
+			if(typeof themes !== 'string') {
+				const userSnippets = [];
+				const name = themes.snippets.split('\n')[0];
 				if(name.length != 0) {
 					userSnippets.push({
-						name : name,
+						name : name.slice('\snippets '.length),
 						icon : '',
-						gen  : snips.split('\n').slice(0),
+						gen  : themes.snippets.slice(name.length + 1),
 					});
 				}
-			}
-			if(userSnippets.length > 0) {
-				mpAsSnippets.push({
-					name        : themes.name,
-					icon        : '',
-					gen         : '',
-					subsnippets : userSnippets
-				});
+				if(userSnippets.length > 0) {
+					mpAsSnippets.push({
+						name        : themes.name,
+						icon        : '',
+						gen         : '',
+						subsnippets : userSnippets
+					});
+				}
 			}
 		}
 	}

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -5,20 +5,22 @@ const dedent = require('dedent');
 
 // Convert the templates from a brew to a Snippets Structure.
 const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets)=>{
-	const textSplit  = /^\\page/gm;
+	const textSplit  = /^\\snippet /gm;
 	const mpAsSnippets = [];
 	// Snippets from Themes first.
 	if(themeBundleSnippets) {
 		for (let themes of themeBundleSnippets) {
 			if(typeof themes !== 'string') {
 				const userSnippets = [];
-				const name = themes.snippets.split('\n')[0];
-				if(name.length != 0) {
-					userSnippets.push({
-						name : name.slice('\snippets '.length),
-						icon : '',
-						gen  : themes.snippets.slice(name.length + 1),
-					});
+				for (let snips of themes.snippets.trim().split(textSplit)) {
+					const name = snips.trim().split('\n')[0];
+					if(name.length != 0) {
+						userSnippets.push({
+							name : name.slice('\snippets'.length),
+							icon : '',
+							gen  : snips.slice(name.length + 1),
+						});
+					}
 				}
 				if(userSnippets.length > 0) {
 					mpAsSnippets.push({
@@ -34,11 +36,11 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets)=>{
 	// Local Snippets
 	if(userBrewSnippets) {
 		const userSnippets = [];
-		for (let snips of userBrewSnippets.split(textSplit)) {
+		for (let snips of userBrewSnippets.trim().split(textSplit)) {
 			let name = snips.split('\n')[0];
 			if(name.length != 0) {
 				userSnippets.push({
-					name : name.slice('\snippet '.length),
+					name : name,
 					icon : '',
 					gen  : snips.slice(name.length + 1),
 				});
@@ -72,7 +74,7 @@ const splitTextStyleAndMetadata = (brew)=>{
 	}
 	if(brew.text.startsWith('```snippets')) {
 		const index = brew.text.indexOf('```\n\n');
-		brew.snippets = brew.text.slice(11, index - 1);
+		brew.snippets = brew.text.slice(12, index - 1);
 		brew.text = brew.text.slice(index + 5);
 	}
 	if(brew.text.startsWith('```css')) {

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -82,9 +82,6 @@ const splitTextStyleAndMetadata = (brew)=>{
 		brew.style = brew.text.slice(7, index - 1);
 		brew.text = brew.text.slice(index + 5);
 	}
-	if(!brew?.snippets) {
-		brew.snippets = `\\snippet Example\nI am an example user snippet\n`;
-	}
 };
 
 const printCurrentBrew = ()=>{

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -35,12 +35,12 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets)=>{
 	if(userBrewSnippets) {
 		const userSnippets = [];
 		for (let snips of userBrewSnippets.split(textSplit)) {
-			let name = mp.split('\n')[0];
+			let name = snips.split('\n')[0];
 			if(name.length != 0) {
 				userSnippets.push({
-					name : name,
+					name : name.slice('\snippet '.length),
 					icon : '',
-					gen  : snips.split('\n').slice(0),
+					gen  : snips.slice(name.length + 1),
 				});
 			}
 		}
@@ -70,16 +70,19 @@ const splitTextStyleAndMetadata = (brew)=>{
 		Object.assign(brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']));
 		brew.text = brew.text.slice(index + 5);
 	}
-	if(brew.text.startsWith('```css')) {
-		const index = brew.text.indexOf('```\n\n');
-		brew.style = brew.text.slice(7, index - 1);
-		brew.text = brew.text.slice(index + 5);
-	}
 	if(brew.text.startsWith('```snippets')) {
 		const index = brew.text.indexOf('```\n\n');
 		brew.snippets = brew.text.slice(11, index - 1);
 		brew.text = brew.text.slice(index + 5);
 	}
+	if(brew.text.startsWith('```css')) {
+		const index = brew.text.indexOf('```\n\n');
+		brew.style = brew.text.slice(7, index - 1);
+		brew.text = brew.text.slice(index + 5);
+	}
+	// if(!brew?.snippets) {
+		brew.snippets = `\\snippet Example\nI am an example user snippet\n`;
+	// }
 };
 
 const printCurrentBrew = ()=>{


### PR DESCRIPTION
This adds brew-based user snippets.

This follows the document pattern using `snippet Snippet Name` instead of page to indicate the start of a snippet.

A new `Brew Snippets` menu is added at the end of the existing menu list with Snippets organized under their owning document names (themeBundles return their snippets as well)

To Do:
- [ ] Highlighting
- [ ] Determine what/if snippet should populate the snippet editor

To test:
- [ ] Add a Snippet to a theme brew
  - [ ] Ensure the snippet shows up on a brew using the theme.
  - [ ] Ensure the snippet inserts
- [ ] Add a snippet to the brew using the theme above
  - [ ] Ensure that both menu items appear
  - [ ] Ensure the snippet insterts

Example Snippet
```
\snippet Example Snippet
Hello!
I'll be your snippet for the day!
```


