### PR TITLE
Brew ID validations

### DIFF
--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -176,6 +176,26 @@ const errorIndex = (props)=>{
 		
 		If the selected brew is your document, you may designate it as a theme by adding the \`theme:meta\` tag.`,
 
+		// ID validation error
+		'11' : dedent`
+		## No Homebrewery document could be found.
+		
+		The server could not locate the Homebrewery document. The Brew ID failed the validation check.
+		
+		:
+
+		**Brew ID:**  ${props.brew.brewId}`,
+
+		// Google ID validation error
+		'12' : dedent`
+		## No Google document could be found.
+		
+		The server could not locate the Google document. The Google ID failed the validation check.
+		
+		:
+
+		**Brew ID:**  ${props.brew.brewId}`,
+
 		//account page when account is not defined
 		'50' : dedent`
 		## You are not signed in

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -50,10 +50,15 @@ const api = {
 		}
 
 		// ID Validation Checks
+		// Homebrewery ID
+		// Typically 12 characters, but the DB shows a range of 7 to 14 characters
 		if(!id.match(/^[A-Za-z0-9_-]{7,14}$/)){
 			throw { name: 'ID Error', message: 'Invalid ID', status: 404, HBErrorCode: '11', brewId: id };
 		}
-		if(googleId && !googleId.match(/^1(?:[A-Za-z0-9+\/]{32}|[A-Za-z0-9+\/]{43})$/)){
+		// Google ID
+		// Typically 33 characters, old format is 44 - always starts with a 1
+		// Managed by Google, may change outside of our control, so any length between 33 and 44 is acceptable
+		if(googleId && !googleId.match(/^1(?:[A-Za-z0-9+\/]{32,43})$/)){
 			throw { name: 'Google ID Error', message: 'Invalid ID', status: 404, HBErrorCode: '12', brewId: id };
 		}
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -50,7 +50,7 @@ const api = {
 		}
 
 		// ID Validation Checks
-		if(!id.match(/^[A-Za-z0-9_-]{7,12}$/)){
+		if(!id.match(/^[A-Za-z0-9_-]{7,14}$/)){
 			throw { name: 'ID Error', message: 'Invalid ID', status: 404, HBErrorCode: '11', brewId: id };
 		}
 		if(googleId && !googleId.match(/^1(?:[A-Za-z0-9+\/]{32}|[A-Za-z0-9+\/]{43})$/)){

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -50,7 +50,7 @@ const api = {
 		}
 
 		// ID Validation Checks
-		if(!id.match(/^[A-Za-z0-9_-]{12}$/)){
+		if(!id.match(/^[A-Za-z0-9_-]{7,12}$/)){
 			throw { name: 'ID Error', message: 'Invalid ID', status: 404, HBErrorCode: '11', brewId: id };
 		}
 		if(googleId && !googleId.match(/^1(?:[A-Za-z0-9+\/]{32}|[A-Za-z0-9+\/]{43})$/)){

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -48,6 +48,15 @@ const api = {
 			}
 			id = id.slice(googleId.length);
 		}
+
+		// ID Validation Checks
+		if(!id.match(/^[A-Za-z0-9_-]{12}$/)){
+			throw { name: 'ID Error', message: 'Invalid ID', status: 404, HBErrorCode: '11', brewId: id };
+		}
+		if(googleId && !googleId.match(/^1(?:[A-Za-z0-9+\/]{32}|[A-Za-z0-9+\/]{43})$/)){
+			throw { name: 'Google ID Error', message: 'Invalid ID', status: 404, HBErrorCode: '12', brewId: id };
+		}
+
 		return { id, googleId };
 	},
 	//Get array of any of this user's brews tagged with `meta:theme`

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -128,7 +128,7 @@ describe('Tests for api', ()=>{
 			expect(googleId).toEqual('123456789012345678901234567890123');
 		});
 
-		it('should throw invalid google id', ()=>{
+		it('should throw invalid - google id right length but does not match pattern', ()=>{
 			let err;
 			try {
 				api.getId({
@@ -137,6 +137,42 @@ describe('Tests for api', ()=>{
 					},
 					body : {
 						googleId : '012345678901234567890123456789012'
+					}
+				});
+			} catch (e) {
+				err = e;
+			}
+
+			expect(err).toEqual({ HBErrorCode: '12', brewId: 'abcdefghijkl', message: 'Invalid ID', name: 'Google ID Error', status: 404 });
+		});
+
+		it('should throw invalid - google id too short (32 char)', ()=>{
+			let err;
+			try {
+				api.getId({
+					params : {
+						id : 'abcdefghijkl'
+					},
+					body : {
+						googleId : '12345678901234567890123456789012'
+					}
+				});
+			} catch (e) {
+				err = e;
+			}
+
+			expect(err).toEqual({ HBErrorCode: '12', brewId: 'abcdefghijkl', message: 'Invalid ID', name: 'Google ID Error', status: 404 });
+		});
+
+		it('should throw invalid - google id too long (45 char)', ()=>{
+			let err;
+			try {
+				api.getId({
+					params : {
+						id : 'abcdefghijkl'
+					},
+					body : {
+						googleId : '123456789012345678901234567890123456789012345'
 					}
 				});
 			} catch (e) {

--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -99,18 +99,51 @@ describe('Tests for api', ()=>{
 			expect(googleId).toBeUndefined();
 		});
 
+		it('should throw if id is too short', ()=>{
+			let err;
+			try {
+				api.getId({
+					params : {
+						id : 'abcd'
+					}
+				});
+			} catch (e) {
+				err = e;
+			};
+
+			expect(err).toEqual({ HBErrorCode: '11', brewId: 'abcd', message: 'Invalid ID', name: 'ID Error', status: 404 });
+		});
+
 		it('should return id and google id from request body', ()=>{
 			const { id, googleId } = api.getId({
 				params : {
-					id : 'abcdefgh'
+					id : 'abcdefghijkl'
 				},
 				body : {
-					googleId : '12345'
+					googleId : '123456789012345678901234567890123'
 				}
 			});
 
-			expect(id).toEqual('abcdefgh');
-			expect(googleId).toEqual('12345');
+			expect(id).toEqual('abcdefghijkl');
+			expect(googleId).toEqual('123456789012345678901234567890123');
+		});
+
+		it('should throw invalid google id', ()=>{
+			let err;
+			try {
+				api.getId({
+					params : {
+						id : 'abcdefghijkl'
+					},
+					body : {
+						googleId : '012345678901234567890123456789012'
+					}
+				});
+			} catch (e) {
+				err = e;
+			}
+
+			expect(err).toEqual({ HBErrorCode: '12', brewId: 'abcdefghijkl', message: 'Invalid ID', name: 'Google ID Error', status: 404 });
 		});
 
 		it('should return 12-char id and google id from params', ()=>{


### PR DESCRIPTION
Given the appearance of some strange requests in the logs, I thought it best to prevent them from actually doing anything by applying some basic validations to the IDs derived from the request parameters.

Currently, the validation parameters are as follows:

- Brew ID : 7 to 14 characters in the ranges `A-Za-z0-9_-` (derived from the NanoID valid character set)
- Google ID: 33 or 44 characters in the ranges `A-Za-z0-9+/`, starting with a `1` (best analysis of existing Google IDs in the database, combined with online reports of Google ID construction)

Should NanoID or Google decide to change the nature of their IDs at any point in the future, these validations would need to be updated to reflect.