### PR TITLE
fix newpage keybind

### DIFF
--- a/client/components/codeEditor/codeEditor.jsx
+++ b/client/components/codeEditor/codeEditor.jsx
@@ -16,6 +16,7 @@ import {
 } from '@codemirror/view';
 import { EditorState, Compartment, StateEffect, StateField } from '@codemirror/state';
 import { foldAll as foldAllCmd, unfoldAll as unfoldAllCmd, foldGutter, foldKeymap, syntaxHighlighting } from '@codemirror/language';
+import { foldEffect } from '@codemirror/language';
 import { defaultKeymap, history, undo, redo, undoDepth, redoDepth } from '@codemirror/commands';
 import { languages } from '@codemirror/language-data';
 import { css } from '@codemirror/lang-css';
@@ -392,7 +393,19 @@ const CodeEditor = forwardRef(
 			foldAll : ()=>{
 				const view = viewRef.current;
 				if(!view) return;
-				view.dispatch(foldAllCmd(view));
+
+				const doc = view.state.doc;
+				const pages = pageMap.current;
+
+				const effects = pages.map((start, i)=>{
+					const next = pages[i + 1] || doc.length;
+					const from = i ? doc.line(doc.lineAt(start).number + 1).from : 0;
+					const to = doc.line(doc.lineAt(next).number).from - 1;
+
+					return to > from ? foldEffect.of({ from, to }) : null;
+				}).filter(Boolean);
+
+				view.dispatch({ effects });
 			},
 			unfoldAll : ()=>{
 				const view = viewRef.current;

--- a/client/components/codeEditor/customKeyMaps.js
+++ b/client/components/codeEditor/customKeyMaps.js
@@ -1,6 +1,7 @@
 /* eslint max-lines: ["error", { "max": 300 }] */
 import { keymap } from '@codemirror/view';
 import { undo, redo, indentMore } from '@codemirror/commands';
+import { Prec } from '@codemirror/state';
 
 const indentLess = (view)=>{
 	const { from, to } = view.state.selection.main;
@@ -193,7 +194,7 @@ export const generalKeymap = keymap.of([
 	{ key: 'Mod-Shift-z', run: redo },
 ]);
 
-export const markdownKeymap = keymap.of([
+export const markdownKeymap = Prec.highest(keymap.of([
 	//{ key: 'Shift-Tab', run: indentMore },
 	{ key: 'Shift-Tab', run: indentLess },
 	{ key: 'Mod-b', run: makeBold },
@@ -219,4 +220,4 @@ export const markdownKeymap = keymap.of([
 	{ key: 'Shift-Mod-Enter', run: newColumn },
 	{ key: 'Mod-Enter', run: newPage },
 
-]);
+]));


### PR DESCRIPTION
It was a matter of precedence of the keybinds, this fixes any shortcut that coincided with the default keymap, mainly italics and newpage input.

This PR also changes the foldAll function back to folding just the ranges of pages.

Headings still have precedence over pages for folding.