### PR TITLE
Fix multiline Definition List highlight breaking

### DIFF
--- a/client/components/codeEditor/customHighlight.js
+++ b/client/components/codeEditor/customHighlight.js
@@ -137,14 +137,14 @@ export function tokenizeCustomMarkdown(text) {
 			for (let i = lineNumber + 1; i < lines.length; i++) {
 				const nextLine = lines[i];
 				const onlyColonsMatch = /^:*$/.test(nextLine);
-				const defMatch = /^(::)(.*\S.*)?\s*$/.exec(nextLine);
+				const defMatch = /^(::)(.+)$/.exec(nextLine);
 				if(!onlyColonsMatch && defMatch) {
 					defs.push({ colons: defMatch[1], desc: defMatch[2], line: i });
 					endLine = i;
 				} else break;
 			}
 
-			if(defs.length > 0) {
+			if(defs.length > 0 && lineText.trim().length > 0) {
 				tokens.push({
 					line : startLine,
 					type : customTags.definitionList,
@@ -175,7 +175,7 @@ export function tokenizeCustomMarkdown(text) {
 						line : d.line,
 						type : customTags.definitionDesc,
 						from : d.colons.length,
-						to   : d.colons.length + d.desc.length,
+						to   : d.colons.length + d.desc?.length,
 					});
 				});
 			}


### PR DESCRIPTION
## Description

This PR does three things:

1) Simplifies some regex that was equivalent to just `.*` to reduce catastrophic backtacking
2) Prevents crashing and losing custom highlights if Description entry length was empty
3) Only begins multiline highlighting if there is a valid Term with content
