### PR TITLE
Fix test option 1 - Shift splitTextStyleAndMetadata to after version check

### DIFF
--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -339,7 +339,6 @@ const api = {
 		// Initialize brew from request and body, destructure query params, and set the initial value for the after-save method
 		const brewFromClient = api.excludePropsFromUpdate(req.body);
 		const brewFromServer = req.brew;
-		splitTextStyleAndMetadata(brewFromServer);
 
 		if(brewFromServer?.version !== brewFromClient?.version){
 			console.log(`Version mismatch on brew ${brewFromClient.editId}`);
@@ -347,6 +346,8 @@ const api = {
 			res.setHeader('Content-Type', 'application/json');
 			return res.status(409).send(JSON.stringify({ message: `The server version is out of sync with the saved brew. Please save your changes elsewhere, refresh, and try again.` }));
 		}
+
+		splitTextStyleAndMetadata(brewFromServer);
 
 		brewFromServer.text  = brewFromServer.text.normalize('NFC');
 		brewFromServer.hash  = await md5(brewFromServer.text);


### PR DESCRIPTION
This PR fixes the current test failures by moving the `splitTextStyleAndMetadata` function to after version check.

The test is currently failing because, as currently written, the test object does not have a `text` property - as the version check occurred before the `splitTextStyleAndMetadata` function call at the time it was written, the `text` property was never accessed and thus was not needed on the test object.
This PR returns the `splitTextStyleAndMetadata` to the same location in the code as when the test was written.

However, if this function call needs to remain before the version check, this PR can be closed in favour of the second PR (#4336).