### PR TITLE
Add unsaved-change warning to Home page editor

### DIFF
--- a/client/homebrew/pages/homePage/homePage.jsx
+++ b/client/homebrew/pages/homePage/homePage.jsx
@@ -70,23 +70,14 @@ const HomePage =(props)=>{
 			}
 		};
 
-		const handleBeforeUnload = (e)=>{
-			if(unsavedChangesRef.current) {
-				e.preventDefault();
-				e.returnValue = '';
-				return '';
-			}
-		};
-		
-		const previousBeforeUnload = window.onbeforeunload;
-
-		window.onbeforeunload = handleBeforeUnload;
-
 		document.addEventListener('keydown', handleControlKeys);
-
+		window.onbeforeunload = ()=>{
+			if(unsavedChangesRef.current)
+				return 'You have unsaved changes!';
+		};
 		return ()=>{
 			document.removeEventListener('keydown', handleControlKeys);
-			window.onbeforeunload = previousBeforeUnload;
+			window.onbeforeunload = null;
 		};
 	}, []);
 


### PR DESCRIPTION
## Description

This PR adds a security warning before any action that could cause the user to lose unsaved work on the home page.

## QA Instructions, Screenshots, Recordings

Added warning:
<img width="459" height="177" alt="image" src="https://github.com/user-attachments/assets/d356929e-e64e-4fd4-afe6-155c6a2da515" />

This warning appears before any action that would cause the user to lose their current work.

### Reviewer Checklist

- [ ] The warning appears whenever it should.
- [ ] Identify opportunities for simplification and refactoring.