### PR TITLE
Fix `:::` BR option 2

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -381,11 +381,17 @@ const forcedParagraphBreaks = {
 	tokenizer(src, tokens) {
 		const regex  = /^(:+)(?:\n|$)/ym;
 		const match = regex.exec(src);
+
 		if(match?.length) {
+			let extraBreak = 0;
+			const lastToken = tokens[tokens.length - 1];
+			if(lastToken?.type == 'text')
+				extraBreak = 1;
+
 			return {
 				type   : 'hardBreaks', // Should match "name" above
 				raw    : match[0],     // Text to consume from the source
-				length : match[1].length,
+				length : match[1].length + extraBreak,
 				text   : ''
 			};
 		}

--- a/themes/V3/5ePHB/style.less
+++ b/themes/V3/5ePHB/style.less
@@ -137,6 +137,9 @@
 		line-height : 0.951em; //Font is misaligned. Shift up slightly
 		& + * { margin-top : 0.2cm; }
 	}
+	br + h3, br + h4 {
+		margin-top : 0;
+	}
 	// *****************************
 	// *          TABLE
 	// *****************************/


### PR DESCRIPTION
## Description

Tweak to the way lists are handled, to address the rendering differences when switching the `::::` to `<br>`. The source of the issue was that in normal text, `:` is always placed between `<p>` elements. But in lists, there is no block separating the list text and the `:::` spacing. An extra `<br>` is required to create a blank line when sitting in normal text, as opposed to a single `<br>` when between two block elements.

```
<p>text</p>
<br> // blank line
<p>text</p>
```

vs 

```
Text
<br><br> // one more br needed
Text
```

___
This PR approaches this by just detecting when the preceding text is plain text (not in a `<p>` or other block) and adds an extra `<br>` in that case.

Works and solves 95% of the issue without any CSS change needed. However, `<br>` inside lists will be about a pixel taller than before (`<br>` outside of lists are OK), because we can not separately style the text and the `<br>` to different heights. This is only really an issue if there are multiple `::::` *inside* a list, which I suspect is rare.

Alternative to #4120 