### PR TITLE
Add database connection check middleware

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -32,6 +32,7 @@ import { splitTextStyleAndMetadata } from '../shared/helpers.js';
 
 //==== Middleware Imports ====//
 import contentNegotiation from './middleware/content-negotiation.js';
+import dbCheck from './middleware/dbCheck.js';
 import bodyParser         from 'body-parser';
 import cookieParser       from 'cookie-parser';
 import forceSSL           from './forcessl.mw.js';
@@ -49,6 +50,7 @@ const sanitizeBrew = (brew, accessType)=>{
 app.set('trust proxy', 1 /* number of proxies between user and server */);
 
 app.use('/', serveCompressedStaticAssets(`build`));
+app.use(dbCheck);
 app.use(contentNegotiation);
 app.use(bodyParser.json({ limit: '25mb' }));
 app.use(cookieParser());

--- a/server/db.js
+++ b/server/db.js
@@ -22,12 +22,21 @@ const handleConnectionError = (error)=>{
 	}
 };
 
+const addListeners = (conn)=>{
+	conn.connection.on('disconnecting', ()=>{console.log('Mongo disconnecting...');});
+	conn.connection.on('disconnected', ()=>{console.log('Mongo disconnected!');});
+	conn.connection.on('connecting', ()=>{console.log('Mongo connecting...');});
+	conn.connection.on('connected', ()=>{console.log('Mongo connected!');});
+	return conn;
+};
+
 const disconnect = async ()=>{
 	return await Mongoose.disconnect();
 };
 
 const connect = async (config)=>{
 	return await Mongoose.connect(getMongoDBURL(config), { retryWrites: false })
+		.then(addListeners(Mongoose))
 		.catch((error)=>handleConnectionError(error));
 };
 
@@ -35,3 +44,4 @@ export default {
 	connect,
 	disconnect
 };
+

--- a/server/middleware/dbCheck.js
+++ b/server/middleware/dbCheck.js
@@ -1,0 +1,13 @@
+import mongoose from 'mongoose';
+import config from '../config.js';
+
+export default (req, res, next)=>{
+	// Bypass DB checks during testing
+	if(config.get('node_env') == 'test') return next();
+
+	if(mongoose.connection.readyState == 1) return next();
+	return res.status(503).send({
+		message : 'Unable to connect to database',
+		state   : mongoose.connection.readyState
+	});
+};

--- a/server/middleware/dbCheck.spec.js
+++ b/server/middleware/dbCheck.spec.js
@@ -1,0 +1,63 @@
+import mongoose from 'mongoose';
+import dbCheck from './dbCheck.js';
+import config from '../config.js';
+
+describe('database check middleware', ()=>{
+	let request;
+	let response;
+	let next;
+
+	beforeEach(()=>{
+		request = {
+			get : function(key) {
+				return this[key];
+			}
+		};
+		response = {
+			status : jest.fn(()=>response),
+			send   : jest.fn(()=>{})
+		};
+		next = jest.fn();
+
+		// Mock the Config module
+		jest.mock('../config.js');
+		config.get = jest.fn((param)=>{
+			// The requested key name will be reflected to the output
+			return param;
+		});
+	});
+
+	afterEach(()=>{
+		jest.clearAllMocks();
+	});
+
+	it('should return 503 if readystate != 1', ()=>{
+		const dbState = mongoose.connection.readyState;
+
+		mongoose.connection.readyState = 99;
+
+		dbCheck(request, response);
+
+		mongoose.connection.readyState = dbState;
+
+		expect(response.status).toHaveBeenLastCalledWith(503);
+		expect(response.send).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				message : 'Unable to connect to database',
+				state   : 99
+			})
+		);
+	});
+
+	it('should call next if readystate == 1', ()=>{
+		const dbState = mongoose.connection.readyState;
+
+		mongoose.connection.readyState = 1;
+
+		dbCheck(request, response, next);
+
+		mongoose.connection.readyState = dbState;
+
+		expect(next).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
This PR adds middleware that checks that Mongoose database connection is in the `connected` state before processing requests. If the connection is not `1`, a basic error message is returned.

From https://mongoosejs.com/docs/api/connection.html#Connection.prototype.readyState, the potential states are as follows:

    0 = disconnected
    1 = connected
    2 = connecting
    3 = disconnecting

This PR also adds console messages for database connectivity events.

---

While MongoDB is running during normal operation, everything continues as normal.
<img width="1785" height="858" alt="image" src="https://github.com/user-attachments/assets/b0877151-be1f-4a4d-875d-651b1b036f3a" />

Current result when DB is unavailable:
<img width="752" height="291" alt="image" src="https://github.com/user-attachments/assets/374eeba3-e54e-49b5-8bc4-dc4679052754" />
<img width="709" height="217" alt="image" src="https://github.com/user-attachments/assets/84e0ef69-1f51-4f66-a08b-e26f9be30d29" />


New results when DB is unavailable:
<img width="1144" height="696" alt="image" src="https://github.com/user-attachments/assets/57b876f4-767c-4da0-a9f8-df12e3a71399" />
<img width="986" height="493" alt="image" src="https://github.com/user-attachments/assets/98dd306c-2323-4961-9276-b202a8af8626" />

---

This PR also adds tests to ensure that a 503 page is returned if the `readyState` is set to `99`, and also that `next()` is called if `readyState` is set to `1`.
