### PR TITLE
Use project babel config for buildHomebrew script

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -1,3 +1,7 @@
+//╔===--------------- Polyfills --------------===╗//
+import 'core-js/es/string/to-well-formed.js';
+//╚===---------------          ---------------===╝//
+
 require('./homebrew.less');
 const React = require('react');
 const createClass = require('create-react-class');

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "classnames": "^2.5.1",
         "codemirror": "^5.65.6",
         "cookie-parser": "^1.4.7",
+        "core-js": "^3.39.0",
         "cors": "^2.8.5",
         "create-react-class": "^15.7.0",
         "dedent-tabs": "^0.10.3",
@@ -4596,6 +4597,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.39.0.tgz",
+      "integrity": "sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-js-compat": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "classnames": "^2.5.1",
     "codemirror": "^5.65.6",
     "cookie-parser": "^1.4.7",
+    "core-js": "^3.39.0",
     "cors": "^2.8.5",
     "create-react-class": "^15.7.0",
     "dedent-tabs": "^0.10.3",

--- a/scripts/buildHomebrew.js
+++ b/scripts/buildHomebrew.js
@@ -7,11 +7,12 @@ const { pack, watchFile, livereload } = vitreum;
 import lessTransform  from 'vitreum/transforms/less.js';
 import assetTransform from 'vitreum/transforms/asset.js';
 import babel          from '@babel/core';
+import babelConfig    from '../babel.config.json' with { type : 'json' };
 import less           from 'less';
 
 const isDev = !!process.argv.find((arg) => arg === '--dev');
 
-const babelify = async (code)=>(await babel.transformAsync(code, { presets: [['@babel/preset-env', { 'exclude': ['proposal-dynamic-import'] }], '@babel/preset-react'], plugins: ['@babel/plugin-transform-runtime'] })).code;
+const babelify = async (code)=>(await babel.transformAsync(code, babelConfig)).code;
 
 const transforms = {
 	'.js'   : (code, filename, opts)=>babelify(code),


### PR DESCRIPTION
## Description

Manually adds a polyfill for `string.toWellFormed()` for older browsers (Windows 7 is stuck at Chrome 109, ~March 2023).

Babel is capable of automatically detecting and applying polyfills according to our target browser audience but Browserify (included in Vitreum) can't handle it. At least not embedded inside of Vitreum.