### PR TITLE
Get Google Brews with user auth if owner

### DIFF
--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -241,8 +241,8 @@ const GoogleActions = {
 		return obj.data.id;
 	},
 
-	getGoogleBrew : async (auth, id, accessId, accessType)=>{
-		const drive = googleDrive.drive({ version: 'v3', auth: auth || defaultAuth });
+	getGoogleBrew : async (auth = defaultAuth, id, accessId, accessType)=>{
+		const drive = googleDrive.drive({ version: 'v3', auth: auth });
 
 		const obj = await drive.files.get({
 			fileId : id,

--- a/server/googleActions.js
+++ b/server/googleActions.js
@@ -241,8 +241,8 @@ const GoogleActions = {
 		return obj.data.id;
 	},
 
-	getGoogleBrew : async (id, accessId, accessType)=>{
-		const drive = googleDrive.drive({ version: 'v3', auth: defaultAuth });
+	getGoogleBrew : async (auth, id, accessId, accessType)=>{
+		const drive = googleDrive.drive({ version: 'v3', auth: auth || defaultAuth });
 
 		const obj = await drive.files.get({
 			fileId : id,

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -87,76 +87,66 @@ const api = {
 		// Create middleware with the accessType passed in as part of the scope
 		return async (req, res, next)=>{
 			// Get relevant IDs for the brew
-			const { id, googleId } = api.getId(req);
+			let { id, googleId } = api.getId(req);
 
 			const accessMap = {
 				edit  : { editId: id },
 				share : { shareId: id },
-				admin : {
-					$or : [
-						{ editId: id },
-						{ shareId: id },
-					] }
+				admin : { $or : [{ editId: id }, { shareId: id }] }
 			};
 
 			// Try to find the document in the Homebrewery database -- if it doesn't exist, that's fine.
 			let stub = await HomebrewModel.get(accessMap[accessType])
 				.catch((err)=>{
-					if(googleId) {
+					if(googleId)
 						console.warn(`Unable to find document stub for ${accessType}Id ${id}`);
-					} else {
+					else
 						console.warn(err);
-					}
 				});
 			stub = stub?.toObject();
+			googleId ??= stub?.googleId;
+
+			const isAuthor  = stub?.authors?.includes(req.account?.username);
+			const isInvited = stub?.invitedAuthors?.includes(req.account?.username);
+
+			if(accessType === 'edit' && !(isOwner || isAuthor || isInvited)) {
+				const accessError = { name: 'Access Error', status: 401, authors: stub.authors, brewTitle: stub.title, shareId: stub.shareId };
+				if(req.account)
+					throw { ...accessError, message: 'User is not an Author', HBErrorCode: '03' };
+				else
+					throw { ...accessError, message: 'User is not logged in', HBErrorCode: '04' };
+			}
 
 			if(stub?.lock?.locked && accessType != 'edit') {
 				throw { HBErrorCode: '51', code: stub.lock.code, message: stub.lock.shareMessage, brewId: stub.shareId, brewTitle: stub.title };
 			}
 
 			// If there is a google id, try to find the google brew
-			if(!stubOnly && (googleId || stub?.googleId)) {
-				let googleError;
 				const googleBrew = await GoogleActions.getGoogleBrew(googleId || stub?.googleId, id, accessType)
-					.catch((err)=>{
-						googleError = err;
+			if(!stubOnly && googleId) {
+				
+					.catch((googleError)=>{
+						const reason = googleError.errors?.[0].reason;
+						if(reason == 'notFound')
+							throw { ...googleError, HBErrorCode: '02', authors: stub?.authors, account: req.account?.username };
+						else
+							throw { ...googleError, HBErrorCode: '01' };
 					});
-				// Throw any error caught while attempting to retrieve Google brew.
-				if(googleError) {
-					const reason = googleError.errors?.[0].reason;
-					if(reason == 'notFound') {
-						throw { ...googleError, HBErrorCode: '02', authors: stub?.authors, account: req.account?.username };
-					} else {
-						throw { ...googleError, HBErrorCode: '01' };
-					}
-				}
+
 				// Combine the Homebrewery stub with the google brew, or if the stub doesn't exist just use the google brew
 				stub = stub ? _.assign({ ...api.excludeStubProps(stub), stubbed: true }, api.excludeGoogleProps(googleBrew)) : googleBrew;
 			}
-			const authorsExist = stub?.authors?.length > 0;
-			const isAuthor = stub?.authors?.includes(req.account?.username);
-			const isInvited = stub?.invitedAuthors?.includes(req.account?.username);
-			if(accessType === 'edit' && (authorsExist && !(isAuthor || isInvited))) {
-				const accessError = { name: 'Access Error', status: 401 };
-				if(req.account){
-					throw { ...accessError, message: 'User is not an Author', HBErrorCode: '03', authors: stub.authors, brewTitle: stub.title, shareId: stub.shareId };
-				}
-				throw { ...accessError, message: 'User is not logged in', HBErrorCode: '04', authors: stub.authors, brewTitle: stub.title, shareId: stub.shareId };
-			}
 
 			// If after all of that we still don't have a brew, throw an exception
-			if(!stub && !stubOnly) {
+			if(!stub)
 				throw { name: 'BrewLoad Error', message: 'Brew not found', status: 404, HBErrorCode: '05', accessType: accessType, brewId: id };
-			}
 
 			// Clean up brew: fill in missing fields with defaults / fix old invalid values
-			if(stub) {
-				stub.tags     = stub.tags     || undefined; // Clear empty strings
-				stub.renderer = stub.renderer || undefined; // Clear empty strings
-				stub = _.defaults(stub, DEFAULT_BREW_LOAD); // Fill in blank fields
-			}
+			stub.tags     = stub.tags     || undefined; // Clear empty strings
+			stub.renderer = stub.renderer || undefined; // Clear empty strings
+			stub = _.defaults(stub, DEFAULT_BREW_LOAD); // Fill in blank fields
 
-			req.brew = stub ?? {};
+			req.brew = stub;
 			next();
 		};
 	},

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -106,6 +106,7 @@ const api = {
 			stub = stub?.toObject();
 			googleId ??= stub?.googleId;
 
+			const isOwner   = stub?.authors?.length === 0 || stub?.authors?.[0] === req.account?.username;
 			const isAuthor  = stub?.authors?.includes(req.account?.username);
 			const isInvited = stub?.invitedAuthors?.includes(req.account?.username);
 
@@ -122,9 +123,10 @@ const api = {
 			}
 
 			// If there is a google id, try to find the google brew
-				const googleBrew = await GoogleActions.getGoogleBrew(googleId || stub?.googleId, id, accessType)
 			if(!stubOnly && googleId) {
+				const oAuth2Client = isOwner? GoogleActions.authCheck(req.account, res) : undefined;
 				
+				const googleBrew = await GoogleActions.getGoogleBrew(oAuth2Client, googleId, id, accessType)
 					.catch((googleError)=>{
 						const reason = googleError.errors?.[0].reason;
 						if(reason == 'notFound')

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -298,7 +298,7 @@ describe('Tests for api', ()=>{
 			expect(next).toHaveBeenCalled();
 			expect(api.getId).toHaveBeenCalledWith(req);
 			expect(model.get).toHaveBeenCalledWith({ shareId: '1' });
-			expect(google.getGoogleBrew).toHaveBeenCalledWith('2', '1', 'share');
+			expect(google.getGoogleBrew).toHaveBeenCalledWith(undefined, '2', '1', 'share');
 		});
 
 		it('access is denied to a locked brew', async()=>{


### PR DESCRIPTION
## Description
Supercedes #2955

Alters `getBrew()` to use the current user Google Auth instead of the ServiceAccount if current user is the owner. This fixes the issue in #2955 wherein the Homebrewery has lost permissions to the Google Brew (set to "restricted", etc.). This would cause the brew to be listed under the user account (brews are fetched using User Auth), but unable to delete it (brews are deleted using ServiceAccount).

The difference here from #2955 is a logic to only apply User Auth if the current user is the owner (first author, or no stub => no authors). This avoids the conflict where a co-author would be stuck unable to interact with the brew because their own user auth cannot see the document.  This logic is handled internal to `getBrew()`, so the auth does not need to be passed in externally.

This PR also includes a handful of refactorings of `getBrew()` made along the way to find where the appropriate logic should be applied.

## Related Issues or Discussions

- Closes #2954

### Reviewer Checklist

*Reviewers, refer to this list when testing features, or suggest new items *
- [x] Google Brews can be created
- [x] can be updated
- [x] can be opened
- [x] can be shared to non-owners
- [x] can be assigned co-authors
- [x] co-authors can edit
- [x] appears in user page of author and co-author
- [x] when deleted by co-author, they are only removed as author
- [x] when deleted by owner, is transferred to Homebrewery and co-authors retain access
- [x] when deleted by last author, is deleted
- [x] can be deleted when permissions set to restricted