### PR TITLE
fix: correct invalid HTML pattern attribute for language input (#4813)

### DIFF
--- a/client/components/combobox.jsx
+++ b/client/components/combobox.jsx
@@ -17,8 +17,7 @@ const Combobox = createReactClass({
 				suggestMethod           : 'includes',
 				filterOn                : []  // should allow as array to filter on multiple attributes, or even custom filter
 			},
-			valuePatterns : /.+/
-		};
+			valuePatterns : '.+';
 	},
 	getInitialState : function() {
 		this.dropdownRef = React.createRef();

--- a/client/homebrew/editor/metadataEditor/metadataEditor.jsx
+++ b/client/homebrew/editor/metadataEditor/metadataEditor.jsx
@@ -261,6 +261,7 @@ const MetadataEditor = createReactClass({
 					className='language-dropdown'
 					default={this.props.metadata.lang || ''}
 					placeholder='en'
+					valuePatterns='^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2})?$'
 					onSelect={(value)=>this.handleLanguage(value)}
 					onEntry={(e)=>{
 						e.target.setCustomValidity('');	//Clear the validation popup while typing


### PR DESCRIPTION
## Summary

Fixes the invalid `pattern` attribute for the language input field in the Homebrewery editor.

### Problem

The `pattern` attribute for the language input was using a JavaScript regex literal (`/.+/`) instead of a valid HTML pattern string. When passed to the HTML `pattern` attribute, this resulted in an invalid/inoperative validation pattern.

### Changes

1. **combobox.jsx**: Change `valuePatterns` default from `/+.+/` to `'.+'` (proper string)
   - HTML `pattern` attribute expects a string, not a JS regex literal

2. **metadataEditor.jsx**: Add BCP 47 language tag pattern: `^[a-z]{2,3}(-[A-Z][a-z]{3})?(-[A-Z]{2})?$`
   - Supports 2-3 letter language codes (en, eng, hac)
   - Supports 4-letter script codes (e.g., Hant for Traditional Chinese)
   - Supports optional 2-letter region codes (e.g., US, CN)

### Test

- [ ] Enter a language code like 'en', 'eng', 'Hant', 'en-US' in the language field — all should validate correctly
- [ ] Enter invalid input like 'xyz' — should be rejected

Fixes #4813