### PR TITLE
Experimental brew load function

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -17,6 +17,10 @@ const ErrorPage = require('./pages/errorPage/errorPage.jsx');
 const VaultPage = require('./pages/vaultPage/vaultPage.jsx');
 const AccountPage = require('./pages/accountPage/accountPage.jsx');
 
+const request = require('superagent');
+const { splitTextStyleAndMetadata } = require('../../shared/helpers.js');
+
+
 const WithRoute = (props)=>{
 	const params = useParams();
 	const [searchParams] = useSearchParams();
@@ -63,7 +67,22 @@ const Homebrew = createClass({
 		global.enable_themes = this.props.enable_themes;
 		global.config = this.props.config;
 
-		return {};
+		return {
+			brew : this.props.brew
+		};
+	},
+
+	componentDidMount : async function() {
+		if(this.props.url.startsWith('/share2/')){
+			request.get(`/get/${this.props.data.id}`)
+				.then((data)=>{
+					const brew = data.body;
+					splitTextStyleAndMetadata(brew);
+					this.setState({
+						brew: brew
+					})
+				});
+		}
 	},
 
 	render : function (){
@@ -73,6 +92,7 @@ const Homebrew = createClass({
 					<Routes>
 						<Route path='/edit/:id' element={<WithRoute el={EditPage} brew={this.props.brew} userThemes={this.props.userThemes}/>} />
 						<Route path='/share/:id' element={<WithRoute el={SharePage} brew={this.props.brew} />} />
+						<Route path='/share2/:id' element={<WithRoute el={SharePage} brew={this.state.brew} />} />
 						<Route path='/new/:id' element={<WithRoute el={NewPage} brew={this.props.brew} userThemes={this.props.userThemes}/>} />
 						<Route path='/new' element={<WithRoute el={NewPage} userThemes={this.props.userThemes}/> } />
 						<Route path='/user/:username' element={<WithRoute el={UserPage} brews={this.props.brews} />} />

--- a/client/homebrew/pages/sharePage/sharePage.jsx
+++ b/client/homebrew/pages/sharePage/sharePage.jsx
@@ -49,7 +49,7 @@ const SharePage = (props)=>{
 		return ()=>{
 			document.removeEventListener('keydown', handleControlKeys);
 		};
-	}, []);
+	}, [brew]);
 
 	const processShareId = ()=>{
 		return brew.googleId && !brew.stubbed ? brew.googleId + brew.shareId : brew.shareId;

--- a/server/app.js
+++ b/server/app.js
@@ -432,6 +432,19 @@ app.get('/new', asyncHandler(async(req, res, next)=>{
 	return next();
 }));
 
+// Get brew data
+app.get('/get/:id', asyncHandler(getBrew('share')), (req, res)=>{
+	res.status(200).json(req.brew);
+});
+
+app.get('/share2/:id', (req, res, next)=>{
+	req.data = {
+		id   : req.params.id,
+		type : 'share'
+	};
+	return next();
+});
+
 //Share Page
 app.get('/share/:id', asyncHandler(getBrew('share')), asyncHandler(async (req, res, next)=>{
 	const { brew } = req;
@@ -567,7 +580,8 @@ const renderPage = async (req, res)=>{
 		enable_themes : config.get('enable_themes'),
 		config        : configuration,
 		ogMeta        : req.ogMeta,
-		userThemes    : req.userThemes
+		userThemes    : req.userThemes,
+		data          : req.data || undefined
 	};
 	const title = req.brew ? req.brew.title : '';
 	const page = await templateFn('homebrew', title, props)


### PR DESCRIPTION
This experimental PR demonstrates a process for loading brew data from `homebrew.jsx` rather than from `app.js`. This prevents user data (like `</script>`) from appearing in the emitted HTML source (and potentially crashing the web app).

As an example, the following is a brew that contains the title `TITLE`, text content of `TEXT`, and style content of `STYLE` - none of which appear in the `start_app` function call:

```
<script>start_app({"version":"3.17.0","url":"/share2/YcHkHfN17mRI","account":{"username":"sor_robertson","issued":"2025-03-01T05:27:16.385Z"},"enable_v3":true,"enable_themes":true,"config":{"local":true,"publicUrl":"https://homebrewery.naturalcrit.com","baseUrl":"http://localhost:8000","environment":"local","deployment":""},"data":{"id":"YcHkHfN17mRI","type":"share"}})</script>
```