### PR TITLE
Update New Item on NavBar

### DIFF
--- a/client/homebrew/navbar/newbrew.navitem.jsx
+++ b/client/homebrew/navbar/newbrew.navitem.jsx
@@ -34,25 +34,20 @@ const NewBrew = ()=>{
 
 			alert(`This file is invalid: ${!type ? 'Missing file extension' :`.${type} files are not supported`}. Only .txt files exported from the Homebrewery are allowed.`);
 
-
 			console.log(file);
 		};
 		reader.readAsText(file);
 	};
 
-	const checkLocalStorage = ()=>{
-		// Check if changes exist for New editor
-		const currentText = localStorage.getItem(BREWKEY);
-		const currentStyle = localStorage.getItem(STYLEKEY);
-		const currentMeta = localStorage.getItem(METAKEY);
-		return (currentText || currentStyle || currentMeta);
-	};
-
 	const confirmLocalStorageChange = ()=>{
+		const currentText  = localStorage.getItem(BREWKEY);
+		const currentStyle = localStorage.getItem(STYLEKEY);
+		const currentMeta  = localStorage.getItem(METAKEY);
+
 		// TRUE if no data in any local storage key
 		// TRUE if data in any local storage key AND approval given
 		// FALSE if data in any local storage key AND approval declined
-		return (!checkLocalStorage() || confirm(
+		return (!(currentText || currentStyle || currentMeta) || confirm(
 			`You have made changes in the new brew space. If you continue, that information will be PERMANENTLY LOST.\nAre you sure you wish to continue?`
 		));
 	};
@@ -75,7 +70,7 @@ const NewBrew = ()=>{
 				className='new'
 				color='purple'
 				icon='fa-solid fa-plus-square'>
-                new
+					new
 			</Nav.item>
 			<Nav.item
 				className='new'
@@ -83,7 +78,7 @@ const NewBrew = ()=>{
 				newTab={true}
 				color='purple'
 				icon='fa-solid fa-file'>
-                resume editing
+					resume draft
 			</Nav.item>
 			<Nav.item
 				className='fromBlank'
@@ -91,16 +86,15 @@ const NewBrew = ()=>{
 				color='yellow'
 				icon='fa-solid fa-file-circle-plus'
 				onClick={()=>{ clearLocalStorage(); }}>
-                from blank
+					from blank
 			</Nav.item>
-
 			<Nav.item
 				className='fromFile'
 				color='green'
 				icon='fa-solid fa-upload'
 				onClick={()=>{ document.getElementById('uploadTxt').click(); }}>
 				<input id='uploadTxt' className='newFromLocal' type='file' onChange={handleFileChange} style={{ display: 'none' }} />
-                from file
+					from file
 			</Nav.item>
 		</Nav.dropdown>
 	);


### PR DESCRIPTION
This PR:

- fixes an issue with incorrect local storage key names when checking for content before loading from a text file backup
- changes the name of "NEW FROM BLANK" to "RESUME EDITING"
- adds a new button "NEW FROM BLANK" which will clear the local storage content before redirecting to the New Page editor
- consolidates the functions for checking local storage between NEW FROM BLANK and NEW FROM FILE
- provides a checkLocalStorage function which may be used in the future to check if RESUME EDITING is valid (if no local storage content, then there will be nothing to resume).

<img width="167" height="135" alt="image" src="https://github.com/user-attachments/assets/d6656cac-906c-4aaf-af46-14f398ab45e5" />
