### PR TITLE
Custom Snippets: Allow Inline

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -19,7 +19,7 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=nul
 						userSnippets.push({
 							name : snippetName,
 							icon : '',
-							gen  : snipSplit[snips + 1],
+							gen  : snipSplit[snips + 1].replace(/\n$/, ''),
 						});
 					}
 				}
@@ -44,7 +44,7 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=nul
 			if(snippetName.length != 0) {
 				const subSnip = {
 					name : snippetName,
-					gen  : snipSplit[snips + 1],
+					gen  : snipSplit[snips + 1].replace(/\n$/, ''),
 				};
 				// if(full) subSnip.icon = '';
 				userSnippets.push(subSnip);


### PR DESCRIPTION
## Description

Removes the additional line after a snippet, so it doesn't effectively create a `\n` at the end of the snippet.  This allows snippets to be inline with text.

## Related Issues or Discussions

Discussed in Gitter Feb 21 2026

## QA Instructions, Screenshots, Recordings

To see current behavior in the live site, create a new document and a custom snippet:
```
\snippet test 1
{{red car}}
\snippet test 2

{{blue
van
}}

```
Write in your brew a sentence, and in the sentence add the *test 1* snippet.  It will break the sentence to a new line after the snippet.
```
Here is {{red car}}
my sentence.
```
Now, with this PR, do the same, and see the result is 
```
Here is {{red car}} my sentence.
```

### Reviewer Checklist

*Reviewers, refer to this list when testing features, or suggest new items *
- [x] Verify new features are functional
  - [x] inline/single line snippets now no longer break lines
- [x] Verify old features have not broken
  - [x] multi-line snippets still work as expected
- [x] Test for edge cases / try to break things
