### PR TITLE
Add indexes to HomebrewSchema

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -29,7 +29,7 @@ const disconnect = async ()=>{
 const connect = async (config)=>{
 	return await Mongoose.connect(getMongoDBURL(config), {
 		retryWrites : false,
-		autoIndex   : (config.get('node_env') == 'local' || config.get('node_env') == 'docker')
+		autoIndex   : (config.get('local_environments').includes(config.get('node_env')))
 	})
 		.catch((error)=>handleConnectionError(error));
 };

--- a/server/db.js
+++ b/server/db.js
@@ -27,7 +27,10 @@ const disconnect = async ()=>{
 };
 
 const connect = async (config)=>{
-	return await Mongoose.connect(getMongoDBURL(config), { retryWrites: false })
+	return await Mongoose.connect(getMongoDBURL(config), {
+		retryWrites : false,
+		autoIndex   : (config.get('node_env') == 'local' || config.get('node_env') == 'docker')
+	})
 		.catch((error)=>handleConnectionError(error));
 };
 

--- a/server/homebrew.model.js
+++ b/server/homebrew.model.js
@@ -7,29 +7,29 @@ import zlib       from 'zlib';
 const HomebrewSchema = mongoose.Schema({
 	shareId   : { type: String, default: ()=>{return nanoid(12);}, index: { unique: true } },
 	editId    : { type: String, default: ()=>{return nanoid(12);}, index: { unique: true } },
-	googleId  : { type: String },
-	title     : { type: String, default: '' },
+	googleId  : { type: String, index: true },
+	title     : { type: String, default: '', index: true },
 	text      : { type: String, default: '' },
 	textBin   : { type: Buffer },
-	pageCount : { type: Number, default: 1 },
+	pageCount : { type: Number, default: 1, index: true },
 
 	description    : { type: String, default: '' },
-	tags           : [String],
+	tags           : { type: [String], index: true },
 	systems        : [String],
-	lang           : { type: String, default: 'en' },
-	renderer       : { type: String, default: '' },
-	authors        : [String],
+	lang           : { type: String, default: 'en', index: true },
+	renderer       : { type: String, default: '', index: true },
+	authors        : { type: [String], index: true },
 	invitedAuthors : [String],
-	published      : { type: Boolean, default: false },
-	thumbnail      : { type: String, default: '' },
+	published      : { type: Boolean, default: false, index: true },
+	thumbnail      : { type: String, default: '', index: true },
 
-	createdAt  : { type: Date, default: Date.now },
-	updatedAt  : { type: Date, default: Date.now },
-	lastViewed : { type: Date, default: Date.now },
+	createdAt  : { type: Date, default: Date.now, index: true },
+	updatedAt  : { type: Date, default: Date.now, index: true },
+	lastViewed : { type: Date, default: Date.now, index: true },
 	views      : { type: Number, default: 0 },
-	version    : { type: Number, default: 1 },
+	version    : { type: Number, default: 1, index: true },
 
-	lock : { type: Object }
+	lock : { type: Object, index: true }
 }, { versionKey: false });
 
 HomebrewSchema.statics.increaseView = async function(query) {
@@ -42,6 +42,8 @@ HomebrewSchema.statics.increaseView = async function(query) {
 	});
 	return brew;
 };
+
+// STATIC FUNCTIONS
 
 HomebrewSchema.statics.get = async function(query, fields=null){
 	const brew = await Homebrew.findOne(query, fields).orFail()
@@ -62,6 +64,15 @@ HomebrewSchema.statics.getByUser = async function(username, allowAccess=false, f
 		.catch((error)=>{throw 'Can not find brews';});
 	return brews;
 };
+
+// INDEXES
+
+HomebrewSchema.index({ updatedAt: -1, lastViewed: -1 });
+HomebrewSchema.index({ published: 1, title: 'text' });
+
+HomebrewSchema.index({ lock: 1, sparse: true });
+HomebrewSchema.path('lock.reviewRequested').index({ sparse: true });
+
 
 const Homebrew = mongoose.model('Homebrew', HomebrewSchema);
 


### PR DESCRIPTION
This PR adds the indexes currently in use in the Production database to the HomebrewSchema file. It also modifies the DB connection string so that these indexes are automatically built when Homebrewery is started with the NODE_ENV is set to an option from the `local_environments` configuration setting - at time of writing, these default to `local` or `docker`.