### PR TITLE
bring back icons to admin

### DIFF
--- a/client/admin/admin.less
+++ b/client/admin/admin.less
@@ -3,6 +3,7 @@
 @import 'naturalcrit/styles/animations.less';
 @import 'naturalcrit/styles/colors.less';
 @import 'naturalcrit/styles/tooltip.less';
+@import './themes/fonts/iconFonts/fontAwesome.less';
 
 @import 'font-awesome/css/font-awesome.css';
 


### PR DESCRIPTION
imports the font to admin, although perhaps we should import it through the shared folder and move the font there.