### PR TITLE
Style .frontCover and .insideCover to position : absolute

### DIFF
--- a/themes/V3/5ePHB/style.less
+++ b/themes/V3/5ePHB/style.less
@@ -545,8 +545,9 @@
 	columns    : 1;
 	text-align : center;
 	&::after { display : none; }
+	.frontCover { position : absolute; }
 	h1 {
-		margin-top     : 1.2cm;
+		margin-top     : 1.55cm;
 		margin-bottom  : 0;
 		font-family    : 'NodestoCapsCondensed';
 		font-size      : 2.245cm;
@@ -632,8 +633,9 @@
 	columns    : 1;
 	text-align : center;
 	&::after { display	: none; }
+	.insideCover { position : absolute; }
 	h1 {
-		margin-top     : 1.2cm;
+		margin-top     : 1.55cm;
 		margin-bottom  : 0;
 		font-family    : 'NodestoCapsCondensed';
 		font-size      : 2.1cm;


### PR DESCRIPTION
## Description

Some of our styling uses `:has(xyz)` to mark pages with special behavior. These `xyz` classes have no content and otherwise should not influence the flow of the page. This PR simply changes `{{frontCover}}` and `{{insideCover}}` styling to be `position : absolute`, taking them out of document flow, and updating margins of the following headers to account for the removed line.

`.partCover` and `.backCover` already have `position : absolute` and so do not need to be changed.

This fixes the issue recently reported on Discord where `:::` was not working for vertical space directly after `{{frontCover}}`.

### Reviewer Checklist

- [ ] Confirm no change in appearance for all "cover" pages
- [ ] Confirm `:::` does add vertical spacing directly after all `{{xyzCover}}` elements
- [ ] Generally check for no other behavior changes
