### PR TITLE
Fix admin added as author #3952

### DIFF
--- a/server/admin.api.js
+++ b/server/admin.api.js
@@ -108,6 +108,9 @@ router.put('/admin/clean/script/:id', asyncHandler(HomebrewAPI.getBrew('admin', 
 
 	req.body = brew;
 
+	// Remove Account from request to prevent Admin user from being added to brew as an Author
+	req.account = undefined;
+
 	return await HomebrewAPI.updateBrew(req, res);
 });
 

--- a/server/admin.api.js
+++ b/server/admin.api.js
@@ -1,5 +1,5 @@
-import {model as HomebrewModel }     from './homebrew.model.js';
-import {model as NotificationModel } from './notifications.model.js';
+import { model as HomebrewModel }     from './homebrew.model.js';
+import { model as NotificationModel } from './notifications.model.js';
 import express    from 'express';
 import Moment     from 'moment';
 import zlib       from 'zlib';


### PR DESCRIPTION
This PR resolves #3952.

This PR removes the account property from the brew update initiated by the script cleaning tool. This prevents the Admin user performing the cleaning from being added to the brew as an author.