### PR TITLE
Add forceSSL middleware tests

### DIFF
--- a/server/forcessl.mw.spec.js
+++ b/server/forcessl.mw.spec.js
@@ -1,0 +1,74 @@
+import forceSSL from './forcessl.mw';
+
+describe('Tests for ForceSSL middleware', ()=>{
+
+	it('should call next() when NODE_ENV is set to local', ()=>{
+		const nodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'local';
+
+		const nextFn = jest.fn();
+
+		forceSSL(null, null, nextFn);
+
+		process.env.NODE_ENV = nodeEnv;
+
+		expect(nextFn).toHaveBeenCalled();
+	});
+
+	it('should call next() when NODE_ENV is set to docker', ()=>{
+		const nodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'docker';
+
+		const nextFn = jest.fn();
+
+		forceSSL(null, null, nextFn);
+
+		process.env.NODE_ENV = nodeEnv;
+
+		expect(nextFn).toHaveBeenCalled();
+	});
+
+	it('should return 302 when header not HTTPS', ()=>{
+		const nodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'test';
+
+		const req = {
+			header : ()=>{ return true; },
+			get    : ()=>{ return 'test'; },
+			url    : 'URL'
+		};
+
+		const res = {
+			redirect : jest.fn((code, url)=>{})
+		};
+
+		const nextFn = jest.fn();
+
+		forceSSL(req, res, nextFn);
+
+		process.env.NODE_ENV = nodeEnv;
+
+		expect(res.redirect).toHaveBeenCalledWith(302, 'https://testURL');
+	});
+
+	it('should call next() header is HTTPS and NODE_ENV not local or docker', ()=>{
+		const nodeEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'test';
+
+		const req = {
+			header : ()=>{ return 'https'; }
+		};
+
+		const res = {
+		};
+
+		const nextFn = jest.fn();
+
+		forceSSL(req, res, nextFn);
+
+		process.env.NODE_ENV = nodeEnv;
+
+		expect(nextFn).toHaveBeenCalled();
+	});
+
+});


### PR DESCRIPTION
This PR adds tests for the Force SSL middleware, bring coverage testing for this file to 100%.

<img width="564" height="332" alt="image" src="https://github.com/user-attachments/assets/26d5ab3d-d852-44bf-a404-bf4ac7ed28eb" />
