### PR TITLE
Log additional information during brew mismatches

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -163,7 +163,7 @@ const debugTextMismatch = (clientTextRaw, serverTextRaw, label)=>{
 			const getMismatchContext = (text, index, name, size = 10)=>{
 				const lower = Math.max(index - size, 0);
 				const upper = Math.min(index + size, text.length);
-				const slice = `${JSON.stringify(text.slice(lower, index - 1)).slice(1, -1)}\u001B[31m${JSON.stringify(text[i]).slice(1, -1)}\u001B[0m${JSON.stringify(text.slice(index+1, upper)).slice(1, -1)}`;
+				const slice = `${JSON.stringify(text.slice(lower, index)).slice(1, -1)}\u001B[31m${JSON.stringify(text[i]).slice(1, -1)}\u001B[0m${JSON.stringify(text.slice(index+1, upper)).slice(1, -1)}`;
 				const lineNo = text.slice(0, index).split('\n').length;
 				const code = `U+${text.charCodeAt(i).toString(16).toUpperCase()}`;
 

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -160,9 +160,35 @@ const debugTextMismatch = (clientTextRaw, serverTextRaw, label)=>{
 	// Char-level diff
 	for (let i = 0; i < Math.min(clientText.length, serverText.length); i++) {
 		if(clientText[i] !== serverText[i]) {
+			const getMismatchContext = (text, index, name, size = 10)=>{
+				const lower = Math.max(index - size, 0);
+				const upper = Math.min(index + size, text.length);
+				const slice = `${JSON.stringify(text.slice(lower, index - 1)).slice(1, -1)}\u001B[31m${JSON.stringify(text[i]).slice(1, -1)}\u001B[0m${JSON.stringify(text.slice(index+1, upper)).slice(1, -1)}`;
+				const lineNo = text.slice(0, index).split('\n').length;
+				const code = `U+${text.charCodeAt(i).toString(16).toUpperCase()}`;
+
+				return {
+					name,
+					lineNo,
+					code,
+					lower,
+					upper,
+					slice
+				};
+			};
+
+			const boundSize = 10;
+
+			const clientContext = getMismatchContext(clientText, i, 'Client', boundSize);
+			const serverContext = getMismatchContext(serverText, i, 'Server', boundSize);
+
+			const logContext = (context)=>{
+				console.log(`  ${context.name} - line ${context.lineNo} : (${context.code})\t${context.slice}`);
+			};
+
 			console.log(`Char mismatch at index ${i}:`);
-			console.log(`  Client: '${clientText[i]}' (U+${clientText.charCodeAt(i).toString(16).toUpperCase()})`);
-			console.log(`  Server: '${serverText[i]}' (U+${serverText.charCodeAt(i).toString(16).toUpperCase()})`);
+			logContext(clientContext);
+			logContext(serverContext);
 			break;
 		}
 	}


### PR DESCRIPTION
## Description

In order to help diagnose the cause of hash mismatches, this PR logs additional information about the error.

## Related Issues or Discussions

None

## QA Instructions, Screenshots, Recordings

When the `debugTextMismatch` function fires, this change causes additional data to be added to the log.

### Reviewer Checklist

1. Initiate a hash mismatch
2. Observe that the log window now contains additional data.

### Example of Log Output

<img width="405" height="136" alt="image" src="https://github.com/user-attachments/assets/1abc1c4a-bc98-4c8f-9be1-909645b59c16" />

