### PR TITLE
Split hash and version checks in updateBrew function

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -339,17 +339,22 @@ const api = {
 		// Initialize brew from request and body, destructure query params, and set the initial value for the after-save method
 		const brewFromClient = api.excludePropsFromUpdate(req.body);
 		const brewFromServer = req.brew;
+
+		if(brewFromServer?.version !== brewFromClient?.version){
+			console.log(`Version mismatch on brew ${brewFromClient.editId}`);
+
+			res.setHeader('Content-Type', 'application/json');
+			return res.status(409).send(JSON.stringify({ message: `The server version is out of sync with the saved brew. Please save your changes elsewhere, refresh, and try again.` }));
+		}
+
 		splitTextStyleAndMetadata(brewFromServer);
-		
+
 		brewFromServer.text  = brewFromServer.text.normalize();
 		brewFromServer.hash  = await md5(brewFromServer.text);
 
-		if((brewFromServer?.version !== brewFromClient?.version) || (brewFromServer?.hash !== brewFromClient?.hash)) {
-			if(brewFromClient?.version !== brewFromClient?.version)
-				console.log(`Version mismatch on brew ${brewFromClient.editId}`);
-			if(brewFromServer?.hash    !== brewFromClient?.hash) {
-				console.log(`Hash mismatch on brew ${brewFromClient.editId}`);
-			}
+		if(brewFromServer?.hash !== brewFromClient?.hash) {
+			console.log(`Hash mismatch on brew ${brewFromClient.editId}`);
+
 			res.setHeader('Content-Type', 'application/json');
 			return res.status(409).send(JSON.stringify({ message: `The server copy is out of sync with the saved brew. Please save your changes elsewhere, refresh, and try again.` }));
 		}


### PR DESCRIPTION
During the recent changes,the updateBrew was accidentally changed to do a version comparison of the client version to the client version. As a result, a mismatch can never occur and the version error cannot occur.

This PR corrects this check to once again compare Server version to Client version.

This PR also updates the API spec to include checks of the `updateBrew` function, bringing coverage testing for the API to ~85%.