### PR TITLE
Run patch processing in parallel to prior system

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -88,6 +88,14 @@ pre {
 ## changelog
 For a full record of development, visit our [Github Page](https://github.com/naturalcrit/homebrewery).
 
+### Wednesday 7/09/2025 - v3.19.3
+
+{{taskList
+##### calculuschild
+* [x] Restoring original saving behavior; will continue investigating why save was failing for some users in background
+}}
+
+
 ### Wednesday 7/09/2025 - v3.19.2
 
 {{taskList

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -265,7 +265,7 @@ const EditPage = createClass({
 		brew.pageCount      = ((brew.renderer=='legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$/gm)) || []).length + 1;
 		brew.patches        = stringifyPatches(makePatches(this.savedBrew.text, brew.text));
 		brew.hash           = await md5(this.savedBrew.text);
-		brew.text           = undefined;
+		//brew.text           = undefined; - Temporary parallel path
 		brew.textBin        = undefined;
 
 		const transfer = this.state.saveGoogle == _.isNil(this.state.brew.googleId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "homebrewery",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "homebrewery",
-      "version": "3.19.2",
+      "version": "3.19.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebrewery",
   "description": "Create authentic looking D&D homebrews using only markdown",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "type": "module",
   "engines": {
     "npm": "^10.8.x",
@@ -72,7 +72,7 @@
         "lines": 50
       },
       "server/homebrew.api.js": {
-        "statements": 69,
+        "statements": 60,
         "branches": 50,
         "functions": 65,
         "lines": 70


### PR DESCRIPTION
This shifts things a bit so the pre-patch saving system runs in parallel with the patching *but* should not 500 on patch fail and should always write out the pre-patch save data.

