### PR TITLE
Fix final cursor positions on hotkeys

### DIFF
--- a/client/components/codeEditor/customKeyMaps.js
+++ b/client/components/codeEditor/customKeyMaps.js
@@ -103,23 +103,33 @@ const removeSpace = (view)=>{
 	return true;
 };
 
+// Wraps text in braces on same line, leaves cursor ready to add attributes.  Or, removes braces, ready to continue typing content.
 const makeSpan = (view)=>{
 	const { from, to } = view.state.selection.main;
 	const selected = view.state.doc.sliceString(from, to);
-	const text = selected.startsWith('{{') && selected.endsWith('}}')
+	const alreadyWrapped = selected.startsWith('{{') && selected.endsWith('}}');
+	const text = alreadyWrapped
 		? selected.slice(2, -2)
-		: `{{${selected}}}`;
-	view.dispatch({ changes: { from, to, insert: text } });
+		: `{{ ${selected}}}`;
+	view.dispatch({
+		changes   : { from, to, insert: text },
+		selection : { anchor: alreadyWrapped ? from + text.length : from + 2 }
+	});
 	return true;
 };
 
+// Wraps text in braces on new lines, leaves cursor ready to add attributes.  Or, removes braces and new lines, ready to continue typing content.
 const makeDiv = (view)=>{
 	const { from, to } = view.state.selection.main;
 	const selected = view.state.doc.sliceString(from, to);
-	const text = selected.startsWith('{{') && selected.endsWith('}}')
-		? selected.slice(2, -2)
+	const alreadyWrapped = selected.startsWith('{{\n') && selected.endsWith('\n}}');
+	const text = alreadyWrapped
+		? selected.slice(3, -3)
 		: `{{\n${selected}\n}}`;
-	view.dispatch({ changes: { from, to, insert: text } });
+	view.dispatch({
+		changes   : { from, to, insert: text },
+		selection : { anchor: alreadyWrapped ? from + text.length : from + 2 }
+	});
 	return true;
 };
 

--- a/client/components/codeEditor/customKeyMaps.js
+++ b/client/components/codeEditor/customKeyMaps.js
@@ -81,7 +81,10 @@ const makeSpace = (view)=>{
 		const percent = Math.min(parseInt(match[1], 10) + 10, 100);
 		newText = `{{width:${percent}% }}`;
 	}
-	view.dispatch({ changes: { from, to, insert: newText } });
+	view.dispatch({ 
+		changes   : { from, to, insert: newText },
+		selection : { anchor: from, head: from + newText.length }
+	});
 	return true;
 };
 
@@ -92,7 +95,10 @@ const removeSpace = (view)=>{
 	if(match) {
 		const percent = parseInt(match[1], 10) - 10;
 		const newText = percent > 0 ? `{{width:${percent}% }}` : '';
-		view.dispatch({ changes: { from, to, insert: newText } });
+		view.dispatch({ 
+			changes   : { from, to, insert: newText },
+			selection : { anchor: from, head: from + newText.length }
+		});
 	}
 	return true;
 };

--- a/client/components/codeEditor/customKeyMaps.js
+++ b/client/components/codeEditor/customKeyMaps.js
@@ -162,13 +162,21 @@ const makeHeader = (level)=>(view)=>{
 
 const newColumn = (view)=>{
 	const { from, to } = view.state.selection.main;
-	view.dispatch({ changes: { from, to, insert: '\n\\column\n\n' } });
+	const insert = '\n\\column\n\n';
+	view.dispatch({
+		changes   : { from, to, insert: insert },
+		selection : { anchor: from + insert.length }
+	});
 	return true;
 };
 
 const newPage = (view)=>{
 	const { from, to } = view.state.selection.main;
-	view.dispatch({ changes: { from, to, insert: '\n\\page\n\n' } });
+	const insert = '\n\\page\n\n';
+	view.dispatch({
+		changes   : { from, to, insert: insert },
+		selection : { anchor: from + insert.length }
+	});
 	return true;
 };
 


### PR DESCRIPTION
## Description

Revisits the keymaps/hotkeys/shortcuts to adjust the final cursor position/selection after snippets are added.  Since the editor update, snippets like `new page` are leaving their cursors at the start of the snippet string, which is annoying because then you need to move your cursor via keyboard or mouse to where you likely want it (in the case of new page, you want the cursor on that new page).

This PR doesn't yet hit every existing keymap.  Either it can sit and wallow until I do all of them, or just take this small chunk and throw it live.  Here is what it has:

- **New Column** and **New Page** keymaps:  final cursor position is at end of snippet
- **Make Space** / **Remove Space**: final cursor is the entire snippet as a range, so the hotkey can be pressed repeatedly to increase the space, or be decreased by using the *remove* hotkey.
- **Make Span** / **Make Div**: final cursor is place after the new opening brackets to be ready to type attributes/class name/id etc.  Removing the span/div leaves the cursor at the end of the selected text.

I do also have my own version of the wrapSelection function in the keymaps that apparently is a hot topic right now.  I'm spinning that into it's own PR.

### To-Do

- [ ] Headings (H1, H2, etc)
- [ ] Make Link
  - I'd be interested to get opinions on what final cursor position should be here...the whole snippet `[alt](url)`? Or just the `url` part?  Is it more important to allow quickly toggling the link syntax entirely, off and on?  Or to create the link syntax and then be ready to type the URL, or the alt text?
- [ ] Lists seem to be entirely broken on live site, particularly if trying to convert a series of lines into a list.
- [ ] Add tests




## Related Issues or Discussions

- Closes #4790

## QA Instructions, Screenshots, Recordings

Will update out of draft status.

<details>
<summary>
### Reviewer Checklist
</summary>

_Replace the list below with specific features you want reviewers to look at._

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Feature A does X
  - [ ] Feature B does Y
- [ ] Verify old features have not broken
  - [ ] Feature Z can still be used
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments

</details>
