### PR TITLE
Fix Account page FA icon font weights

### DIFF
--- a/client/homebrew/pages/basePages/uiPage/uiPage.less
+++ b/client/homebrew/pages/basePages/uiPage/uiPage.less
@@ -29,6 +29,7 @@
 						&::before {
 							margin-right : 5px;
 							font-family  : 'Font Awesome 6 Free';
+							font-weight  : 900;
 							content      : '\f00c';
 						}
 					}


### PR DESCRIPTION
This PR changes the `font-weight` property to `900`, which should correct the broken icons.