### PR TITLE
Fix Dialog.jsx to prevent crashes

### DIFF
--- a/client/components/dialog.jsx
+++ b/client/components/dialog.jsx
@@ -1,25 +1,25 @@
 // Dialog box, for popups and modal blocking messages
-import React from "react";
+import React from 'react';
 const { useRef, useEffect } = React;
 
 function Dialog({ dismisskeys = [], closeText = 'Close', blocking = false, ...rest }) {
 	const dialogRef = useRef(null);
 
 	useEffect(()=>{
-		if (dismisskeys.length !== 0) {
+		if(dismisskeys.length !== 0) {
 			blocking ? dialogRef.current?.showModal() : dialogRef.current?.show();
 		}
 	}, [dialogRef.current, dismisskeys]);
 
-	const dismiss = () => {
-		dismisskeys.forEach(key => {
-			if (key) {
+	const dismiss = ()=>{
+		dismisskeys.forEach((key)=>{
+			if(key) {
 				localStorage.setItem(key, 'true');
 			}
 		});
 		dialogRef.current?.close();
 	};
-	
+
 	return (
 		<dialog ref={dialogRef} onCancel={dismiss} {...rest}>
 			{rest.children}

--- a/client/components/dialog.jsx
+++ b/client/components/dialog.jsx
@@ -2,7 +2,7 @@
 import React from "react";
 const { useRef, useEffect } = React;
 
-function Dialog({ dismisskeys, closeText = 'Close', blocking = false, ...rest }) {
+function Dialog({ dismisskeys = [], closeText = 'Close', blocking = false, ...rest }) {
 	const dialogRef = useRef(null);
 
 	useEffect(()=>{


### PR DESCRIPTION
dialog.jsx currently crashes the app if `dismisskeys` is not defined, so this PR adds a default (`dismisskeys = []`) in the props.  

The crash happens if you open up master and don't have any 'notification dismissals' saved in your localStorage.

Also I linted the file.