### PR TITLE
Load tags from Homebrewery stub, not text metadata

### DIFF
--- a/client/homebrew/navbar/newbrew.navitem.jsx
+++ b/client/homebrew/navbar/newbrew.navitem.jsx
@@ -19,7 +19,7 @@ const NewBrew = ()=>{
 					style : ''
 				};
 				if(fileContent.startsWith('```metadata')) {
-					splitTextStyleAndMetadata(newBrew); // Modify newBrew directly
+					splitTextStyleAndMetadata(newBrew, true); // Modify newBrew directly
 					localStorage.setItem(BREWKEY, newBrew.text);
 					localStorage.setItem(STYLEKEY, newBrew.style);
 					localStorage.setItem(METAKEY, JSON.stringify(_.pick(newBrew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang'])));

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -70,6 +70,7 @@ const NewPage = createClass({
 			brew.renderer = metaStorage?.renderer ?? brew.renderer;
 			brew.theme    = metaStorage?.theme    ?? brew.theme;
 			brew.lang     = metaStorage?.lang     ?? brew.lang;
+			brew.tags     = metaStorage?.tags     ?? brew.tags;
 		}
 
 		SAVEKEY = `HOMEBREWERY-DEFAULT-SAVE-LOCATION-${global.account?.username || ''}`;
@@ -223,38 +224,38 @@ const NewPage = createClass({
 	render : function(){
 		return <div className='newPage sitePage'>
 			{this.renderNavbar()}
-			<div className="content">
-			<SplitPane onDragFinish={this.handleSplitMove}>
-				<Editor
-					ref={this.editor}
-					brew={this.state.brew}
-					onTextChange={this.handleTextChange}
-					onStyleChange={this.handleStyleChange}
-					onMetaChange={this.handleMetaChange}
-					renderer={this.state.brew.renderer}
-					userThemes={this.props.userThemes}
-					snippetBundle={this.state.themeBundle.snippets}
-					onCursorPageChange={this.handleEditorCursorPageChange}
-					onViewPageChange={this.handleEditorViewPageChange}
-					currentEditorViewPageNum={this.state.currentEditorViewPageNum}
-					currentEditorCursorPageNum={this.state.currentEditorCursorPageNum}
-					currentBrewRendererPageNum={this.state.currentBrewRendererPageNum}
-				/>
-				<BrewRenderer
-					text={this.state.brew.text}
-					style={this.state.brew.style}
-					renderer={this.state.brew.renderer}
-					theme={this.state.brew.theme}
-					themeBundle={this.state.themeBundle}
-					errors={this.state.htmlErrors}
-					lang={this.state.brew.lang}
-					onPageChange={this.handleBrewRendererPageChange}
-					currentEditorViewPageNum={this.state.currentEditorViewPageNum}
-					currentEditorCursorPageNum={this.state.currentEditorCursorPageNum}
-					currentBrewRendererPageNum={this.state.currentBrewRendererPageNum}
-					allowPrint={true}
-				/>
-			</SplitPane>
+			<div className='content'>
+				<SplitPane onDragFinish={this.handleSplitMove}>
+					<Editor
+						ref={this.editor}
+						brew={this.state.brew}
+						onTextChange={this.handleTextChange}
+						onStyleChange={this.handleStyleChange}
+						onMetaChange={this.handleMetaChange}
+						renderer={this.state.brew.renderer}
+						userThemes={this.props.userThemes}
+						snippetBundle={this.state.themeBundle.snippets}
+						onCursorPageChange={this.handleEditorCursorPageChange}
+						onViewPageChange={this.handleEditorViewPageChange}
+						currentEditorViewPageNum={this.state.currentEditorViewPageNum}
+						currentEditorCursorPageNum={this.state.currentEditorCursorPageNum}
+						currentBrewRendererPageNum={this.state.currentBrewRendererPageNum}
+					/>
+					<BrewRenderer
+						text={this.state.brew.text}
+						style={this.state.brew.style}
+						renderer={this.state.brew.renderer}
+						theme={this.state.brew.theme}
+						themeBundle={this.state.themeBundle}
+						errors={this.state.htmlErrors}
+						lang={this.state.brew.lang}
+						onPageChange={this.handleBrewRendererPageChange}
+						currentEditorViewPageNum={this.state.currentEditorViewPageNum}
+						currentEditorCursorPageNum={this.state.currentEditorCursorPageNum}
+						currentBrewRendererPageNum={this.state.currentBrewRendererPageNum}
+						allowPrint={true}
+					/>
+				</SplitPane>
 			</div>
 		</div>;
 	}

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -999,7 +999,8 @@ brew`);
 			// Metadata
 			expect(testBrew.title).toEqual('title');
 			expect(testBrew.description).toEqual('description');
-			expect(testBrew.tags).toEqual(['tag a', 'tag b']);
+			expect(testBrew.tags).toBeInstanceOf(Array);
+			expect(testBrew.tags.length).toBe(0);
 			expect(testBrew.systems).toEqual(['test system']);
 			expect(testBrew.renderer).toEqual('legacy');
 			expect(testBrew.theme).toEqual('5ePHB');
@@ -1010,14 +1011,27 @@ brew`);
 			expect(testBrew.text).toEqual('text\n');
 		});
 
-		it('convert tags string to array', async ()=>{
+		it('load tags array from text metadata', async ()=>{
+			const testBrew = {
+				text : '```metadata\n' +
+					'tags: [ tag a ]\n' +
+					'```\n\n'
+			};
+
+			splitTextStyleAndMetadata(testBrew, true);
+
+			// Metadata
+			expect(testBrew.tags).toEqual(['tag a']);
+		});
+
+		it('load tags and convert string to array', async ()=>{
 			const testBrew = {
 				text : '```metadata\n' +
 					'tags: tag a\n' +
 					'```\n\n'
 			};
 
-			splitTextStyleAndMetadata(testBrew);
+			splitTextStyleAndMetadata(testBrew, true);
 
 			// Metadata
 			expect(testBrew.tags).toEqual(['tag a']);

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -2,13 +2,15 @@ import _       from 'lodash';
 import yaml    from 'js-yaml';
 import request from '../client/homebrew/utils/request-middleware.js';
 
-const splitTextStyleAndMetadata = (brew)=>{
+const splitTextStyleAndMetadata = (brew, loadTags=false)=>{
 	brew.text = brew.text.replaceAll('\r\n', '\n');
 	if(brew.text.startsWith('```metadata')) {
 		const index = brew.text.indexOf('```\n\n');
 		const metadataSection = brew.text.slice(12, index - 1);
 		const metadata = yaml.load(metadataSection);
-		Object.assign(brew, _.pick(metadata, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang']));
+		const metadataProps = ['title', 'description', 'systems', 'renderer', 'theme', 'lang'];
+		if(loadTags) metadataProps.push('tags');
+		Object.assign(brew, _.pick(metadata, metadataProps));
 		brew.text = brew.text.slice(index + 5);
 	}
 	if(brew.text.startsWith('```css')) {
@@ -23,7 +25,8 @@ const splitTextStyleAndMetadata = (brew)=>{
 	}
 
 	// Handle old brews that still have empty strings in the tags metadata
-	if(typeof brew.tags === 'string') brew.tags = brew.tags ? [brew.tags] : [];
+	if(typeof brew.tags === 'string' || !brew.tags) brew.tags = brew.tags ? [brew.tags] : [];
+	brew.tags = brew.tags.filter((tag)=>{return tag != '';});
 };
 
 const printCurrentBrew = ()=>{


### PR DESCRIPTION
This PR resolves #2692.

This PR removes `tags` from the metadata loading process of the `splitTextStyleAndMetadata` function, ensuring that only tags stored in Homebrewery's internal database stub are used.
However, the option to load these tags is retained, and used in the NEW FROM FILE function - so when recovering a brew from a downloaded backup, the `tags` should be retained.