### PR TITLE
Fix test option 2 - Add text property to version check test object

### DIFF
--- a/server/homebrew.api.spec.js
+++ b/server/homebrew.api.spec.js
@@ -1056,7 +1056,7 @@ brew`);
 	describe('updateBrew', ()=>{
 		it('should return error on version mismatch', async ()=>{
 			const brewFromClient = { version: 1 };
-			const brewFromServer = { version: 1000 };
+			const brewFromServer = { version: 1000, text: '' };
 
 			const req = {
 				brew : brewFromServer,


### PR DESCRIPTION
This PR fixes the current test failures by adding the `text` property to the test object used in the version check.

The test is currently failing because, as currently written, the test object does not have a text property - as the version check occurred before the splitTextStyleAndMetadata function call at the time it was written, the text property was never accessed and thus was not needed on the test object.
This PR adds the text to the object passed for the test, which stops `splitTextStyleAndMetadata` from throwing an error during testing.

However, if this function call can be moved to after the version check, this PR can be closed in favour of the first PR (#4335).