### PR TITLE
Handle mongo count qurey error by returning default value

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -487,8 +487,8 @@ app.get('/account', asyncHandler(async (req, res, next)=>{
 		const query = { authors: req.account.username, googleId: { $exists: false } };
 		const mongoCount = await HomebrewModel.countDocuments(query)
 			.catch((err)=>{
-				mongoCount = 0;
 				console.log(err);
+				return 0;
 			});
 
 		data.accountDetails = {


### PR DESCRIPTION
> [!TIP]
> Before submitting a Pull Request, please consider the following to speed up reviews:
> - 👷‍♀️ Create small PRs. Large PRs can usually be broken down into incremental PRs.
> - 🚩 Do you already have several open PRs? Consider finishing or asking for help with existing PRs first.
> - 🔧 Does your PR reference a discussed and approved issue, especially for personal or edge-case requests?
> - 💡 Is the solution agreed upon? Save rework time by discussing strategy before coding.

## Description

Small PR - This change fixes an issue in the `/account` route where the `mongoCount` variable, declared as `const`, was being reassigned inside a `.catch()` block when the `countDocuments` query failed, causing a runtime error. The fix replaces the reassignment with a `return 0;` statement inside the `.catch()` callback.

## Related Issues or Discussions

## QA Instructions, Screenshots, Recordings

### Reviewer Checklist

_Replace the list below with specific features you want reviewers to look at._

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Feature A does X
  - [ ] Feature B does Y
- [ ] Verify old features have not broken
  - [ ] Feature Z can still be used
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments
