### PR TITLE
Fix Issue 3718 by bounds checking prerender.

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -161,7 +161,8 @@ const BrewRenderer = (props)=>{
 			renderedPages.length = 0;
 
 		// Render currently-edited page first so cross-page effects (variables, links) can propagate out first
-		renderedPages[props.currentEditorCursorPageNum - 1] = renderPage(rawPages[props.currentEditorCursorPageNum - 1], props.currentEditorCursorPageNum - 1);
+		if(rawPages.length > props.currentEditorCursorPageNum -1)
+			renderedPages[props.currentEditorCursorPageNum - 1] = renderPage(rawPages[props.currentEditorCursorPageNum - 1], props.currentEditorCursorPageNum - 1);
 
 		_.forEach(rawPages, (page, index)=>{
 			if((isInView(index) || !renderedPages[index]) && typeof window !== 'undefined'){


### PR DESCRIPTION
## Description

Add bounds-checking to prerender to prevent attempting to create pages past the current end of document.

## Related Issues or Discussions

- Closes #3176

## QA Instructions, Screenshots, Recordings

 - Start with a new document
 - Insert several `\page` entries
 - Ensure the cursor is not on the first Brew page.
 - Past over the full document with a single page text
 - Verify the correct number of pages and none list `undefined` as the sole content.
