### PR TITLE
Wrap titles in error messages with pre blocks to prevent rendering.

### DIFF
--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -89,7 +89,7 @@ const errorIndex = (props)=>{
 		
 		:
 
-		**Brew Title:** ${props.brew.brewTitle || 'Unable to show title'}
+		**Brew Title:** \`${props.brew.brewTitle || 'Unable to show title'}\`
 
 		**Current Authors:** ${props.brew.authors?.map((author)=>{return `[${author}](/user/${author})`;}).join(', ') || 'Unable to list authors'}
 		
@@ -104,7 +104,7 @@ const errorIndex = (props)=>{
 		
 		:
 
-		**Brew Title:** ${props.brew.brewTitle || 'Unable to show title'}
+		**Brew Title:** \`${props.brew.brewTitle || 'Unable to show title'}\`
 
 		**Current Authors:** ${props.brew.authors?.map((author)=>{return `[${author}](/user/${author})`;}).join(', ') || 'Unable to list authors'}
 
@@ -181,7 +181,7 @@ const errorIndex = (props)=>{
 
 		**Brew ID:**  ${props.brew.brewId}
 		
-		**Brew Title:** ${props.brew.brewTitle}`,
+		**Brew Title:** \`${props.brew.brewTitle}\`,
 
 		// ####### Admin page error #######
 		'52' : dedent`


### PR DESCRIPTION
## Description

Attempt to prevent URLS  in titles ( which shouldn't be there! ) from rendering by wrapping it in a <pre> block.

## Related Issues or Discussions

> [!CAUTION]

- Closes #3231

## QA Instructions, Screenshots, Recordings

Trigger error page on a document with an image URL in the Title.

