### PR TITLE
Handle Request Abort Error

### DIFF
--- a/client/homebrew/navbar/error-navitem.jsx
+++ b/client/homebrew/navbar/error-navitem.jsx
@@ -23,14 +23,15 @@ const ErrorNavItem = createClass({
 
 		const error       = this.props.error;
 		const response    = error.response;
-		const status      = response.status;
-		const HBErrorCode = response.body?.HBErrorCode;
-		const message     = response.body?.message;
+		const status      = response?.status;
+		const errorCode   = error.code
+		const HBErrorCode = response?.body?.HBErrorCode;
+		const message     = response?.body?.message;
 		let errMsg = '';
 		try {
 			errMsg += `${error.toString()}\n\n`;
 			errMsg += `\`\`\`\n${error.stack}\n`;
-			errMsg += `${JSON.stringify(response.error, null, '  ')}\n\`\`\``;
+			errMsg += `${JSON.stringify(response?.error, null, '  ')}\n\`\`\``;
 			console.log(errMsg);
 		} catch (e){}
 
@@ -73,7 +74,7 @@ const ErrorNavItem = createClass({
 			</Nav.item>;
 		}
 
-		if(response.body?.errors?.[0].reason == 'storageQuotaExceeded') {
+		if(response?.body?.errors?.[0].reason == 'storageQuotaExceeded') {
 			return <Nav.item className='save error' icon='fas fa-exclamation-triangle'>
 			Oops!
 				<div className='errorContainer' onClick={clearError}>
@@ -82,7 +83,7 @@ const ErrorNavItem = createClass({
 			</Nav.item>;
 		}
 
-		if(response.req.url.match(/^\/api.*Google.*$/m)){
+		if(response?.req.url.match(/^\/api.*Google.*$/m)){
 			return <Nav.item className='save error' icon='fas fa-exclamation-triangle'>
 				Oops!
 				<div className='errorContainer' onClick={clearError}>
@@ -125,6 +126,18 @@ const ErrorNavItem = createClass({
 					theme. Verify that
 					brew <a className='lowercase' target='_blank' rel='noopener noreferrer' href={`/share/${response.body.brewId}`}>
 						{response.body.brewId}</a> has the <span className='lowercase'>meta:theme</span> tag!
+				</div>
+			</Nav.item>;
+		}
+
+		if(errorCode === 'ECONNABORTED') {
+			return <Nav.item className='save error' icon='fas fa-exclamation-triangle'>
+				Oops!
+				<div className='errorContainer' onClick={clearError}>
+					The request to the server was interrupted or timed out.
+					This can happen due to a network issue, or if
+					trying to save a particularly large brew.
+					Please check your internet connection and try again.
 				</div>
 			</Nav.item>;
 		}


### PR DESCRIPTION
## Description

This PR edits the error popup on the edit page to handle the REQUEST ABORT errors from the server. Since we didn't generate these errors ourselves, they have a different format, notably missing the `response` object.

`error-navItem.jsx` now should fall back to the existing generic "There was an issue saving" message even if the error does not contain any of the expected fields (done by using `?.` conditional formatting to allow these to be undefined.). 

Additionally, added a new error message specific to the REQUEST ABORT message.

This does not fix the root issue of REQUEST ABORT (likely because we are passing long brews down and back each time they are saved, which may be hitting a timeout limit from the client). But the browser should no longer crash when that error is sent from the server.

See #4259