### PR TITLE
Correct typo in date of v3.17.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -88,7 +88,7 @@ pre {
 ## changelog
 For a full record of development, visit our [Github Page](https://github.com/naturalcrit/homebrewery).
 
-### Thursday 01/30/2024 - v3.17.0
+### Thursday 01/30/2025 - v3.17.0
 
 {{taskList
 ##### 5e-Cleric


### PR DESCRIPTION
This PR resolves #4028 by correcting the date of the v3.17.0 release in the change log.

Only one character of one line of the change log is affected by this PR.