### PR TITLE
Prevent pattern matching in HTML replace function

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -593,7 +593,7 @@ export default async function createApp(vite) {
 
 		html = html.replace(
 			'<head>',
-			`<head>\n<script id="props" >window.__INITIAL_PROPS__ = ${JSON.stringify(props).replaceAll('$', '$$')}</script>\n${ogMetaTags}`
+			()=>{ return `<head>\n<script id="props" >window.__INITIAL_PROPS__ = ${JSON.stringify(props)}</script>\n${ogMetaTags}`; }
 		);
 
 		return html;

--- a/server/app.js
+++ b/server/app.js
@@ -593,7 +593,7 @@ export default async function createApp(vite) {
 
 		html = html.replace(
 			'<head>',
-			`<head>\n<script id="props" >window.__INITIAL_PROPS__ = ${JSON.stringify(props)}</script>\n${ogMetaTags}`
+			`<head>\n<script id="props" >window.__INITIAL_PROPS__ = ${JSON.stringify(props).replaceAll('$', '$$')}</script>\n${ogMetaTags}`
 		);
 
 		return html;


### PR DESCRIPTION
## Description

The use of a string in the `replace` function causes the function to attempt pattern matching on the output, resulting in a number of unexpected behaviours.
Changing this to instead pass a function as the parameter disables this behaviour.

## Related Issues or Discussions

TBC

## QA Instructions, Screenshots, Recordings

### Reproduction:
1. On /new, create a brew containing `$$`.
2. Save.
3. In /edit, observe that the brew now contains a single `$` and immediately reports an "Out of Sync" error.

### Reviewer Checklist

1. [x] Performing the reproduction steps does not result in a single `$` nor the "Out of Sync" error.