### PR TITLE
Add google refresh info to error page #3955

### DIFF
--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -70,7 +70,7 @@ const errorIndex = (props)=>{
 			- **The Google Account may be closed.** Google may have removed the account
 			due to inactivity or violating a Google policy. Make sure the owner can
 			still access Google Drive normally and upload/download files to it.
-			:
+			
 			If the file isn't found, Google Drive usually puts your file in your Trash folder for
 			30 days. Assuming the trash hasn't been emptied yet, it might be worth checking.
 			You can also find the Activity tab on the right side of the Google Drive page, which

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -7,7 +7,7 @@ const loginUrl = 'https://www.naturalcrit.com/login';
 
 const errorIndex = (props)=>{
 	const googleRefreshInstructions = dedent`
-	:
+	&nbsp;
 	
 	### Refreshing your Google Credentials
 

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -6,24 +6,6 @@ const loginUrl = 'https://www.naturalcrit.com/login';
 //050-100 : Other pages errors
 
 const errorIndex = (props)=>{
-	const googleRefreshInstructions = dedent`
-	&nbsp;
-	
-	### Refreshing your Google Credentials
-
-	This issue may be caused by an issue with your Google credentials; if so, the following steps may resolve the issue:
-
-	- Go to https://www.naturalcrit.com/login and click logout if present (in small text at the bottom of the page).
-
-	- Click "Sign In with Google", which will refresh your Google credentials.
-	
-	- After completing the sign in process, return to Homebrewery and refresh/reload the page so that it can pick up the updated credentials.
-	
-	- If this was the source of the issue, it should now be resolved.
-
-	If following these steps does not resolve the issue, please let us know!
-	`;
-
 	return {
 		// Default catch all
 		'00' : dedent`
@@ -36,9 +18,18 @@ const errorIndex = (props)=>{
 		'01' : dedent`
 			## An error occurred while retrieving this brew from Google Drive!
 			
-			Google reported an error while attempting to retrieve a brew from this link.`
+			Google is able to see the brew at this link, but reported an error while attempting to retrieve it.
 
-			+ googleRefreshInstructions,
+			### Refreshing your Google Credentials
+
+			This issue is likely caused by an issue with your Google credentials; if you are the owner of this file, the following steps may resolve the issue:
+
+			- Go to https://www.naturalcrit.com/login and click logout if present (in small text at the bottom of the page).
+			- Click "Sign In with Google", which will refresh your Google credentials.
+			- After completing the sign in process, return to Homebrewery and refresh/reload the page so that it can pick up the updated credentials.
+			- If this was the source of the issue, it should now be resolved.
+
+			If following these steps does not resolve the issue, please let us know!`,
 
 		// Google Drive - 404 : brew deleted or access denied
 		'02' : dedent`
@@ -85,9 +76,7 @@ const errorIndex = (props)=>{
 			:
 			Also note, if you prefer not to use your Google Drive for storage, you can always
 			change the storage location of a brew by clicking the Google drive icon by the
-			brew title and choosing *transfer my brew to/from Google Drive*.`
-
-			+ googleRefreshInstructions,
+			brew title and choosing *transfer my brew to/from Google Drive*.`,
 
 		// User is not Authors list
 		'03' : dedent`

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -194,8 +194,8 @@ const errorIndex = (props)=>{
 		
 		**Brew Title:** ${props.brew.brewTitle}`,
 
-		// ####### Admin page error ####### 
-		'52': dedent`
+		// ####### Admin page error #######
+		'52' : dedent`
 		## Access Denied
 		You need to provide correct administrator credentials to access this page.`,
 

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -6,6 +6,24 @@ const loginUrl = 'https://www.naturalcrit.com/login';
 //050-100 : Other pages errors
 
 const errorIndex = (props)=>{
+	const googleRefreshInstructions = dedent`
+	:
+	
+	### Refreshing your Google Credentials
+
+	This issue may be caused by an issue with your Google credentials; if so, the following steps may resolve the issue:
+
+	- Go to https://www.naturalcrit.com/login and click logout if present (in small text at the bottom of the page).
+
+	- Click "Sign In with Google", which will refresh your Google credentials.
+	
+	- After completing the sign in process, return to Homebrewery and refresh/reload the page so that it can pick up the updated credentials.
+	
+	- If this was the source of the issue, it should now be resolved.
+
+	If following these steps does not resolve the issue, please let us know!
+	`;
+
 	return {
 		// Default catch all
 		'00' : dedent`
@@ -18,7 +36,9 @@ const errorIndex = (props)=>{
 		'01' : dedent`
 			## An error occurred while retrieving this brew from Google Drive!
 			
-			Google reported an error while attempting to retrieve a brew from this link.`,
+			Google reported an error while attempting to retrieve a brew from this link.`
+
+			+ googleRefreshInstructions,
 
 		// Google Drive - 404 : brew deleted or access denied
 		'02' : dedent`
@@ -65,7 +85,9 @@ const errorIndex = (props)=>{
 			:
 			Also note, if you prefer not to use your Google Drive for storage, you can always
 			change the storage location of a brew by clicking the Google drive icon by the
-			brew title and choosing *transfer my brew to/from Google Drive*.`,
+			brew title and choosing *transfer my brew to/from Google Drive*.`
+
+			+ googleRefreshInstructions,
 
 		// User is not Authors list
 		'03' : dedent`


### PR DESCRIPTION
This PR resolves #3955.

This PR adds guidance on how a user can refresh their Google credentials directly to the Homebrewery error message.

The instructions are added as a constant so that they are consistent between HB Error Codes 01 and 02, and can then be easily added to any other messages that would also benefit from the instructions.