### PR TITLE
Don't send full text back to client on save

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -412,6 +412,8 @@ const api = {
 		const after = await afterSave();
 		if(!after) return;
 
+		saved.textBin = undefined; // Remove textBin from the saved object to save bandwidth
+
 		res.status(200).send(saved);
 	},
 	deleteGoogleBrew : async (account, id, editId, res)=>{


### PR DESCRIPTION
We return the stub after saving. When saving to HB MongoDB, the stub also includes the full text. This does not need to be sent back to the client. This should help save on bandwidth and shorten save times for large files.