### PR TITLE
Accessibility: Add title to the brew render iframe.

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -28,7 +28,8 @@ const PAGE_HEIGHT = 1056;
 const TOOLBAR_STATE_KEY = 'HB_renderer_toolbarState';
 
 const INITIAL_CONTENT = dedent`
-	<!DOCTYPE html><html><head>
+	<!DOCTYPE html><html lang="en"><head>
+	<title>Rendered Brew Content</title>
 	<link href='/homebrew/bundle.css' type="text/css" rel='stylesheet' />
 	<link href="${brewRendererStylesUrl}" rel="stylesheet" />
 	<link href="${headerNavStylesUrl}" rel="stylesheet" />
@@ -91,7 +92,7 @@ const BrewPage = (props)=>{
 
 //v=====--------------------< Brew Renderer Component >-------------------=====v//
 let renderedPages = [];
-let pageTemplates = [];
+const pageTemplates = [];
 let rawPages      = [];
 
 const BrewRenderer = (props)=>{
@@ -210,7 +211,7 @@ const BrewRenderer = (props)=>{
 					classes    = [classes, injectedTags.classes].join(' ').trim();
 					attributes = injectedTags.attributes;
 					if(global.enablev4) {
-						if (attributes && Object.hasOwn(attributes, 'hbtemplate')) {
+						if(attributes && Object.hasOwn(attributes, 'hbtemplate')) {
 							pageTemplates[index] = attributes['hbtemplate'];
 						}
 					}
@@ -220,7 +221,7 @@ const BrewRenderer = (props)=>{
 					if(!pageTemplates[index]) {
 						for (let i=index;i>=0; i--) {
 							// If one is found, add the template attribute
-							if (pageTemplates[i]) attributes['hbtemplate'] = pageTemplates[i];
+							if(pageTemplates[i]) attributes['hbtemplate'] = pageTemplates[i];
 						}
 					}
 				}
@@ -348,7 +349,7 @@ const BrewRenderer = (props)=>{
 			<ToolBar displayOptions={displayOptions} onDisplayOptionsChange={handleDisplayOptionsChange} visiblePages={state.visiblePages.length > 0 ? state.visiblePages : [state.centerPage]} totalPages={rawPages.length} headerState={headerState} setHeaderState={setHeaderState}/>
 
 			{/*render in iFrame so broken code doesn't crash the site.*/}
-			<Frame id='BrewRenderer' initialContent={INITIAL_CONTENT}
+			<Frame id='BrewRenderer'  title="Rendered Brew Content" initialContent={INITIAL_CONTENT}
 				style={{ width: '100%', height: '100%', visibility: state.visibility }}
 				contentDidMount={frameDidMount}
 				onClick={()=>{emitClick();}}

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -92,7 +92,7 @@ const BrewPage = (props)=>{
 
 //v=====--------------------< Brew Renderer Component >-------------------=====v//
 let renderedPages = [];
-const pageTemplates = [];
+let pageTemplates = [];
 let rawPages      = [];
 
 const BrewRenderer = (props)=>{

--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -28,7 +28,7 @@ const PAGE_HEIGHT = 1056;
 const TOOLBAR_STATE_KEY = 'HB_renderer_toolbarState';
 
 const INITIAL_CONTENT = dedent`
-	<!DOCTYPE html><html lang="en"><head>
+	<!DOCTYPE html><html><head>
 	<title>Rendered Brew Content</title>
 	<link href='/homebrew/bundle.css' type="text/css" rel='stylesheet' />
 	<link href="${brewRendererStylesUrl}" rel="stylesheet" />


### PR DESCRIPTION
## Description

This adds lang and title tags for accessibility to the brew renderer iframe. The `title` is added as an attribute to the `iframe` but also as a `title` element in the iframe's head since some screen readers like voice over use that instead of the iframe's title. This change means that the iframe shows up in the rotor menu as something more than just "frame"

Bonus, this includes some changes made by the linter to this file.

## Related Issues or Discussions

- Closes # 
  - Currently no issue logged that I'm aware of. I haven't seen a lot of accessibility issues in the list.

## QA Instructions, Screenshots, Recordings

No visual change. On mac, you can turn on voice over, open the rotor (shift+cmd+u) and use the left/right arrow keys until you get a list of frames on the page, at which point you will see the change.
