### PR TITLE
Add basic CSS cache busting

### DIFF
--- a/client/template.js
+++ b/client/template.js
@@ -1,3 +1,6 @@
+import packageJSON from '../package.json' with { type: 'json' };
+const version = packageJSON.version;
+
 const template = async function(name, title='', props = {}){
 	const ogTags = [];
 	const ogMeta = props.ogMeta ?? {};
@@ -15,7 +18,7 @@ const template = async function(name, title='', props = {}){
 		<head>
 			<meta name="viewport" content="width=device-width, initial-scale=1, height=device-height, interactive-widget=resizes-visual" />
 			<link href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700" rel="stylesheet" type="text/css" />
-			<link href=${`/${name}/bundle.css`} type="text/css" rel='stylesheet' />
+			<link href=${`/${name}/bundle-${version}.css`} type="text/css" rel='stylesheet' />
 			<link rel="icon" href="/assets/favicon.ico" type="image/x-icon" />
 			${ogMetaTags}
 			<meta name="twitter:card" content="summary">

--- a/scripts/buildHomebrew.js
+++ b/scripts/buildHomebrew.js
@@ -10,6 +10,9 @@ import babel          from '@babel/core';
 import babelConfig    from '../babel.config.json' with { type : 'json' };
 import less           from 'less';
 
+import packageJSON from '../package.json' with { type: 'json' };
+const version = packageJSON.version;
+
 const isDev = !!process.argv.find((arg)=>arg === '--dev');
 
 const babelify = async (code)=>(await babel.transformAsync(code, babelConfig)).code;
@@ -24,7 +27,7 @@ const transforms = {
 const build = async ({ bundle, render, ssr })=>{
 	const css = await lessTransform.generate({ paths: './shared' });
 	//css = `@layer bundle {\n${css}\n}`;
-	await fs.outputFile('./build/homebrew/bundle.css', css);
+	await fs.outputFile(`./build/homebrew/bundle-${version}.css`, css);
 	await fs.outputFile('./build/homebrew/bundle.js', bundle);
 	await fs.outputFile('./build/homebrew/ssr.cjs', ssr);
 
@@ -32,11 +35,11 @@ const build = async ({ bundle, render, ssr })=>{
 
 	//compress files in production
 	if(!isDev){
-		await fs.outputFile('./build/homebrew/bundle.css.br', zlib.brotliCompressSync(css));
+		await fs.outputFile(`./build/homebrew/bundle-${version}.css.br`, zlib.brotliCompressSync(css));
 		await fs.outputFile('./build/homebrew/bundle.js.br', zlib.brotliCompressSync(bundle));
 		await fs.outputFile('./build/homebrew/ssr.js.br', zlib.brotliCompressSync(ssr));
 	} else {
-		await fs.remove('./build/homebrew/bundle.css.br');
+		await fs.remove(`./build/homebrew/bundle-${version}.css.br`);
 		await fs.remove('./build/homebrew/bundle.js.br');
 		await fs.remove('./build/homebrew/ssr.js.br');
 	}


### PR DESCRIPTION
This PR changes the name of the compiled CSS file, created during the build process, and modifies the HTML template to point at this file.

The new filename includes the current Homebrewery version (i.e. `bundle-v3.19.0.css`), so any future versions will automatically import their associated compiled CSS; this should eliminate the issues experienced during the recent v3.19.0 update.