### PR TITLE
Add Navigation API check

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -273,24 +273,13 @@ const BrewRenderer = (props)=>{
 	const frameDidMount = ()=>{	//This triggers when iFrame finishes internal "componentDidMount"
 		scrollToHash(window.location.hash);
 
-		if(navigation) {
-			navigation.addEventListener('navigate', (e)=>{
-				if(e.hashChange && e.destination.sameDocument){
-					const dest = e.destination.url.slice(e.destination.url.indexOf('#'));
-					scrollToHash(dest);
-				}
-			});
-		} else {
-			urlRef.current = window.location.href;
-			setInterval(()=>{
-				if(window.location.href != urlRef.current){
-					urlRef.current = window.location.href;
-					const tmpURL = new URL(window.location.href);
-					const target = tmpURL.hash;
-					scrollToHash(target);
-				}
-			}, 1000);
-		};
+		window.addEventListener('hashchange', ()=>{
+			scrollToHash(window.location.hash);
+		});
+
+		window.onbeforeunload(()=>{
+			window.removeEventListener('hashchange');
+		});
 
 		setTimeout(()=>{	//We still see a flicker where the style isn't applied yet, so wait 100ms before showing iFrame
 			renderPages(); //Make sure page is renderable before showing

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -135,6 +135,7 @@ const BrewRenderer = (props)=>{
 
 	const mainRef  = useRef(null);
 	const pagesRef = useRef(null);
+	const urlRef = useRef('');
 
 	if(props.renderer == 'legacy') {
 		rawPages = props.text.split(PAGEBREAK_REGEX_LEGACY);
@@ -272,12 +273,24 @@ const BrewRenderer = (props)=>{
 	const frameDidMount = ()=>{	//This triggers when iFrame finishes internal "componentDidMount"
 		scrollToHash(window.location.hash);
 
-		navigation.addEventListener('navigate', (e)=>{
-			if(e.hashChange && e.destination.sameDocument){
-				const dest = e.destination.url.slice(e.destination.url.indexOf('#'));
-				scrollToHash(dest);
-			}
-		});
+		if(navigation) {
+			navigation.addEventListener('navigate', (e)=>{
+				if(e.hashChange && e.destination.sameDocument){
+					const dest = e.destination.url.slice(e.destination.url.indexOf('#'));
+					scrollToHash(dest);
+				}
+			});
+		} else {
+			urlRef.current = window.location.href;
+			setInterval(()=>{
+				if(window.location.href != urlRef.current){
+					urlRef.current = window.location.href;
+					const tmpURL = new URL(window.location.href);
+					const target = tmpURL.hash;
+					scrollToHash(target);
+				}
+			}, 1000);
+		};
 
 		setTimeout(()=>{	//We still see a flicker where the style isn't applied yet, so wait 100ms before showing iFrame
 			renderPages(); //Make sure page is renderable before showing


### PR DESCRIPTION
This PR adds a check to see if the Navigation API exists before attempting to hook an Event Listener to it.
In the event that the API does NOT exist, it instead creates a small function that runs once per second which checks if the current URL has changed; in the event that it has, it calls `scrollToHash` using the current URL's `hash` property.

This should resolve the issue that users have been reporting on Reddit and Discord of Homebrewery crashing when attempting to load on older browsers.