### PR TITLE
Fix default save location functionality

### DIFF
--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -23,7 +23,7 @@ import { printCurrentBrew, fetchThemeBundle, splitTextStyleAndMetadata } from '.
 const BREWKEY  = 'homebrewery-new';
 const STYLEKEY = 'homebrewery-new-style';
 const METAKEY  = 'homebrewery-new-meta';
-const SAVEKEY  = `HOMEBREWERY-DEFAULT-SAVE-LOCATION-${global.account?.username || ''}`;
+const SAVEKEYPREFIX  = 'HOMEBREWERY-DEFAULT-SAVE-LOCATION-';
 
 const NewPage = (props) => {
 	props = {
@@ -67,6 +67,7 @@ const NewPage = (props) => {
 			brew.lang     = metaStorage?.lang     ?? brew.lang;
 		}
 
+		const SAVEKEY = `${SAVEKEYPREFIX}${global.account?.username}`;
 		const saveStorage = localStorage.getItem(SAVEKEY) || 'HOMEBREWERY';
 
 		setCurrentBrew(brew);


### PR DESCRIPTION
This PR resolves #4437.

The root cause of the issue was SAVEKEY being defined while the `global.account.username` is not defined. By shifting the definition of SAVEKEY to just before it is used to retrieve the data from local storage, the username is populated and all of the expected functionality returns.