### PR TITLE
Parse mustache "style" properties into object instead of string

### DIFF
--- a/tests/markdown/mustache-syntax.test.js
+++ b/tests/markdown/mustache-syntax.test.js
@@ -300,7 +300,7 @@ describe('Injection: When an injection tag follows an element', ()=>{
 		it('Renders a span "text" with its own styles, appended with injected styles', function() {
 			const source = '{{color:blue,height:10px text}}{width:10px,color:red}';
 			const rendered = Markdown.render(source);
-			expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="color:blue; height:10px; width:10px; color:red;">text</span>');
+			expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<span class="inline-block" style="color:red; height:10px; width:10px;">text</span>');
 		});
 
 		it('Renders a span "text" with its own classes, appended with injected classes', function() {
@@ -429,7 +429,7 @@ describe('Injection: When an injection tag follows an element', ()=>{
 														}}
 														{width:10px,color:red}`;
 			const rendered = Markdown.render(source).trimReturns();
-			expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<div class="block" style="color:blue; height:10px; width:10px; color:red;"><p>text</p></div>');
+			expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe('<div class="block" style="color:red; height:10px; width:10px;"><p>text</p></div>');
 		});
 
 		it('Renders a span "text" with its own classes, appended with injected classes', function() {


### PR DESCRIPTION
## Description
With our curly syntax, Style attributes (`{{color:red}}`) are parsed into one long string, which makes manipulating, merging, etc. a little tricky, since it involves re-parsing the string each time it needs to be handled. This is also not convenient for injection into a React component, which requires a JS object with key/value pairs for the `style` property.

HTML attributes (attr="some value") are already parsed into an object with key/value pairs.

This PR simply copies over the logic we already use for attributes into styles, so both are neatly in a key/value object format.

## Related Issues or Discussions

One large chunk of #3899 is re-parsing curly styles so they can be put into a React component. With this PR all that work is not necessary.

## QA Instructions, Screenshots, Recordings

Output is the same. Already passes all the markdown tests we have, so this should be safe to merge.
