### PR TITLE
Implement content-visibility on pages

### DIFF
--- a/themes/Legacy/5ePHB/style.less
+++ b/themes/Legacy/5ePHB/style.less
@@ -42,23 +42,25 @@ body {
 }
 .phb, .page{
 	.useColumns();
-	counter-increment : phb-page-numbers;
-	position          : relative;
-	z-index           : 15;
-	box-sizing        : border-box;
-	overflow          : hidden;
-	height            : 279.4mm;
-	width             : 215.9mm;
-	padding           : 1.0cm 1.7cm;
-	padding-bottom    : 1.5cm;
-	background-color  : @background;
-	background-image  : @backgroundImage;
-	font-family       : BookSanity;
-	font-size         : 0.317cm;
-	text-rendering    : optimizeLegibility;
-	page-break-before : always;
-	page-break-after  : always;
-	contain           : size;
+	counter-increment      : phb-page-numbers;
+	position               : relative;
+	z-index                : 15;
+	box-sizing             : border-box;
+	overflow               : hidden;
+	height                 : 279.4mm;
+	width                  : 215.9mm;
+	padding                : 1.0cm 1.7cm;
+	padding-bottom         : 1.5cm;
+	background-color       : @background;
+	background-image       : @backgroundImage;
+	font-family            : BookSanity;
+	font-size              : 0.317cm;
+	text-rendering         : optimizeLegibility;
+	page-break-before      : always;
+	page-break-after       : always;
+	contain                : strict;
+	content-visibility     : auto;
+	contain-intrinsic-size : auto none;
 }
 
 .phb{

--- a/themes/V3/Blank/style.less
+++ b/themes/V3/Blank/style.less
@@ -45,19 +45,21 @@ body { counter-reset : page-numbers 0; }
 }
 .page {
 	.useColumns();
-	position          : relative;
-	z-index           : 15;
-	box-sizing        : border-box;
-	width             : 215.9mm;
-	height            : 279.4mm;
-	padding           : 1.4cm 1.9cm 1.7cm;
-	overflow          : hidden;
-	background-color  : var(--HB_Color_Background);
-	text-rendering    : optimizeLegibility;
-	contain           : size;
+	position               : relative;
+	z-index                : 15;
+	box-sizing             : border-box;
+	width                  : 215.9mm;
+	height                 : 279.4mm;
+	padding                : 1.4cm 1.9cm 1.7cm;
+	overflow               : hidden;
+	background-color       : var(--HB_Color_Background);
+	text-rendering         : optimizeLegibility;
+	contain                : strict;
+	content-visibility     : auto;
+	contain-intrinsic-size : auto none;
 }
-//*****************************
-// *            BASE
+	//*****************************
+	// *            BASE
 	// *****************************/
 .page {
 	p {


### PR DESCRIPTION
## Description

Adds CSS properties `content-visibility` and `contain-intrinsic-size`, and changes `contain` to "strict` for Legacy and V3 `.page` components.

Dramatically speeds up reflow calculations on large brews, as pages outside of the viewport can be skipped.

## Related Issues or Discussions

Noticed extreme lag when testing #3845. This seems to solve *most* of it.

@5e-Cleric brought up a possible solution to speed up the brewRenderer earlier in the Gitter Chat

> Dec 12, 2024
> 5e-Cleric (Victor)
> https://www.trevorlasn.com/blog/css-content-visibility
> This one could be useful

## QA Instructions, Screenshots, Recordings

Load this test brew (500+ pages) and compare lag with/without the PR upon changing zoom level or page layout. I don't think this will improve scrolling performance. Confirm normal page display, scrolling/jumping, toolbar behavior is otherwise unchanged.

[Test Brew](https://github.com/user-attachments/files/17656392/HB-NecromanticArmorofSaladDressing.1.txt)