### PR TITLE
Refine import file error feedback

### DIFF
--- a/client/homebrew/navbar/newbrew.navitem.jsx
+++ b/client/homebrew/navbar/newbrew.navitem.jsx
@@ -10,43 +10,44 @@ const METAKEY = 'homebrewery-new-meta';
 const NewBrew = ()=>{
 	const handleFileChange = (e)=>{
 		const file = e.target.files[0];
-		if(file) {
-			const reader = new FileReader();
-			reader.onload = (e)=>{
-				const fileContent = e.target.result;
-				const newBrew = {
-					text  : fileContent,
-					style : ''
-				};
-				if(fileContent.startsWith('```metadata')) {
-					splitTextStyleAndMetadata(newBrew); // Modify newBrew directly
-					localStorage.setItem(BREWKEY, newBrew.text);
-					localStorage.setItem(STYLEKEY, newBrew.style);
-					localStorage.setItem(
-						METAKEY,
-						JSON.stringify(
-							_.pick(newBrew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang'])
-						)
-					);
-					window.location.href = '/new';
-				} else {
-					const type = file.name.split('.').pop().toLowercase();
-					if(type === 'txt') {
-						alert(
-							`This file type is correct, but it is not from the homebrewery or has been tampered with,
-							 please try with a correct file or report this as an issue if you think it is a mistake.`
-						);
-					} else if(!type) {
-						alert('This file is invalid, please, enter a valid file');
-						console.log(file);
-					} else {
-						alert(`This is a .${type} file, only '.txt' files are allowed`);
-					}
-				}
-			};
-			reader.readAsText(file);
-		}
+		if(!file) return;
+
+		const currentNew = localStorage.getItem(BREWKEY);
+		if(currentNew && !confirm(
+			`You have some text in the new brew space, if you load a file that text will be lost, are you sure you want to load the file?`
+		)) return;
+
+		const reader = new FileReader();
+		reader.onload = (e)=>{
+			const fileContent = e.target.result;
+			const newBrew = { text: fileContent, style: '' };
+
+			if(fileContent.startsWith('```metadata')) {
+				splitTextStyleAndMetadata(newBrew);
+				localStorage.setItem(BREWKEY, newBrew.text);
+				localStorage.setItem(STYLEKEY, newBrew.style);
+				localStorage.setItem(METAKEY, JSON.stringify(
+					_.pick(newBrew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang'])
+				));
+				window.location.href = '/new';
+				return;
+			}
+
+			const type = file.name.split('.').pop().toLowerCase();
+			if(type === 'txt') {
+				alert(
+					`This file type is correct, but it is not from the homebrewery or has been tampered with, please try with a correct file or report this as an issue if you think it is a mistake.`
+				);
+			} else if(!type) {
+				alert('This file is invalid, please, enter a valid file');
+				console.log(file);
+			} else {
+				alert(`This is a .${type} file, only .txt files are allowed`);
+			}
+		};
+		reader.readAsText(file);
 	};
+
 
 	return (
 		<Nav.dropdown>

--- a/client/homebrew/navbar/newbrew.navitem.jsx
+++ b/client/homebrew/navbar/newbrew.navitem.jsx
@@ -5,7 +5,7 @@ const { splitTextStyleAndMetadata } = require('../../../shared/helpers.js'); // 
 
 const BREWKEY  = 'homebrewery-new';
 const STYLEKEY = 'homebrewery-new-style';
-const METAKEY  = 'homebrewery-new-meta';
+const METAKEY = 'homebrewery-new-meta';
 
 const NewBrew = ()=>{
 	const handleFileChange = (e)=>{
@@ -22,10 +22,26 @@ const NewBrew = ()=>{
 					splitTextStyleAndMetadata(newBrew); // Modify newBrew directly
 					localStorage.setItem(BREWKEY, newBrew.text);
 					localStorage.setItem(STYLEKEY, newBrew.style);
-					localStorage.setItem(METAKEY, JSON.stringify(_.pick(newBrew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang'])));
+					localStorage.setItem(
+						METAKEY,
+						JSON.stringify(
+							_.pick(newBrew, ['title', 'description', 'tags', 'systems', 'renderer', 'theme', 'lang'])
+						)
+					);
 					window.location.href = '/new';
 				} else {
-					alert('This file is invalid, please, enter a valid file');
+					const type = file.name.split('.').pop().toLowercase();
+					if(type === 'txt') {
+						alert(
+							`This file type is correct, but it is not from the homebrewery or has been tampered with,
+							 please try with a correct file or report this as an issue if you think it is a mistake.`
+						);
+					} else if(!type) {
+						alert('This file is invalid, please, enter a valid file');
+						console.log(file);
+					} else {
+						alert(`This is a .${type} file, only '.txt' files are allowed`);
+					}
 				}
 			};
 			reader.readAsText(file);


### PR DESCRIPTION
Features:

- Asks confirmation to the user if loading a file will delete brew text in /new:
"You have some text in the new brew space, if you load a file that text will be lost, are you sure you want to load the file?"
- Checks file type if its not txt
  - If there is no file type, gives the old non-specific warning:
  "This file is invalid, please, enter a valid file"
  - If the file is not a txt but is known, send a type specific message:
  "This is a .${type} file, only .txt files are allowed"
  - If the file is a txt but does not fit the profile  (having a metadata block at the start) it outputs:
  "This file type is correct, but it is not from the homebrewery or has been tampered with, please try with a correct file or report this as an issue if you think it is a mistake."

Disclaimer: files not updated recently may not have metadata blocks either and will not work in the upload of files.

This does not change the nature of the import, just makes sure users don't make anything extra dumb and gives proper feedback when they do it wrong.