### PR TITLE
Diff patching fix using encodeURI

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -266,7 +266,7 @@ const EditPage = createClass({
 		brew.text           = brew.text.normalize('NFC');
 		this.savedBrew.text = this.savedBrew.text.normalize('NFC');
 		brew.pageCount      = ((brew.renderer=='legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$/gm)) || []).length + 1;
-		brew.patches        = stringifyPatches(makePatches(this.savedBrew.text, brew.text));
+		brew.patches        = stringifyPatches(makePatches(encodeURI(this.savedBrew.text), encodeURI(brew.text)));
 		brew.hash           = await md5(this.savedBrew.text);
 		//brew.text           = undefined; - Temporary parallel path
 		brew.textBin        = undefined;

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -375,7 +375,7 @@ const api = {
 		try {
 			const patches = parsePatch(brewFromClient.patches);
 			// Patch to a throwaway variable while parallelizing - we're more concerned with error/no error.
-			const patchedResult = applyPatches(patches, brewFromServer.text, { allowExceedingIndices: true })[0];
+			const patchedResult = decodeURI(applyPatches(patches, encodeURI(brewFromServer.text))[0]);
 			if(patchedResult != brewFromClient.text)
 				throw("Patches did not apply cleanly, text mismatch detected");
 			// brew.text = applyPatches(patches, brewFromServer.text)[0];


### PR DESCRIPTION
This PR uses `encodeURI`/`decodeURI` to work around the issue with emoji and special characters when applying patches generated by the diff package.

By running the brew through `encodeURI` before the patches are generated, all special characters are replaced - for example, `hello 👋 🌎 world` becomes `hello%20%F0%9F%91%8B%20%F0%9F%8C%8E%20world`. While the diff package appears to have issues determining the correct byte location when dealing with emojis, it has no such issues when dealing with the more standard set of characters that results from `encodeURI`.

When the patches are applied, the base text must thus also be passed through `encodeURI`, before the resulting patched text is run through `decodeURI` for the final comparison to the actual user text.

---

After applying these changes, I have no longer been able to generate the error with the emoji string, even with `allowExceedingIndices` returned to it's default value of `false`.