### PR TITLE
Alternate Glossary Snippet based on Brew Snippet variables

### DIFF
--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -545,10 +545,10 @@ function MarkedVariables() {
 		hooks : {
 			preprocess(src) {
 				const codeBlockSkip   = /^(?: {4}[^\n]+(?:\n(?: *(?:\n|$))*)?)+|^ {0,3}(`{3,}(?=[^`\n]*(?:\n|$))|~{3,})(?:[^\n]*)(?:\n|$)(?:|(?:[\s\S]*?)(?:\n|$))(?: {0,3}\2[~`]* *(?=\n|$))|`[^`]*?`/;
-				const blockDefRegex   = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\][:#](?!\() *((?:\n? *[^\s].*)+)(?=\n+|$)/; //Matches 3, [4]:5
-				const blockCallRegex  = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?=\n|$)/;                                 //Matches 6, [7]
-				const inlineDefRegex  = /([!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\])\(([^\n]+)\)/;                            //Matches 8, 9[10](11)
-				const inlineCallRegex =  /[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?!\()/;                                   //Matches 12, [13]
+				const blockDefRegex   = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\]([:\#])(?!\() *((?:\n? *[^\s].*)+)(?=\n+|$)/; //Matches 3,[4] [5]:6
+				const blockCallRegex  = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?=\n|$)/;                                 //Matches 7, [8]
+				const inlineDefRegex  = /([!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\])\(([^\n]+)\)/;                            //Matches 9, 10[11](12)
+				const inlineCallRegex =  /[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?!\()/;                                   //Matches 13, [14]
 
 				// Combine regexes and wrap in parens like so: (regex1)|(regex2)|(regex3)|(regex4)
 				const combinedRegex = new RegExp([codeBlockSkip, blockDefRegex, blockCallRegex, inlineDefRegex, inlineCallRegex].map((s)=>`(${s.source})`).join('|'), 'gm');
@@ -573,17 +573,18 @@ function MarkedVariables() {
 					}
 					if(match[3]) { // Block Definition
 						const label   = match[4] ? normalizeVarNames(match[4]) : null;
-						const content = match[5] ? match[5].trim().replace(/[ \t]+/g, ' ') : null; // Normalize text content (except newlines for block-level content)
+						const content = match[6] ? match[6].trim().replace(/[ \t]+/g, ' ') : null; // Normalize text content (except newlines for block-level content)
 
-						// Drop Snippet brew variables
-						if(content[0] !== '#') varsQueue.push(
+						// Don't push brew snippet variables
+						if(match[5] != '#') varsQueue.push(
 							{ type    : 'varDefBlock',
 								varName : label,
 								content : content
 							});
+
 					}
-					if(match[6]) { // Block Call
-						const label = match[7] ? normalizeVarNames(match[7]) : null;
+					if(match[7]) { // Block Call
+						const label = match[8] ? normalizeVarNames(match[8]) : null;
 
 						varsQueue.push(
 							{ type    : 'varCallBlock',
@@ -591,9 +592,9 @@ function MarkedVariables() {
 								content : match[0]
 							});
 					}
-					if(match[8]) { // Inline Definition
-						const label = match[10] ? normalizeVarNames(match[10]) : null;
-						let content = match[11] || null;
+					if(match[9]) { // Inline Definition
+						const label = match[11] ? normalizeVarNames(match[11]) : null;
+						let content = match[12] || null;
 
 						// In case of nested (), find the correct matching end )
 						let level = 0;
@@ -623,8 +624,8 @@ function MarkedVariables() {
 								content : match[9]
 							});
 					}
-					if(match[12]) { // Inline Call
-						const label = match[13] ? normalizeVarNames(match[13]) : null;
+					if(match[13]) { // Inline Call
+						const label = match[14] ? normalizeVarNames(match[14]) : null;
 
 						varsQueue.push(
 							{ type    : 'varCallInline',

--- a/shared/naturalcrit/markdown.js
+++ b/shared/naturalcrit/markdown.js
@@ -545,10 +545,10 @@ function MarkedVariables() {
 		hooks : {
 			preprocess(src) {
 				const codeBlockSkip   = /^(?: {4}[^\n]+(?:\n(?: *(?:\n|$))*)?)+|^ {0,3}(`{3,}(?=[^`\n]*(?:\n|$))|~{3,})(?:[^\n]*)(?:\n|$)(?:|(?:[\s\S]*?)(?:\n|$))(?: {0,3}\2[~`]* *(?=\n|$))|`[^`]*?`/;
-				const blockDefRegex   = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\]:(?!\() *((?:\n? *[^\s].*)+)(?=\n+|$)/; //Matches 3, [4]:5
-				const blockCallRegex  = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?=\n|$)/;                              //Matches 6, [7]
-				const inlineDefRegex  = /([!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\])\(([^\n]+)\)/;                         //Matches 8, 9[10](11)
-				const inlineCallRegex =  /[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?!\()/;                                //Matches 12, [13]
+				const blockDefRegex   = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\][:#](?!\() *((?:\n? *[^\s].*)+)(?=\n+|$)/; //Matches 3, [4]:5
+				const blockCallRegex  = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?=\n|$)/;                                 //Matches 6, [7]
+				const inlineDefRegex  = /([!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\])\(([^\n]+)\)/;                            //Matches 8, 9[10](11)
+				const inlineCallRegex =  /[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\](?!\()/;                                   //Matches 12, [13]
 
 				// Combine regexes and wrap in parens like so: (regex1)|(regex2)|(regex3)|(regex4)
 				const combinedRegex = new RegExp([codeBlockSkip, blockDefRegex, blockCallRegex, inlineDefRegex, inlineCallRegex].map((s)=>`(${s.source})`).join('|'), 'gm');
@@ -575,7 +575,8 @@ function MarkedVariables() {
 						const label   = match[4] ? normalizeVarNames(match[4]) : null;
 						const content = match[5] ? match[5].trim().replace(/[ \t]+/g, ' ') : null; // Normalize text content (except newlines for block-level content)
 
-						varsQueue.push(
+						// Drop Snippet brew variables
+						if(content[0] !== '#') varsQueue.push(
 							{ type    : 'varDefBlock',
 								varName : label,
 								content : content

--- a/tests/markdown/variables.test.js
+++ b/tests/markdown/variables.test.js
@@ -145,6 +145,15 @@ describe('Block-level variables', ()=>{
 		const rendered = Markdown.render(source).replace(/\s/g, ' ').trimReturns();
 		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<p>My name is $[first] Jones</p>`.trimReturns());
 	});
+
+	it('Doesn\'t store snippet variables in the variable stack', function() {
+		const source = dedent`
+		[Term]#definition
+		
+		$[Term]`;
+		const rendered = Markdown.render(source).replace(/\s/g, ' ').trimReturns();
+		expect(rendered, `Input:\n${source}`, { showPrefix: false }).toBe(`<p>\$[Term]</p>`.trimReturns());
+	});
 });
 
 describe('Inline-level variables', ()=>{

--- a/themes/V3/Blank/snippets.js
+++ b/themes/V3/Blank/snippets.js
@@ -4,6 +4,7 @@ const WatercolorGen = require('./snippets/watercolor.gen.js');
 const ImageMaskGen  = require('./snippets/imageMask.gen.js');
 const FooterGen     = require('./snippets/footer.gen.js');
 const dedent        = require('dedent-tabs').default;
+const glossaryGen   = require('./snippets/glossary.gen.js');
 const TableOfContentsGen = require('./snippets/tableOfContents.gen.js');
 const indexGen           = require('./snippets/index.gen.js');
 
@@ -133,6 +134,12 @@ module.exports = [
 				name : 'Add Comment',
 				icon : 'fas fa-code',
 				gen  : '<!-- This is a comment that will not be rendered into your brew. Hotkey (Ctrl/Cmd + /). -->'
+			},
+			{
+				name         : 'Glossary',
+				icon         : 'fas fa-indent',
+				gen          : glossaryGen,
+				experimental : true
 			},
 			{
 				name : 'Homebrewery Credit',

--- a/themes/V3/Blank/snippets/glossary.gen.js
+++ b/themes/V3/Blank/snippets/glossary.gen.js
@@ -6,8 +6,11 @@ const insertGlossary = (glossaries, entry, definition, runningErrors)=>{
 	const glossarySplitRegex = /(?<!\\):/;
 
 	const glossarySplit = entry.split(glossarySplitRegex);
-	const useGlossary = glossarySplit.length == 2 ? glossarySplit[0] : 'Glossary:';
-	const term = glossarySplit.length == 2 ? glossarySplit[1] : glossarySplit[0];
+
+	if(glossarySplit.length != 2) return;
+
+	const useGlossary = glossarySplit[0].trim().length > 0 ? glossarySplit[0].trim() : 'Glossary:';
+	const term = glossarySplit[1].trim();
 
 	if((!definition) || (!term)) return;
 
@@ -43,7 +46,6 @@ const findGlossaryEntries = (pages, glossaries, runningErrors)=>{
 		if(page.match(theRegex)) {
 			let match;
 			while ((match = theRegex.exec(page)) !== null){
-				console.log(match);
 				insertGlossary(glossaries, match[1], match[2], runningErrors);
 			}
 		}
@@ -90,8 +92,6 @@ module.exports = function (props) {
 
 	const runningErrors = [];
 	findGlossaryEntries(pages, glossaries, runningErrors);
-
-	console.log(glossaries);
 
 	let  resultglossaries = '';
 

--- a/themes/V3/Blank/snippets/glossary.gen.js
+++ b/themes/V3/Blank/snippets/glossary.gen.js
@@ -1,0 +1,119 @@
+const _ = require('lodash');
+const dedent = require('dedent-tabs').default;
+
+const insertGlossary = (glossaries, entry, definition, runningErrors)=>{
+
+	const glossarySplitRegex = /(?<!\\):/;
+
+	const glossarySplit = entry.split(glossarySplitRegex);
+	const useGlossary = glossarySplit.length == 2 ? glossarySplit[0] : 'Glossary:';
+	const term = glossarySplit.length == 2 ? glossarySplit[1] : glossarySplit[0];
+
+	if((!definition) || (!term)) return;
+
+	if(!glossaries.has(useGlossary)) {
+		glossaries.set(useGlossary, new Map());
+	}
+
+	const activeGlossary = glossaries.get(useGlossary);
+	let activeTerm;
+	if(!activeGlossary.has(term)) {
+		// This is a new Term, initialize it.
+		activeGlossary.set(term, new Map());
+		activeTerm = activeGlossary.get(term);
+		activeTerm.set('entries', new Map());
+	} else {
+		activeTerm = activeGlossary.get(term);
+	}
+
+	const subEntries = activeTerm.get('entries');
+	if((!subEntries.size > 0) || (!subEntries.has(definition))) {
+		// This is a new definition, initialize it.
+		const definitionMap = new Map();
+		subEntries.set(definition, definitionMap);
+	}
+	activeGlossary.set(term, activeTerm);
+	glossaries.set(useGlossary, activeGlossary);
+};
+
+const findGlossaryEntries = (pages, glossaries, runningErrors)=>{
+	// const theRegex = /^#((.+)(?<!\\):)?(.+)((?:(?<!\\)\/(.+)))?\n/mg;
+	const theRegex = /^[!$]?\[((?!\s*\])(?:\\.|[^\[\]\\])+)\]\#(?!\() *((?:\n? *[^\s].*)+)(?=\n+|$)/mg;
+	for (const [pageNumber, page] of pages.entries()) {
+		if(page.match(theRegex)) {
+			let match;
+			while ((match = theRegex.exec(page)) !== null){
+				console.log(match);
+				insertGlossary(glossaries, match[1], match[2], runningErrors);
+			}
+		}
+	};
+};
+
+const sortMap = (m)=>{
+	return (new Map([...m.entries()].sort((a, b)=>{
+		const lowA = a[0].toLowerCase();
+		const lowB = b[0].toLowerCase();
+		if(lowA == lowB) return 0;
+		if(lowA > lowB) return 1;
+		return -1;
+	})));
+};
+
+const markup = (glossaries, glossaryName, glossary, runningErrors)=>{
+	const sortedGlossary = sortMap(glossary);
+	let results = '';
+
+	for (const [subjectHeading, subjectHeadingContents] of sortedGlossary) {
+		let termResults = '';
+		let definitionResults = '';
+		const subEntries = subjectHeadingContents.get('entries');
+		if(subEntries.size) {
+			const sortedEntries = sortMap(subEntries);
+			for (const [entry, entryPages] of sortedEntries){
+				definitionResults = definitionResults.concat('::', entry, '\n');
+			}
+		}
+		if(definitionResults.length > 0) {
+			termResults = termResults.concat(subjectHeading, '\n', definitionResults, '\n\n');
+			results = results.concat(termResults);
+		}
+	}
+	return results;
+};
+
+module.exports = function (props) {
+	const glossaries = new Map();
+	glossaries.set('Glossary:', new Map());
+
+	const pages = props.brew.text.split('\\page');
+
+	const runningErrors = [];
+	findGlossaryEntries(pages, glossaries, runningErrors);
+
+	console.log(glossaries);
+
+	let  resultglossaries = '';
+
+	if(glossaries.get('Glossary:').size == 0) glossaries.delete('Glossary:');
+
+	const sortedglossaries = sortMap(glossaries);
+
+	for (const [glossaryName, glossary] of sortedglossaries) {
+		const markdown = markup(glossaries, glossaryName.replace(/[^\w\s\']|_/g, '').replace(/\s+/g, ''), glossary, runningErrors);
+		if(markdown.length > 0) {
+			resultglossaries +=dedent`
+			{{glossary
+			##### ${glossaryName}
+
+			${markdown}
+			}}
+			\page
+
+			`;
+			resultglossaries += '\n';
+		}
+	};
+
+	return resultglossaries;
+};


### PR DESCRIPTION
## Description
__I created this version of the snippet to demonstrate why #4153 would be useful. I think this is cleaner for the codebase and simpler for the user to learn__

This alternate version of dynamic glossaries uses the Brew Snippet Variable syntax in #4153.

A glossary entry is signified by a ':' being present in the variable name.

`[:Term]#Definition`

If multiple Glossaries are preferred, the term may be prefixed with a specific name

`[Glossary Name:Term]#Definition`

Multiple definitions may be presented for a term. 

The snippet does the rest. Individual glossaries are sorted alphabetically with terms as `DL` elements in alphabetical order and separated by a `\page` element.

```{{glossary
##### ${glossaryName}

${list of DLs}
}}
\page
```
Presently, the glossary style is not present in the style sheets.

## Related Issues or Discussions

- Closes #3370

