### PR TITLE
Change page overflow from hidden to clip

### DIFF
--- a/themes/V3/Blank/style.less
+++ b/themes/V3/Blank/style.less
@@ -52,7 +52,7 @@ body { counter-reset : page-numbers 0; }
 	width                  : 215.9mm;
 	height                 : 279.4mm;
 	padding                : 1.4cm 1.9cm 1.7cm;
-	overflow               : hidden;
+	overflow               : clip;
 	background-color       : var(--HB_Color_Background);
 	text-rendering         : optimizeLegibility;
 	contain                : strict;


### PR DESCRIPTION
This PR resolves #4157.

This PR changes the `overflow` property of `page` elements from `hidden` to `clip`. This prevents unintended scrolling within the page when navigating by ID.
