### PR TITLE
Close Theme Selector on Selection

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -170,7 +170,7 @@ const Snippetbar = createReactClass({
 		this.props.updateEditorTheme(e.target.value);
 
 		this.setState({
-			showThemeSelector : false,
+			themeSelector : false,
 		});
 	},
 


### PR DESCRIPTION
## Description

The editor theme selector currently doesn't close after a selection is chosen.  This seems counterintuitive, and I believe it's just an oversight.  There is code to enable hiding it after a selection, but it just had the wrong variable name, `showThemeSelector: false` rather than `themeSelector: false`.

I change it from the former to the latter, because `themeSelector` was used many more times in the codebase.  I sort of think `showThemeSelector` is more descriptive and better, but chose the smaller change.
