### PR TITLE
Alternate \page{curlies}

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -176,6 +176,7 @@ const BrewRenderer = (props)=>{
 			...(!displayOptions.pageShadows ? { boxShadow: 'none' } : {})
 			// Add more conditions as needed
 		};
+		let classes    = 'page';
 		let attributes = {};
 
 		if(props.renderer == 'legacy') {
@@ -187,8 +188,9 @@ const BrewRenderer = (props)=>{
 				const firstLineTokens  = Markdown.marked.lexer(pageText.split('\n', 1)[0])[0].tokens;
 				const injectedTags = firstLineTokens.find((obj)=>obj.injectedTags !== undefined)?.injectedTags;
 				if(injectedTags) {
-					styles = { ...styles, ...injectedTags.styles };
-					styles = _.mapKeys(styles, (v, k)=>_.camelCase(k)); // Convert CSS to camelCase for React
+					styles     = { ...styles, ...injectedTags.styles };
+					styles     = _.mapKeys(styles, (v, k)=>_.camelCase(k)); // Convert CSS to camelCase for React
+					classes    = [classes, injectedTags.classes].join(' ').trim();
 					attributes = injectedTags.attributes;
 				}
 				pageText = pageText.includes('\n') ? pageText.substring(pageText.indexOf('\n') + 1) : ''; // Remove the \page line
@@ -197,7 +199,7 @@ const BrewRenderer = (props)=>{
 			pageText += `\n\n&nbsp;\n\\column\n&nbsp;`; //Artificial column break at page end to emulate column-fill:auto (until `wide` is used, when column-fill:balance will reappear)
 			const html = Markdown.render(pageText, index);
 
-			return <BrewPage className='page' index={index} key={index} contents={html} style={styles} attributes={attributes} onVisibilityChange={handlePageVisibilityChange} />;
+			return <BrewPage className={classes} index={index} key={index} contents={html} style={styles} attributes={attributes} onVisibilityChange={handlePageVisibilityChange} />;
 		}
 	};
 

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -17,10 +17,9 @@ const dedent = require('dedent-tabs').default;
 const { printCurrentBrew } = require('../../../shared/helpers.js');
 
 import HeaderNav from './headerNav/headerNav.jsx';
-
 import { safeHTML } from './safeHTML.js';
 
-
+const PAGEBREAK_REGEX_V3 = /^(?=\\page(?: *{[^\n{}]*})?$)/m;
 const PAGE_HEIGHT = 1056;
 
 const INITIAL_CONTENT = dedent`
@@ -126,7 +125,7 @@ const BrewRenderer = (props)=>{
 	if(props.renderer == 'legacy') {
 		rawPages = props.text.split('\\page');
 	} else {
-		rawPages = props.text.split(/^(?=\\page(?:{[^\n{}]*})?$)/gm);
+		rawPages = props.text.split(PAGEBREAK_REGEX_V3);
 	}
 
 	const handlePageVisibilityChange = (pageNum, isVisible, isCenter)=>{

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -189,7 +189,7 @@ const BrewRenderer = (props)=>{
 				const injectedTags = firstLineTokens.find((obj)=>obj.injectedTags !== undefined)?.injectedTags;
 				if(injectedTags) {
 					styles     = { ...styles, ...injectedTags.styles };
-					styles     = _.mapKeys(styles, (v, k)=>_.camelCase(k)); // Convert CSS to camelCase for React
+					styles     = _.mapKeys(styles, (v, k) => k.startsWith('--') ? k : _.camelCase(k)); // Convert CSS to camelCase for React
 					classes    = [classes, injectedTags.classes].join(' ').trim();
 					attributes = injectedTags.attributes;
 				}

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -126,7 +126,7 @@ const BrewRenderer = (props)=>{
 	if(props.renderer == 'legacy') {
 		rawPages = props.text.split('\\page');
 	} else {
-		rawPages = props.text.split(/^(?=\\page(?:{[^\n{}]+})?$)/gm);
+		rawPages = props.text.split(/^(?=\\page(?:{[^\n{}]*})?$)/gm);
 	}
 
 	const handlePageVisibilityChange = (pageNum, isVisible, isCenter)=>{

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -40,7 +40,7 @@ const BrewPage = (props)=>{
 		...props
 	};
 	const pageRef = useRef(null);
-	let cleanText = safeHTML(props.contents);
+	const cleanText = safeHTML(props.contents);
 
 	useEffect(()=>{
 		if(!pageRef.current) return;
@@ -77,7 +77,7 @@ const BrewPage = (props)=>{
 			centerObserver.disconnect();
 		};
 	}, []);
-	
+
 	return <div className={props.className} id={`p${props.index + 1}`} data-index={props.index} ref={pageRef} style={props.style} {...props.attributes}>
 	         <div className='columnWrapper' dangerouslySetInnerHTML={{ __html: cleanText }} />
 	       </div>;
@@ -185,11 +185,11 @@ const BrewRenderer = (props)=>{
 			return <BrewPage className='page phb' index={index} key={index} contents={html} style={styles} onVisibilityChange={handlePageVisibilityChange} />;
 		} else {
 			if(pageText.startsWith('\\page')) {
-				let firstLineTokens  = Markdown.marked.lexer(pageText.split('\n', 1)[0])[0].tokens;
-				let injectedTags = firstLineTokens.find(obj => obj.injectedTags !== undefined)?.injectedTags;
+				const firstLineTokens  = Markdown.marked.lexer(pageText.split('\n', 1)[0])[0].tokens;
+				const injectedTags = firstLineTokens.find((obj)=>obj.injectedTags !== undefined)?.injectedTags;
 				if(injectedTags) {
-					styles = {...styles, ...injectedTags.styles};
-					styles = _.mapKeys(styles, (v, k) => _.camelCase(k)); // Convert CSS to camelCase for React
+					styles = { ...styles, ...injectedTags.styles };
+					styles = _.mapKeys(styles, (v, k)=>_.camelCase(k)); // Convert CSS to camelCase for React
 					attributes = injectedTags.attributes;
 				}
 				pageText = pageText.includes('\n') ? pageText.substring(pageText.indexOf('\n') + 1) : ''; // Remove the \page line

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -192,7 +192,7 @@ const Editor = createClass({
 					if((this.props.renderer == 'legacy' && line.includes('\\page')) ||
 				     (this.props.renderer == 'V3'     && line.match(/^(?=\\page(?:{[^\n{}]+})?$)/))) {
 
-						if(lineNumber > 1)      // Since \page is optional on first line of document,
+						if(lineNumber > 0)      // Since \page is optional on first line of document,
 							editorPageCount += 1; // don't use it to increment page count; stay at 1 
 
 						// add back the original class 'background' but also add the new class '.pageline'

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -12,7 +12,7 @@ const MetadataEditor = require('./metadataEditor/metadataEditor.jsx');
 
 const EDITOR_THEME_KEY = 'HOMEBREWERY-EDITOR-THEME';
 
-const PAGEBREAK_REGEX_V3 = /^(?=\\page(?:{[^\n{}]+})?$)/m;
+const PAGEBREAK_REGEX_V3 = /^(?=\\page(?:{[^\n{}]*})?$)/m;
 const SNIPPETBAR_HEIGHT  = 25;
 const DEFAULT_STYLE_TEXT = dedent`
 				/*=======---  Example CSS styling  ---=======*/
@@ -21,8 +21,6 @@ const DEFAULT_STYLE_TEXT = dedent`
 				.myExampleClass {
 					color: black;
 				}`;
-
-
 
 let isJumping = false;
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -126,15 +126,15 @@ const Editor = createClass({
 	},
 
 	updateCurrentCursorPage : function(cursor) {
-		const lines = this.props.brew.text.split('\n').slice(0, cursor.line + 1);
-		const pageRegex = this.props.brew.renderer == 'V3' ? /^\\page$/ : /\\page/;
+		const lines = this.props.brew.text.split('\n').slice(1, cursor.line + 1);
+		const pageRegex = this.props.brew.renderer == 'V3' ? /^(?=\\page(?:{[^\n{}]+})?$)/ : /\\page/;
 		const currentPage = lines.reduce((count, line)=>count + (pageRegex.test(line) ? 1 : 0), 1);
 		this.props.onCursorPageChange(currentPage);
 	},
 
 	updateCurrentViewPage : function(topScrollLine) {
-		const lines = this.props.brew.text.split('\n').slice(0, topScrollLine + 1);
-		const pageRegex = this.props.brew.renderer == 'V3' ? /^\\page$/ : /\\page/;
+		const lines = this.props.brew.text.split('\n').slice(1, topScrollLine + 1);
+		const pageRegex = this.props.brew.renderer == 'V3' ? /^(?=\\page(?:{[^\n{}]+})?$)/ : /\\page/;
 		const currentPage = lines.reduce((count, line)=>count + (pageRegex.test(line) ? 1 : 0), 1);
 		this.props.onViewPageChange(currentPage);
 	},
@@ -174,7 +174,7 @@ const Editor = createClass({
 
 				for (let i=customHighlights.length - 1;i>=0;i--) customHighlights[i].clear();
 
-				let editorPageCount = 2; // start page count from page 2
+				let editorPageCount = 1; // start page count from page 1
 
 				_.forEach(this.props.brew.text.split('\n'), (line, lineNumber)=>{
 
@@ -190,7 +190,10 @@ const Editor = createClass({
 
 					// Styling for \page breaks
 					if((this.props.renderer == 'legacy' && line.includes('\\page')) ||
-				     (this.props.renderer == 'V3'     && line.match(/^\\page$/))) {
+				     (this.props.renderer == 'V3'     && line.match(/^(?=\\page(?:{[^\n{}]+})?$)/))) {
+
+						if(lineNumber > 1)      // Since \page is optional on first line of document,
+							editorPageCount += 1; // don't use it to increment page count; stay at 1 
 
 						// add back the original class 'background' but also add the new class '.pageline'
 						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');
@@ -199,8 +202,6 @@ const Editor = createClass({
 							textContent : editorPageCount
 						});
 						codeMirror.setBookmark({ line: lineNumber, ch: line.length }, pageCountElement);
-
-						editorPageCount += 1;
 					};
 
 					// New Codemirror styling for V3 renderer
@@ -358,7 +359,7 @@ const Editor = createClass({
 		if(!this.isText() || isJumping)
 			return;
 
-		const textSplit  = this.props.renderer == 'V3' ? /^\\page$/gm : /\\page/;
+		const textSplit  = this.props.renderer == 'V3' ? /^(?=\\page(?:{[^\n{}]+})?$)/gm : /\\page/;
 		const textString = this.props.brew.text.split(textSplit).slice(0, targetPage-1).join(textSplit);
 		const targetLine = textString.match('\n') ? textString.split('\n').length - 1 : -1;
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -12,7 +12,8 @@ const MetadataEditor = require('./metadataEditor/metadataEditor.jsx');
 
 const EDITOR_THEME_KEY = 'HOMEBREWERY-EDITOR-THEME';
 
-const SNIPPETBAR_HEIGHT = 25;
+const PAGEBREAK_REGEX_V3 = /^(?=\\page(?:{[^\n{}]+})?$)/m;
+const SNIPPETBAR_HEIGHT  = 25;
 const DEFAULT_STYLE_TEXT = dedent`
 				/*=======---  Example CSS styling  ---=======*/
 				/* Any CSS here will apply to your document! */
@@ -20,6 +21,8 @@ const DEFAULT_STYLE_TEXT = dedent`
 				.myExampleClass {
 					color: black;
 				}`;
+
+
 
 let isJumping = false;
 
@@ -127,14 +130,14 @@ const Editor = createClass({
 
 	updateCurrentCursorPage : function(cursor) {
 		const lines = this.props.brew.text.split('\n').slice(1, cursor.line + 1);
-		const pageRegex = this.props.brew.renderer == 'V3' ? /^(?=\\page(?:{[^\n{}]+})?$)/ : /\\page/;
+		const pageRegex = this.props.brew.renderer == 'V3' ? PAGEBREAK_REGEX_V3 : /\\page/;
 		const currentPage = lines.reduce((count, line)=>count + (pageRegex.test(line) ? 1 : 0), 1);
 		this.props.onCursorPageChange(currentPage);
 	},
 
 	updateCurrentViewPage : function(topScrollLine) {
 		const lines = this.props.brew.text.split('\n').slice(1, topScrollLine + 1);
-		const pageRegex = this.props.brew.renderer == 'V3' ? /^(?=\\page(?:{[^\n{}]+})?$)/ : /\\page/;
+		const pageRegex = this.props.brew.renderer == 'V3' ? PAGEBREAK_REGEX_V3 : /\\page/;
 		const currentPage = lines.reduce((count, line)=>count + (pageRegex.test(line) ? 1 : 0), 1);
 		this.props.onViewPageChange(currentPage);
 	},
@@ -190,7 +193,7 @@ const Editor = createClass({
 
 					// Styling for \page breaks
 					if((this.props.renderer == 'legacy' && line.includes('\\page')) ||
-				     (this.props.renderer == 'V3'     && line.match(/^(?=\\page(?:{[^\n{}]+})?$)/))) {
+				     (this.props.renderer == 'V3'     && line.match(PAGEBREAK_REGEX_V3))) {
 
 						if(lineNumber > 0)      // Since \page is optional on first line of document,
 							editorPageCount += 1; // don't use it to increment page count; stay at 1
@@ -359,7 +362,7 @@ const Editor = createClass({
 		if(!this.isText() || isJumping)
 			return;
 
-		const textSplit  = this.props.renderer == 'V3' ? /^(?=\\page(?:{[^\n{}]+})?$)/gm : /\\page/;
+		const textSplit  = this.props.renderer == 'V3' ? PAGEBREAK_REGEX_V3 : /\\page/;
 		const textString = this.props.brew.text.split(textSplit).slice(0, targetPage-1).join(textSplit);
 		const targetLine = textString.match('\n') ? textString.split('\n').length - 1 : -1;
 

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -193,7 +193,7 @@ const Editor = createClass({
 				     (this.props.renderer == 'V3'     && line.match(/^(?=\\page(?:{[^\n{}]+})?$)/))) {
 
 						if(lineNumber > 0)      // Since \page is optional on first line of document,
-							editorPageCount += 1; // don't use it to increment page count; stay at 1 
+							editorPageCount += 1; // don't use it to increment page count; stay at 1
 
 						// add back the original class 'background' but also add the new class '.pageline'
 						codeMirror.addLineClass(lineNumber, 'background', 'pageLine');

--- a/client/homebrew/editor/editor.jsx
+++ b/client/homebrew/editor/editor.jsx
@@ -12,7 +12,7 @@ const MetadataEditor = require('./metadataEditor/metadataEditor.jsx');
 
 const EDITOR_THEME_KEY = 'HOMEBREWERY-EDITOR-THEME';
 
-const PAGEBREAK_REGEX_V3 = /^(?=\\page(?:{[^\n{}]*})?$)/m;
+const PAGEBREAK_REGEX_V3 = /^(?=\\page(?: *{[^\n{}]*})?$)/m;
 const SNIPPETBAR_HEIGHT  = 25;
 const DEFAULT_STYLE_TEXT = dedent`
 				/*=======---  Example CSS styling  ---=======*/

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -527,21 +527,6 @@ const definitionListsMultiLine = {
 	}
 };
 
-const pageBreak = {
-	name  : 'pageBreak',
-	level : 'block',
-	start(src) { return src.match(/\n\\page/m)?.index; },  // Hint to Marked.js to stop and check for a match
-	tokenizer(src) {
-		const regex = /^\\page(?:$|(?={[^\n{}]+}$))/m;
-		const match = regex.exec(src);
-		if(match?.length)
-			return { type : 'pageBreak', raw : match[0] };
-	},
-	renderer(token) {
-		return `<pagebreak></pagebreak>\n`;
-	}
-};
-
 //v=====--------------------< Variable Handling >-------------------=====v// 242 lines
 const replaceVar = function(input, hoist=false, allowUnresolved=false) {
 	const regex = /([!$]?)\[((?!\s*\])(?:\\.|[^\[\]\\])+)\]/g;
@@ -810,7 +795,7 @@ const tableTerminators = [
 ];
 
 Marked.use(MarkedVariables());
-Marked.use({ extensions : [pageBreak, justifiedParagraphs, definitionListsMultiLine, definitionListsSingleLine, forcedParagraphBreaks,
+Marked.use({ extensions : [justifiedParagraphs, definitionListsMultiLine, definitionListsSingleLine, forcedParagraphBreaks,
 	nonbreakingSpaces, superSubScripts, mustacheSpans, mustacheDivs, mustacheInjectInline] });
 Marked.use(mustacheInjectBlock);
 Marked.use({ renderer: renderer, tokenizer: tokenizer, mangle: false });
@@ -1017,9 +1002,7 @@ const Markdown = {
 		});
 
 		return errors;
-	},
-
-	extractHTMLStyleTags : extractHTMLStyleTags
+	}
 };
 
 export default Markdown;

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -527,6 +527,21 @@ const definitionListsMultiLine = {
 	}
 };
 
+const pageBreak = {
+	name  : 'pageBreak',
+	level : 'block',
+	start(src) { return src.match(/\n\\page/m)?.index; },  // Hint to Marked.js to stop and check for a match
+	tokenizer(src) {
+		const regex = /^\\page(?:$|(?={[^\n{}]+}$))/m;
+		const match = regex.exec(src);
+		if(match?.length)
+			return { type : 'pageBreak', raw : match[0] };
+	},
+	renderer(token) {
+		return `<pagebreak></pagebreak>\n`;
+	}
+};
+
 //v=====--------------------< Variable Handling >-------------------=====v// 242 lines
 const replaceVar = function(input, hoist=false, allowUnresolved=false) {
 	const regex = /([!$]?)\[((?!\s*\])(?:\\.|[^\[\]\\])+)\]/g;
@@ -795,7 +810,7 @@ const tableTerminators = [
 ];
 
 Marked.use(MarkedVariables());
-Marked.use({ extensions : [justifiedParagraphs, definitionListsMultiLine, definitionListsSingleLine, forcedParagraphBreaks,
+Marked.use({ extensions : [pageBreak, justifiedParagraphs, definitionListsMultiLine, definitionListsSingleLine, forcedParagraphBreaks,
 	nonbreakingSpaces, superSubScripts, mustacheSpans, mustacheDivs, mustacheInjectInline] });
 Marked.use(mustacheInjectBlock);
 Marked.use({ renderer: renderer, tokenizer: tokenizer, mangle: false });
@@ -992,6 +1007,8 @@ const Markdown = {
 
 		return errors;
 	},
+
+	extractHTMLStyleTags : extractHTMLStyleTags
 };
 
 export default Markdown;

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -1002,7 +1002,7 @@ const Markdown = {
 		});
 
 		return errors;
-	}
+	},
 };
 
 export default Markdown;


### PR DESCRIPTION
## Description

Takes #3899 and moves the handling of curlies back into Markdown.js. Small adjustments to regex, etc.

Opening as a new PR as I was getting too many merge conflicts to easily track. Note that these changes *only* apply to V3. Legacy should be unaffected.

##### Usage:
Similar to an inline single mustache.

`\page{wide,banna=fail,color:black}`

## Related Issues or Discussions

Solves https://github.com/naturalcrit/homebrewery/issues/3901

*Reviewers, refer to this list when testing features, or suggest new items*
- [ ] Verify new features are functional
  - [ ] Adding a style includes a style on the `<div class='page'>` instance.
  - [ ] Adding a class includes a class on the `<div class='page'>` instance.
  - [ ] Adding an HTML Attribute adds the attribute on the `<div class='page'>` instance.
  - [ ] Adding an ID does ***not*** add it to the `<div class='page'>` instance.
  - [ ] Mixed forms of above work as expected
  - [ ] CSS styles with hyphens (e.g. `line-height`) work (Page is a React component, which requires camelCase input)
  - [ ] Curlies mix properly with other pages styles (e.g. the page "shadow" option from the toolbar)
  - [ ] `\page` on the first line of a document will *not* create a page break, and is counted as page 1
- [ ] Verify old features have not broken
  - [ ] `\page` works without values.
  - [ ] Highlighting of `\page` still works
  - [ ] Page number display is accurate
  - [ ] Jumping to source/brew still works in every case (including Legacy)
- [ ] Test for edge cases / try to break things
  - [ ] Ensure CSS Properties ( --FOO ) can be set.
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments

<details><summary>Copy the list here</summary>
<p>

```

- [ ] Verify new features are functional
  - [ ] Adding a style includes a style on the `<div class='page'>` instance.
  - [ ] Adding a class includes a class on the `<div class='page'>` instance.
  - [ ] Adding an HTML Attribute adds the attribute on the `<div class='page'>` instance.
  - [ ] Adding an ID does ***not*** add it to the `<div class='page'>` instance.
  - [ ] Mixed forms of above work as expected
  - [ ] CSS styles with hyphens (e.g. `line-height`) work (Page is a React component, which requires camelCase input)
  - [ ] Curlies mix properly with other pages styles (e.g. the page "shadow" option from the toolbar)
  - [ ] `\page` on the first line of a document will *not* create a page break, and is counted as page 1
- [ ] Verify old features have not broken
  - [ ] `\page` works without values.
  - [ ] Highlighting of `\page` still works
  - [ ] Page number display is accurate
  - [ ] Jumping to source/brew still works in every case (including Legacy)
- [ ] Test for edge cases / try to break things
  - [ ] Ensure CSS Properties ( --FOO ) can be set.
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments

```

</p>
</details> 
