### PR TITLE
Better preview tool collapsing

### DIFF
--- a/client/homebrew/brewRenderer/toolBar/toolBar.jsx
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.jsx
@@ -99,172 +99,177 @@ const ToolBar = ({ displayOptions, onDisplayOptionsChange, visiblePages, totalPa
 	if(!toolsVisible){
 		return (
 			<div id='preview-toolbar' className='toolBar hidden' role='toolbar'>
-				<div className='group toggleButton'>
-					<button data-tooltip-bottom={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} onClick={()=>{
+				<div className='group'>
+					<button data-tooltip-right={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} className='toolBarToggle' onClick={()=>{
 						setToolsVisible(!toolsVisible);
 						localStorage.setItem(TOOLBAR_VISIBILITY, !toolsVisible);
-					}}><i className='fas fa-glasses' /></button>
+					}}><i className='fas fa-caret-right' /></button>
 				</div>
 			</div>
 		)
 	} else {
 		return (
 			<div id='preview-toolbar' className='toolBar visible' role='toolbar'>
-				
-				{/*v=====----------------------< Zoom Controls >---------------------=====v*/}
-				<div className='group' role='group' aria-label='Zoom' aria-hidden={!toolsVisible}>
-					<button
-						id='fill-width'
-						className='tool'
-						data-tooltip-bottom='Set zoom to fill preview with one page'
-						onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fill'))}
-					>
-						<i className='fac fit-width' />
-					</button>
-					<button
-						id='zoom-to-fit'
-						className='tool'
-						data-tooltip-bottom='Set zoom to fit entire page in preview'
-						onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fit'))}
-					>
-						<i className='fac zoom-to-fit' />
-					</button>
-					<button
-						id='zoom-out'
-						className='tool'
-						onClick={()=>handleZoomButton(displayOptions.zoomLevel - 20)}
-						disabled={displayOptions.zoomLevel <= MIN_ZOOM}
-						data-tooltip-bottom='Zoom Out'
-					>
-						<i className='fas fa-magnifying-glass-minus' />
-					</button>
-					<input
-						id='zoom-slider'
-						className='range-input tool hover-tooltip'
-						type='range'
-						name='zoom'
-						list='zoomLevels'
-						min={MIN_ZOOM}
-						max={MAX_ZOOM}
-						step='1'
-						value={displayOptions.zoomLevel}
-						onChange={(e)=>handleZoomButton(parseInt(e.target.value))}
-					/>
-					<datalist id='zoomLevels'>
-						<option value='100' />
-					</datalist>
-
-					<button
-						id='zoom-in'
-						className='tool'
-						onClick={()=>handleZoomButton(displayOptions.zoomLevel + 20)}
-						disabled={displayOptions.zoomLevel >= MAX_ZOOM}
-						data-tooltip-bottom='Zoom In'
-					>
-						<i className='fas fa-magnifying-glass-plus' />
-					</button>
-				</div>
-
-				{/*v=====----------------------< Spread Controls >---------------------=====v*/}
-				<div className='group' role='group' aria-label='Spread' aria-hidden={!toolsVisible}>
-					<div className='radio-group' role='radiogroup'>
-						<button role='radio'
-							id='single-spread'
-							className='tool'
-							data-tooltip-bottom='Single Page'
-							onClick={()=>{handleOptionChange('spread', 'single');}}
-							aria-checked={displayOptions.spread === 'single'}
-						><i className='fac single-spread' /></button>
-						<button role='radio'
-							id='facing-spread'
-							className='tool'
-							data-tooltip-bottom='Facing Pages'
-							onClick={()=>{handleOptionChange('spread', 'facing');}}
-							aria-checked={displayOptions.spread === 'facing'}
-						><i className='fac facing-spread' /></button>
-						<button role='radio'
-							id='flow-spread'
-							className='tool'
-							data-tooltip-bottom='Flow Pages'
-							onClick={()=>{handleOptionChange('spread', 'flow');}}
-							aria-checked={displayOptions.spread === 'flow'}
-						><i className='fac flow-spread' /></button>
-
-					</div>
-					<Anchored>
-						<AnchoredTrigger id='spread-settings' className='tool' data-tooltip-bottom='Spread options'><i className='fas fa-gear' /></AnchoredTrigger>
-						<AnchoredBox>
-							<h1>Options</h1>
-							<label data-tooltip-left='Modify the horizontal space between pages.'>
-								Column gap
-								<input type='range' min={0} max={200} defaultValue={displayOptions.columnGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('columnGap', evt.target.value)} />
-							</label>
-							<label data-tooltip-left='Modify the vertical space between rows of pages.'>
-								Row gap
-								<input type='range' min={0} max={200} defaultValue={displayOptions.rowGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('rowGap', evt.target.value)} />
-							</label>
-							<label data-tooltip-left='Start 1st page on the right side, such as if you have cover page.'>
-								Start on right
-								<input type='checkbox' checked={displayOptions.startOnRight} onChange={()=>{handleOptionChange('startOnRight', !displayOptions.startOnRight);}}
-									data-tooltip-right={displayOptions.spread !== 'facing' ? 'Switch to Facing to enable toggle.' : null} />
-							</label>
-							<label data-tooltip-left='Toggle the page shadow on every page.'>
-								Page shadows
-								<input type='checkbox' checked={displayOptions.pageShadows} onChange={()=>{handleOptionChange('pageShadows', !displayOptions.pageShadows);}} />
-							</label>
-						</AnchoredBox>
-					</Anchored>
-				</div>
-
-				{/*v=====----------------------< Page Controls >---------------------=====v*/}
-				<div className='group' role='group'  aria-label='Pages' aria-hidden={!toolsVisible}>
-					<button
-						id='previous-page'
-						className='previousPage tool'
-						type='button'
-						data-tooltip-bottom='Previous Page(s)'
-						onClick={()=>scrollToPage(_.min(visiblePages) - visiblePages.length)}
-						disabled={visiblePages.includes(1)}
-					>
-						<i className='fas fa-arrow-left'></i>
-					</button>
-
-					<div className='tool'>
-						<input
-							id='page-input'
-							className='text-input'
-							type='text'
-							name='page'
-							data-tooltip-bottom='Current page(s) in view'
-							inputMode='numeric'
-							pattern='[0-9]'
-							value={pageNum}
-							onClick={(e)=>e.target.select()}
-							onChange={(e)=>handlePageInput(e.target.value)}
-							onBlur={()=>scrollToPage(pageNum)}
-							onKeyDown={(e)=>e.key == 'Enter' && scrollToPage(pageNum)}
-							style={{ width: `${pageNum.length}ch` }}
-						/>
-						<span id='page-count' data-tooltip-bottom='Total Page Count'>/ {totalPages}</span>
-					</div>
-
-					<button
-						id='next-page'
-						className='tool'
-						type='button'
-						data-tooltip-bottom='Next Page(s)'
-						onClick={()=>scrollToPage(_.max(visiblePages) + 1)}
-						disabled={visiblePages.includes(totalPages)}
-					>
-						<i className='fas fa-arrow-right'></i>
-					</button>
-				</div>
+			
 				<div className='group'>
-					<button data-tooltip-bottom={`${headerState ? 'Hide' : 'Show'} Header Navigation`} onClick={()=>{setHeaderState(!headerState);}}><i className='fas fa-rectangle-list' /></button>
-					<button data-tooltip-bottom={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} onClick={()=>{
+					<button data-tooltip-right={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} className='toolBarToggle' onClick={()=>{
 						setToolsVisible(!toolsVisible);
 						localStorage.setItem(TOOLBAR_VISIBILITY, !toolsVisible);
-					}}><i className='fas fa-glasses' /></button>
+					}}><i className='fas fa-caret-left' /></button>
+				</div>
+				<div className='tools'>
+					<div className='group'>
+						<button data-tooltip-bottom={`${headerState ? 'Hide' : 'Show'} Header Navigation`} onClick={()=>{setHeaderState(!headerState);}}><i className='fas fa-rectangle-list' /></button>
+
+					</div>
+					{/*v=====----------------------< Zoom Controls >---------------------=====v*/}
+					<div className='group' role='group' aria-label='Zoom' aria-hidden={!toolsVisible}>
+						<button
+							id='fill-width'
+							className='tool'
+							data-tooltip-bottom='Set zoom to fill preview with one page'
+							onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fill'))}
+						>
+							<i className='fac fit-width' />
+						</button>
+						<button
+							id='zoom-to-fit'
+							className='tool'
+							data-tooltip-bottom='Set zoom to fit entire page in preview'
+							onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fit'))}
+						>
+							<i className='fac zoom-to-fit' />
+						</button>
+						<button
+							id='zoom-out'
+							className='tool'
+							onClick={()=>handleZoomButton(displayOptions.zoomLevel - 20)}
+							disabled={displayOptions.zoomLevel <= MIN_ZOOM}
+							data-tooltip-bottom='Zoom Out'
+						>
+							<i className='fas fa-magnifying-glass-minus' />
+						</button>
+						<input
+							id='zoom-slider'
+							className='range-input tool hover-tooltip'
+							type='range'
+							name='zoom'
+							list='zoomLevels'
+							min={MIN_ZOOM}
+							max={MAX_ZOOM}
+							step='1'
+							value={displayOptions.zoomLevel}
+							onChange={(e)=>handleZoomButton(parseInt(e.target.value))}
+						/>
+						<datalist id='zoomLevels'>
+							<option value='100' />
+						</datalist>
+
+						<button
+							id='zoom-in'
+							className='tool'
+							onClick={()=>handleZoomButton(displayOptions.zoomLevel + 20)}
+							disabled={displayOptions.zoomLevel >= MAX_ZOOM}
+							data-tooltip-bottom='Zoom In'
+						>
+							<i className='fas fa-magnifying-glass-plus' />
+						</button>
+					</div>
+
+					{/*v=====----------------------< Spread Controls >---------------------=====v*/}
+					<div className='group' role='group' aria-label='Spread' aria-hidden={!toolsVisible}>
+						<div className='radio-group' role='radiogroup'>
+							<button role='radio'
+								id='single-spread'
+								className='tool'
+								data-tooltip-bottom='Single Page'
+								onClick={()=>{handleOptionChange('spread', 'single');}}
+								aria-checked={displayOptions.spread === 'single'}
+							><i className='fac single-spread' /></button>
+							<button role='radio'
+								id='facing-spread'
+								className='tool'
+								data-tooltip-bottom='Facing Pages'
+								onClick={()=>{handleOptionChange('spread', 'facing');}}
+								aria-checked={displayOptions.spread === 'facing'}
+							><i className='fac facing-spread' /></button>
+							<button role='radio'
+								id='flow-spread'
+								className='tool'
+								data-tooltip-bottom='Flow Pages'
+								onClick={()=>{handleOptionChange('spread', 'flow');}}
+								aria-checked={displayOptions.spread === 'flow'}
+							><i className='fac flow-spread' /></button>
+
+						</div>
+						<Anchored>
+							<AnchoredTrigger id='spread-settings' className='tool' data-tooltip-bottom='Spread options'><i className='fas fa-gear' /></AnchoredTrigger>
+							<AnchoredBox>
+								<h1>Options</h1>
+								<label data-tooltip-left='Modify the horizontal space between pages.'>
+									Column gap
+									<input type='range' min={0} max={200} defaultValue={displayOptions.columnGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('columnGap', evt.target.value)} />
+								</label>
+								<label data-tooltip-left='Modify the vertical space between rows of pages.'>
+									Row gap
+									<input type='range' min={0} max={200} defaultValue={displayOptions.rowGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('rowGap', evt.target.value)} />
+								</label>
+								<label data-tooltip-left='Start 1st page on the right side, such as if you have cover page.'>
+									Start on right
+									<input type='checkbox' checked={displayOptions.startOnRight} onChange={()=>{handleOptionChange('startOnRight', !displayOptions.startOnRight);}}
+										data-tooltip-right={displayOptions.spread !== 'facing' ? 'Switch to Facing to enable toggle.' : null} />
+								</label>
+								<label data-tooltip-left='Toggle the page shadow on every page.'>
+									Page shadows
+									<input type='checkbox' checked={displayOptions.pageShadows} onChange={()=>{handleOptionChange('pageShadows', !displayOptions.pageShadows);}} />
+								</label>
+							</AnchoredBox>
+						</Anchored>
+					</div>
+
+					{/*v=====----------------------< Page Controls >---------------------=====v*/}
+					<div className='group' role='group'  aria-label='Pages' aria-hidden={!toolsVisible}>
+						<button
+							id='previous-page'
+							className='previousPage tool'
+							type='button'
+							data-tooltip-bottom='Previous Page(s)'
+							onClick={()=>scrollToPage(_.min(visiblePages) - visiblePages.length)}
+							disabled={visiblePages.includes(1)}
+						>
+							<i className='fas fa-arrow-left'></i>
+						</button>
+
+						<div className='tool'>
+							<input
+								id='page-input'
+								className='text-input'
+								type='text'
+								name='page'
+								data-tooltip-bottom='Current page(s) in view'
+								inputMode='numeric'
+								pattern='[0-9]'
+								value={pageNum}
+								onClick={(e)=>e.target.select()}
+								onChange={(e)=>handlePageInput(e.target.value)}
+								onBlur={()=>scrollToPage(pageNum)}
+								onKeyDown={(e)=>e.key == 'Enter' && scrollToPage(pageNum)}
+								style={{ width: `${pageNum.length}ch` }}
+							/>
+							<span id='page-count' data-tooltip-bottom='Total Page Count'>/ {totalPages}</span>
+						</div>
+
+						<button
+							id='next-page'
+							className='tool'
+							type='button'
+							data-tooltip-bottom='Next Page(s)'
+							onClick={()=>scrollToPage(_.max(visiblePages) + 1)}
+							disabled={visiblePages.includes(totalPages)}
+						>
+							<i className='fas fa-arrow-right'></i>
+						</button>
+					</div>
 				</div>
 			</div>
 		);

--- a/client/homebrew/brewRenderer/toolBar/toolBar.jsx
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.jsx
@@ -96,165 +96,179 @@ const ToolBar = ({ displayOptions, onDisplayOptionsChange, visiblePages, totalPa
 		return deltaZoom;
 	};
 
-	return (
-		<div id='preview-toolbar' className={`toolBar ${toolsVisible ? 'visible' : 'hidden'}`} role='toolbar'>
-			<div className='toggleButton'>
-				<button data-tooltip-right={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} onClick={()=>{
-					setToolsVisible(!toolsVisible);
-					localStorage.setItem(TOOLBAR_VISIBILITY, !toolsVisible);
-				}}><i className='fas fa-glasses' /></button>
-				<button data-tooltip-right={`${headerState ? 'Hide' : 'Show'} Header Navigation`} onClick={()=>{setHeaderState(!headerState);}}><i className='fas fa-rectangle-list' /></button>
-			</div>
-			{/*v=====----------------------< Zoom Controls >---------------------=====v*/}
-			<div className='group' role='group' aria-label='Zoom' aria-hidden={!toolsVisible}>
-				<button
-					id='fill-width'
-					className='tool'
-					data-tooltip-bottom='Set zoom to fill preview with one page'
-					onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fill'))}
-				>
-					<i className='fac fit-width' />
-				</button>
-				<button
-					id='zoom-to-fit'
-					className='tool'
-					data-tooltip-bottom='Set zoom to fit entire page in preview'
-					onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fit'))}
-				>
-					<i className='fac zoom-to-fit' />
-				</button>
-				<button
-					id='zoom-out'
-					className='tool'
-					onClick={()=>handleZoomButton(displayOptions.zoomLevel - 20)}
-					disabled={displayOptions.zoomLevel <= MIN_ZOOM}
-					data-tooltip-bottom='Zoom Out'
-				>
-					<i className='fas fa-magnifying-glass-minus' />
-				</button>
-				<input
-					id='zoom-slider'
-					className='range-input tool hover-tooltip'
-					type='range'
-					name='zoom'
-					list='zoomLevels'
-					min={MIN_ZOOM}
-					max={MAX_ZOOM}
-					step='1'
-					value={displayOptions.zoomLevel}
-					onChange={(e)=>handleZoomButton(parseInt(e.target.value))}
-				/>
-				<datalist id='zoomLevels'>
-					<option value='100' />
-				</datalist>
-
-				<button
-					id='zoom-in'
-					className='tool'
-					onClick={()=>handleZoomButton(displayOptions.zoomLevel + 20)}
-					disabled={displayOptions.zoomLevel >= MAX_ZOOM}
-					data-tooltip-bottom='Zoom In'
-				>
-					<i className='fas fa-magnifying-glass-plus' />
-				</button>
-			</div>
-
-			{/*v=====----------------------< Spread Controls >---------------------=====v*/}
-			<div className='group' role='group' aria-label='Spread' aria-hidden={!toolsVisible}>
-				<div className='radio-group' role='radiogroup'>
-					<button role='radio'
-						id='single-spread'
-						className='tool'
-						data-tooltip-bottom='Single Page'
-						onClick={()=>{handleOptionChange('spread', 'single');}}
-						aria-checked={displayOptions.spread === 'single'}
-					><i className='fac single-spread' /></button>
-					<button role='radio'
-						id='facing-spread'
-						className='tool'
-						data-tooltip-bottom='Facing Pages'
-						onClick={()=>{handleOptionChange('spread', 'facing');}}
-						aria-checked={displayOptions.spread === 'facing'}
-					><i className='fac facing-spread' /></button>
-					<button role='radio'
-						id='flow-spread'
-						className='tool'
-						data-tooltip-bottom='Flow Pages'
-						onClick={()=>{handleOptionChange('spread', 'flow');}}
-						aria-checked={displayOptions.spread === 'flow'}
-					><i className='fac flow-spread' /></button>
-
+	if(!toolsVisible){
+		return (
+			<div id='preview-toolbar' className='toolBar hidden' role='toolbar'>
+				<div className='group toggleButton'>
+					<button data-tooltip-bottom={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} onClick={()=>{
+						setToolsVisible(!toolsVisible);
+						localStorage.setItem(TOOLBAR_VISIBILITY, !toolsVisible);
+					}}><i className='fas fa-glasses' /></button>
 				</div>
-				<Anchored>
-					<AnchoredTrigger id='spread-settings' className='tool' data-tooltip-bottom='Spread options'><i className='fas fa-gear' /></AnchoredTrigger>
-					<AnchoredBox>
-						<h1>Options</h1>
-						<label data-tooltip-left='Modify the horizontal space between pages.'>
-							Column gap
-							<input type='range' min={0} max={200} defaultValue={displayOptions.columnGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('columnGap', evt.target.value)} />
-						</label>
-						<label data-tooltip-left='Modify the vertical space between rows of pages.'>
-							Row gap
-							<input type='range' min={0} max={200} defaultValue={displayOptions.rowGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('rowGap', evt.target.value)} />
-						</label>
-						<label data-tooltip-left='Start 1st page on the right side, such as if you have cover page.'>
-							Start on right
-							<input type='checkbox' checked={displayOptions.startOnRight} onChange={()=>{handleOptionChange('startOnRight', !displayOptions.startOnRight);}}
-								data-tooltip-right={displayOptions.spread !== 'facing' ? 'Switch to Facing to enable toggle.' : null} />
-						</label>
-						<label data-tooltip-left='Toggle the page shadow on every page.'>
-							Page shadows
-							<input type='checkbox' checked={displayOptions.pageShadows} onChange={()=>{handleOptionChange('pageShadows', !displayOptions.pageShadows);}} />
-						</label>
-					</AnchoredBox>
-				</Anchored>
 			</div>
-
-			{/*v=====----------------------< Page Controls >---------------------=====v*/}
-			<div className='group' role='group'  aria-label='Pages' aria-hidden={!toolsVisible}>
-				<button
-					id='previous-page'
-					className='previousPage tool'
-					type='button'
-					data-tooltip-bottom='Previous Page(s)'
-					onClick={()=>scrollToPage(_.min(visiblePages) - visiblePages.length)}
-					disabled={visiblePages.includes(1)}
-				>
-					<i className='fas fa-arrow-left'></i>
-				</button>
-
-				<div className='tool'>
+		)
+	} else {
+		return (
+			<div id='preview-toolbar' className='toolBar visible' role='toolbar'>
+				
+				{/*v=====----------------------< Zoom Controls >---------------------=====v*/}
+				<div className='group' role='group' aria-label='Zoom' aria-hidden={!toolsVisible}>
+					<button
+						id='fill-width'
+						className='tool'
+						data-tooltip-bottom='Set zoom to fill preview with one page'
+						onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fill'))}
+					>
+						<i className='fac fit-width' />
+					</button>
+					<button
+						id='zoom-to-fit'
+						className='tool'
+						data-tooltip-bottom='Set zoom to fit entire page in preview'
+						onClick={()=>handleZoomButton(displayOptions.zoomLevel + calculateChange('fit'))}
+					>
+						<i className='fac zoom-to-fit' />
+					</button>
+					<button
+						id='zoom-out'
+						className='tool'
+						onClick={()=>handleZoomButton(displayOptions.zoomLevel - 20)}
+						disabled={displayOptions.zoomLevel <= MIN_ZOOM}
+						data-tooltip-bottom='Zoom Out'
+					>
+						<i className='fas fa-magnifying-glass-minus' />
+					</button>
 					<input
-						id='page-input'
-						className='text-input'
-						type='text'
-						name='page'
-						data-tooltip-bottom='Current page(s) in view'
-						inputMode='numeric'
-						pattern='[0-9]'
-						value={pageNum}
-						onClick={(e)=>e.target.select()}
-						onChange={(e)=>handlePageInput(e.target.value)}
-						onBlur={()=>scrollToPage(pageNum)}
-						onKeyDown={(e)=>e.key == 'Enter' && scrollToPage(pageNum)}
-						style={{ width: `${pageNum.length}ch` }}
+						id='zoom-slider'
+						className='range-input tool hover-tooltip'
+						type='range'
+						name='zoom'
+						list='zoomLevels'
+						min={MIN_ZOOM}
+						max={MAX_ZOOM}
+						step='1'
+						value={displayOptions.zoomLevel}
+						onChange={(e)=>handleZoomButton(parseInt(e.target.value))}
 					/>
-					<span id='page-count' data-tooltip-bottom='Total Page Count'>/ {totalPages}</span>
+					<datalist id='zoomLevels'>
+						<option value='100' />
+					</datalist>
+
+					<button
+						id='zoom-in'
+						className='tool'
+						onClick={()=>handleZoomButton(displayOptions.zoomLevel + 20)}
+						disabled={displayOptions.zoomLevel >= MAX_ZOOM}
+						data-tooltip-bottom='Zoom In'
+					>
+						<i className='fas fa-magnifying-glass-plus' />
+					</button>
 				</div>
 
-				<button
-					id='next-page'
-					className='tool'
-					type='button'
-					data-tooltip-bottom='Next Page(s)'
-					onClick={()=>scrollToPage(_.max(visiblePages) + 1)}
-					disabled={visiblePages.includes(totalPages)}
-				>
-					<i className='fas fa-arrow-right'></i>
-				</button>
+				{/*v=====----------------------< Spread Controls >---------------------=====v*/}
+				<div className='group' role='group' aria-label='Spread' aria-hidden={!toolsVisible}>
+					<div className='radio-group' role='radiogroup'>
+						<button role='radio'
+							id='single-spread'
+							className='tool'
+							data-tooltip-bottom='Single Page'
+							onClick={()=>{handleOptionChange('spread', 'single');}}
+							aria-checked={displayOptions.spread === 'single'}
+						><i className='fac single-spread' /></button>
+						<button role='radio'
+							id='facing-spread'
+							className='tool'
+							data-tooltip-bottom='Facing Pages'
+							onClick={()=>{handleOptionChange('spread', 'facing');}}
+							aria-checked={displayOptions.spread === 'facing'}
+						><i className='fac facing-spread' /></button>
+						<button role='radio'
+							id='flow-spread'
+							className='tool'
+							data-tooltip-bottom='Flow Pages'
+							onClick={()=>{handleOptionChange('spread', 'flow');}}
+							aria-checked={displayOptions.spread === 'flow'}
+						><i className='fac flow-spread' /></button>
+
+					</div>
+					<Anchored>
+						<AnchoredTrigger id='spread-settings' className='tool' data-tooltip-bottom='Spread options'><i className='fas fa-gear' /></AnchoredTrigger>
+						<AnchoredBox>
+							<h1>Options</h1>
+							<label data-tooltip-left='Modify the horizontal space between pages.'>
+								Column gap
+								<input type='range' min={0} max={200} defaultValue={displayOptions.columnGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('columnGap', evt.target.value)} />
+							</label>
+							<label data-tooltip-left='Modify the vertical space between rows of pages.'>
+								Row gap
+								<input type='range' min={0} max={200} defaultValue={displayOptions.rowGap || 10} className='range-input' onChange={(evt)=>handleOptionChange('rowGap', evt.target.value)} />
+							</label>
+							<label data-tooltip-left='Start 1st page on the right side, such as if you have cover page.'>
+								Start on right
+								<input type='checkbox' checked={displayOptions.startOnRight} onChange={()=>{handleOptionChange('startOnRight', !displayOptions.startOnRight);}}
+									data-tooltip-right={displayOptions.spread !== 'facing' ? 'Switch to Facing to enable toggle.' : null} />
+							</label>
+							<label data-tooltip-left='Toggle the page shadow on every page.'>
+								Page shadows
+								<input type='checkbox' checked={displayOptions.pageShadows} onChange={()=>{handleOptionChange('pageShadows', !displayOptions.pageShadows);}} />
+							</label>
+						</AnchoredBox>
+					</Anchored>
+				</div>
+
+				{/*v=====----------------------< Page Controls >---------------------=====v*/}
+				<div className='group' role='group'  aria-label='Pages' aria-hidden={!toolsVisible}>
+					<button
+						id='previous-page'
+						className='previousPage tool'
+						type='button'
+						data-tooltip-bottom='Previous Page(s)'
+						onClick={()=>scrollToPage(_.min(visiblePages) - visiblePages.length)}
+						disabled={visiblePages.includes(1)}
+					>
+						<i className='fas fa-arrow-left'></i>
+					</button>
+
+					<div className='tool'>
+						<input
+							id='page-input'
+							className='text-input'
+							type='text'
+							name='page'
+							data-tooltip-bottom='Current page(s) in view'
+							inputMode='numeric'
+							pattern='[0-9]'
+							value={pageNum}
+							onClick={(e)=>e.target.select()}
+							onChange={(e)=>handlePageInput(e.target.value)}
+							onBlur={()=>scrollToPage(pageNum)}
+							onKeyDown={(e)=>e.key == 'Enter' && scrollToPage(pageNum)}
+							style={{ width: `${pageNum.length}ch` }}
+						/>
+						<span id='page-count' data-tooltip-bottom='Total Page Count'>/ {totalPages}</span>
+					</div>
+
+					<button
+						id='next-page'
+						className='tool'
+						type='button'
+						data-tooltip-bottom='Next Page(s)'
+						onClick={()=>scrollToPage(_.max(visiblePages) + 1)}
+						disabled={visiblePages.includes(totalPages)}
+					>
+						<i className='fas fa-arrow-right'></i>
+					</button>
+				</div>
+				<div className='group'>
+					<button data-tooltip-bottom={`${headerState ? 'Hide' : 'Show'} Header Navigation`} onClick={()=>{setHeaderState(!headerState);}}><i className='fas fa-rectangle-list' /></button>
+					<button data-tooltip-bottom={`${toolsVisible ? 'Hide' : 'Show'} Preview Toolbar`} onClick={()=>{
+						setToolsVisible(!toolsVisible);
+						localStorage.setItem(TOOLBAR_VISIBILITY, !toolsVisible);
+					}}><i className='fas fa-glasses' /></button>
+				</div>
 			</div>
-		</div>
-	);
+		);
+	}
 };
 
 export default ToolBar;

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -34,8 +34,12 @@
 		justify-content  : center;
 		height           : 28px;
 		&:has(.toolBarToggle) {
-			height : -webkit-fill-available;
-			height : stretch;
+			height : revert-rule;
+			/* `stretch` not supported by firefox/safari (Apr 27, 2026), but is not much of a problem, the button is still visible and clickable.
+			* 	https://caniuse.com/?search=stretch
+			* 	https://bugzilla.mozilla.org/show_bug.cgi?id=1789477
+			*/
+			height : stretch;  
 		}
 	}
 

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -15,15 +15,15 @@
 	font-size        : 13px;
 	color            : #CCCCCC;
 	background-color : #555555;
-	opacity    : 1;
-	interpolate-size: allow-keywords;
-	transition : all 0.2s ease;
+	opacity          : 1;
+	interpolate-size : allow-keywords;
+	transition       : all 0.2s ease;
 	> .tools {
-		flex: 1 1 auto;
 		display          : flex;
+		flex             : 1 1 auto;
 		flex-wrap        : wrap;
 		gap              : 8px 20px;
-		justify-content: center;
+		justify-content  : center;
 	}
 
 	.group {
@@ -33,10 +33,9 @@
 		align-items      : center;
 		justify-content  : center;
 		height           : 28px;
-		&:has(.toolBarToggle){
-			height: -webkit-fill-available;
-			height: stretch;
-
+		&:has(.toolBarToggle) {
+			height : -webkit-fill-available;
+			height : stretch;
 		}
 	}
 
@@ -173,39 +172,35 @@
 		}
 		i { font-size : 1.2em; }
 		&.toolBarToggle {
-			justify-content:left;
-			padding-left: 5px;
-			height: 100%;
+			justify-content : left;
+			height          : 100%;
+			padding-left    : 5px;
 		}
 	}
 
 	&.hidden {
 		flex-wrap        : nowrap;
 		width            : auto;
-		background-color : #0000;
+		background-color : #00000000;
 		opacity          : 0.7;
-		transition       : opacity 0.2s ease, background-color 0.2s ease, width .2s linear;
+		transition       : opacity 0.2s ease, background-color 0.2s ease, width 0.2s linear;
 
-		.group {
-			height : 28px;
-		}
+		.group { height : 28px; }
 
 		.toolBarToggle {
 			
-			&:focus {outline : none;
-				border  : 1px solid #D3D3D3;
-				border-radius: 8px;
-				background-color: #555;
-				transition: border-radius .5s ease;
+			&:focus {outline          : none;
+				background-color : #555555;
+				border           : 1px solid #D3D3D3;
+				border-radius    : 8px;
+				transition       : border-radius 0.5s ease;
 			}
 			&:hover {
-				border-radius: 8px;
-				background-color: #555;
-				color: white;
+				color            : white;
+				background-color : #555555;
+				border-radius    : 8px;
 			}
-			i {
-				filter: drop-shadow(0 0 2px black) drop-shadow(0 0 1px black);
-			}
+			i { filter : drop-shadow(0 0 2px black) drop-shadow(0 0 1px black); }
 		}
 	}
 }

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -16,7 +16,7 @@
 	color            : #CCCCCC;
 	background-color : #555555;
 	opacity          : 1;
-	interpolate-size : allow-keywords;
+	interpolate-size : allow-keywords;  // allows `transition` between css keywords ('auto', 'max-content', ...) and <length> values.  Inheritable.
 	transition       : all 0.2s ease;
 	> .tools {
 		display          : flex;

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -5,13 +5,12 @@
 	z-index          : 1;
 	box-sizing       : border-box;
 	display          : flex;
-	flex-wrap        : wrap;
-	gap              : 8px 20px;
+	gap              : 8px;
 	align-items      : center;
-	justify-content  : center;
+	justify-content  : left;
 	width            : 100%;
 	height           : auto;
-	padding          : 2px 10px 2px;
+	padding          : 2px;
 	font-family      : 'Open Sans', sans-serif;
 	font-size        : 13px;
 	color            : #CCCCCC;
@@ -19,6 +18,13 @@
 	opacity    : 1;
 	interpolate-size: allow-keywords;
 	transition : all 0.2s ease;
+	> .tools {
+		flex: 1 1 auto;
+		display          : flex;
+		flex-wrap        : wrap;
+		gap              : 8px 20px;
+		justify-content: center;
+	}
 
 	.group {
 		box-sizing       : border-box;
@@ -27,6 +33,11 @@
 		align-items      : center;
 		justify-content  : center;
 		height           : 28px;
+		&:has(.toolBarToggle){
+			height: -webkit-fill-available;
+			height: stretch;
+
+		}
 	}
 
 	.tool {
@@ -161,6 +172,11 @@
 			background-color : unset !important;
 		}
 		i { font-size : 1.2em; }
+		&.toolBarToggle {
+			justify-content:left;
+			padding-left: 5px;
+			height: 100%;
+		}
 	}
 
 	&.hidden {
@@ -168,11 +184,23 @@
 		width            : auto;
 		background-color : #0000;
 		opacity          : 0.7;
-		transition       : opacity 0.2s ease, background-color 1s 0.2s ease, width .2s linear;
+		transition       : opacity 0.2s ease, background-color 0.2s ease, width .2s linear;
 
-		.toggleButton button {
+		.group {
+			height : 28px;
+		}
+
+		.toolBarToggle {
+			
+			&:focus {outline : none;
+				border  : 1px solid #D3D3D3;
+				border-radius: 8px;
+				background-color: #555;
+				transition: border-radius .5s ease;
+			}
 			&:hover {
-				background-color: unset;
+				border-radius: 8px;
+				background-color: #555;
 				color: white;
 			}
 			i {

--- a/client/homebrew/brewRenderer/toolBar/toolBar.less
+++ b/client/homebrew/brewRenderer/toolBar/toolBar.less
@@ -11,15 +11,14 @@
 	justify-content  : center;
 	width            : 100%;
 	height           : auto;
-	padding          : 2px 10px 2px 90px;
+	padding          : 2px 10px 2px;
 	font-family      : 'Open Sans', sans-serif;
 	font-size        : 13px;
 	color            : #CCCCCC;
 	background-color : #555555;
-	& > *:not(.toggleButton) {
-		opacity    : 1;
-		transition : all 0.2s ease;
-	}
+	opacity    : 1;
+	interpolate-size: allow-keywords;
+	transition : all 0.2s ease;
 
 	.group {
 		box-sizing       : border-box;
@@ -166,26 +165,19 @@
 
 	&.hidden {
 		flex-wrap        : nowrap;
-		width            : 50%;
-		overflow         : hidden;
-		background-color : unset;
+		width            : auto;
+		background-color : #0000;
 		opacity          : 0.7;
-		transition       : all 0.3s ease;
-		& > *:not(.toggleButton) {
-			opacity    : 0;
-			transition : all 0.2s ease;
-		}
+		transition       : opacity 0.2s ease, background-color 1s 0.2s ease, width .2s linear;
 
-		.toggleButton button i {
-			filter: drop-shadow(0 0 2px black) drop-shadow(0 0 1px black);
+		.toggleButton button {
+			&:hover {
+				background-color: unset;
+				color: white;
+			}
+			i {
+				filter: drop-shadow(0 0 2px black) drop-shadow(0 0 1px black);
+			}
 		}
 	}
-}
-
-.toggleButton {
-	position  : absolute;
-	left      : 0;
-	z-index   : 5;
-	display   : flex;
-	height    : 100%;
 }


### PR DESCRIPTION
## Description

This PR revisits the Preview Toolbar at an aesthetic level. I've never been satisfied with the opening/closing mechanism, or the "glasses" icon.

Now:

- glasses are replaced by left/right caret depending on open state.  Seems more clear to me what the button will do than "glasses". 
- HeaderNav toggle is decoupled from toolbar toggle.  I think that if someone wants to "hide the toolbar", HB should expect that they really want to remove as much UI as possible.  If I could think of a satisfactory way to remove the caret while making it possible to bring the toolbar back, too, I would.   Note, the Header Nav itself doesn't hide when the toolbar is collapsed.
- better `transition`s now, using the new `interpolate-size` css property to be able to transition between `auto` and some fixed size (`100%`). 

## Related Issues or Discussions

Largely stems from the UI Overhaul work, but otherwise this hasn't been discussed, agreed on, etc.  

## QA Instructions, Screenshots, Recordings

Click the Show/Hide caret toggle, check tooltips, squash viewport/preview pane, try header nav in both opened/closed toolbar state, check that state is preserved between open/close wherever it needs to be.

Note that in non-chromium browsers there are a couple features that aren't supported (`height: stretch` for one) but that doesn't really have any negative consequences.  Everything is totally fine in those browsers.

PR:
<img width="1080" height="201" alt="image" src="https://github.com/user-attachments/assets/09d98f74-974a-4223-9bce-97aa5b8cc276" />

<img width="1080" height="201" alt="image" src="https://github.com/user-attachments/assets/4eead60c-b2a6-4d2b-8fde-2ade5da6bec7" />


Current:
<img width="1080" height="201" alt="image" src="https://github.com/user-attachments/assets/e193ce71-ee50-4338-b67d-0b6c0116bb33" />


### Reviewer Checklist

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Looks okay?
- [ ] Verify old features have not broken
  - [ ] Toolbar opens and closes
  - [ ] state is preserved between opening/closing
- [ ] Test for edge cases / try to break things
  - [ ] Works in different browsers
  - [ ] works on mobile?
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments


## Next steps

I'd like to re-think the `flex` layout of the toolbar so that it more gracefully collapses as the viewport shrinks.  I'm not a big fan of the vertical space it takes, especially beyond two rows.  But that's going to take some *work*, so leaving that for now.

I will also take a swing at reworking the tooltips component to work with the Anchor Positioning/Popover API's (and Oddbird polyfill) to get better algorithmic positioning, which is something that the Preview toolbar and other menubars would really benefit from.  As an independent PR.  