### PR TITLE
Fix `:::` BR option 1

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -381,7 +381,12 @@ const forcedParagraphBreaks = {
 	tokenizer(src, tokens) {
 		const regex  = /^(:+)(?:\n|$)/ym;
 		const match = regex.exec(src);
+
 		if(match?.length) {
+			const lastToken = tokens[tokens.length - 1];
+			if(lastToken?.type == 'text')
+				lastToken.type = 'paragraph';
+
 			return {
 				type   : 'hardBreaks', // Should match "name" above
 				raw    : match[0],     // Text to consume from the source
@@ -394,6 +399,14 @@ const forcedParagraphBreaks = {
 		return `<br>\n`.repeat(token.length);
 	}
 };
+
+const patchHardBreaks = {
+	walkTokens(token) {
+		if(token.type == 'list' || token.type == 'list_item') {
+			token.loose = true;
+		}
+	}
+}
 
 const nonbreakingSpaces = {
 	name  : 'nonbreakingSpaces',
@@ -774,6 +787,7 @@ Marked.use(MarkedVariables());
 Marked.use({ extensions : [justifiedParagraphs, definitionListsMultiLine, definitionListsSingleLine, forcedParagraphBreaks,
 	nonbreakingSpaces, mustacheSpans, mustacheDivs, mustacheInjectInline] });
 Marked.use(mustacheInjectBlock);
+Marked.use(patchHardBreaks);
 Marked.use(MarkedSubSuperText());
 Marked.use({ renderer: renderer, tokenizer: tokenizer, mangle: false });
 Marked.use(MarkedExtendedTables({interruptPatterns : tableTerminators}), MarkedGFMHeadingId({ globalSlugs: true }),

--- a/themes/V3/5ePHB/style.less
+++ b/themes/V3/5ePHB/style.less
@@ -57,12 +57,13 @@
 	ul {
 		padding-left  : 1.4em;
 		margin-bottom : 0.8em;
-		line-height   : 1.25em;
 	}
 	ol {
 		padding-left  : 1.4em;
 		margin-bottom : 0.8em;
-		line-height   : 1.25em;
+	}
+	.page li p {
+		line-height : 1.25em;
 	}
 	//Indents after p or lists
 	p + p, ul + p, ol + p { text-indent : 1em; }
@@ -136,6 +137,9 @@
 		font-size   : 0.423cm;
 		line-height : 0.951em; //Font is misaligned. Shift up slightly
 		& + * { margin-top : 0.2cm; }
+	}
+	br + h3, br + h4 {
+		margin-top : 0;
 	}
 	// *****************************
 	// *          TABLE


### PR DESCRIPTION
## Description

Tweak to the way lists are handled, to address the rendering differences when switching the `::::` to `<br>`. The source of the issue was that in normal text, `:` is always placed between `<p>` elements. But in lists, there is no block separating the list text and the `:::` spacing. An extra `<br>` is required to create a blank line when sitting in normal text, as opposed to a single `<br>` when between two block elements.

```
<p>text</p>
<br> // blank line
<p>text</p>
```

vs 

```
Text
<br><br> // one more br needed
Text
```

___

This PR tries to solve this by simply forcing *all* lists to wrap their text in `<p>` tags.

This does slightly affect spacing for lists that contain both plain text and other block elements without spaces between, though I am not certain this is a common thing. e.g.:

```
- text
  | table immediately after |
  |:-----------------------:|
  | cell                    |
```

The other impact could be for custom styles, as this moves he line spacing of lists from the `ul` element into the `li p` element.

Maybe this is too risky, in which case we just continue waiting for V4 before making this change.

___

### Note
Alternative, perhaps less disruptive approach in #4121 