### PR TITLE
Permanently enable old local storage key deletion

### DIFF
--- a/client/homebrew/utils/updateLocalStorage/updateLocalStorageKeys.js
+++ b/client/homebrew/utils/updateLocalStorage/updateLocalStorageKeys.js
@@ -10,15 +10,13 @@ const updateLocalStorage = function(){
 
 	const storage = window.localStorage;
 
-	const deleteKeys = storage?.getItem('HB_deleteKeys') != null;
-
 	Object.keys(localStorageKeyMap).forEach((key)=>{
 		if(storage[key]){
 			if(!storage[localStorageKeyMap[key]]){
 				const data = storage.getItem(key);
 				storage.setItem(localStorageKeyMap[key], data);
 			};
-			if(deleteKeys) storage.removeItem(key);
+			storage.removeItem(key);
 		}
 	});
 


### PR DESCRIPTION
This PR resolves #4454.

This PR permanently enables the key deletion functionality of the recently merged local storage key update function.