### PR TITLE
Normalize brew text before hashing for saving

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -216,7 +216,7 @@ const EditPage = (props)=>{
 			text      : brew.text.normalize('NFC'),
 			pageCount : ((brew.renderer === 'legacy' ? brew.text.match(/\\page/g) : brew.text.match(/^\\page$/gm)) || []).length + 1,
 			patches   : stringifyPatches(makePatches(encodeURI(lastSavedBrew.current.text.normalize('NFC')), encodeURI(brew.text.normalize('NFC')))),
-			hash      : await md5(lastSavedBrew.current.text),
+			hash      : await md5(lastSavedBrew.current.text.normalize('NFC')),
 			textBin   : undefined,
 			version   : lastSavedBrew.current.version
 		};


### PR DESCRIPTION
## Description

This PR should resolve the issue with hash mismatch error causing Out of Sync error messages.

MD5 hashes were being generated in the EditPage from the editor's text before the entire brew object was sent to the `/update/` API route.
However, the API route compared the hash in the received data to a hash generated from a *normalized* version of the saved text (literally `text.normalize('NFC')`). In cases where the normalized version of the text differed from the original text, this would result in a different hash being created, and thus cause a hash mismatch, even though the text was correct.

## Related Issues or Discussions

Discussed via Gitter.
Issue #4581 also provided a brew which was able to reproduce this error.

## QA Instructions, Screenshots, Recordings

### ORIGINAL REPRODUCTION

**EDIT:** *Now outdated, see minimal reproduction below*

~~1. Clone this example brew: https://homebrewery.naturalcrit.com/share/IiLsN0Pyqv5I~~

~~2. Save.~~

~~You will immediately see that the Out of Sync error appears.~~

~~I will attempt to create a more minimal  reproduction.~~

### MINIMAL REPRODUCTION

1. Navigate to https://homebrewery.naturalcrit.com/new

2. Paste the following character into the Content Editor: `ē`

3. Save.

Once the Edit Page loads, you will immediately see the Out of Sync error appear.