### PR TITLE
Fix safeHTML attribute check

### DIFF
--- a/client/homebrew/brewRenderer/safeHTML.js
+++ b/client/homebrew/brewRenderer/safeHTML.js
@@ -32,12 +32,12 @@ function safeHTML(htmlString) {
 			return;
 		}
 		// Check remaining elements for blacklisted attributes
-		for (const attribute of element.attributes){
+		[...element.attributes].forEach((attribute)=>{
 			if(blacklistAttrs.some((test)=>{return test(attribute);})) {
-				element.removeAttribute(attribute.localName);
-				break;
+				element.removeAttribute(attribute.name);
+				return;
 			};
-		};
+		});
 	});
 
 	return div.innerHTML;

--- a/tests/html/safeHTML.test.js
+++ b/tests/html/safeHTML.test.js
@@ -43,6 +43,12 @@ test('Javascript via inline event handler - onMouseOver', function() {
 	expect(rendered).toBe('<div>Hover over me</div>');
 });
 
+test('Javascript via multiple inline event handlers - onClick + onMouseOver', function() {
+	const source = `<div onclick="alert('This is a JavaScript injection via inline event handler')" onmouseover="alert('This is a JavaScript injection via inline event handler')">Hover over or Click me</div>`;
+	const rendered = safeHTML(source);
+	expect(rendered).toBe('<div>Hover over or Click me</div>');
+});
+
 test('Javascript via data attribute', function() {
 	const source = `<div data-code="javascript:alert('This is a JavaScript injection via data attribute')">Test</div>`;
 	const rendered = safeHTML(source);


### PR DESCRIPTION
## Description

This PR changes how the element attributes are parsed as an iterable list, forcing a conversion from a `NamedNodeMap` to an `Array`.

## Related Issues or Discussions

- Closes #4904

## QA Instructions, Screenshots, Recordings

Check the element produced by this piece of code.
- In the current master, the `onclick` attribute persists.
- In this PR, all three `on` attributes are removed.


```HTML
<div
  id="myDiv"
  style="width:100%;height:50px;border:2px solid magenta;"
  onmouseenter="1"
  onclick="2"
  oninput="3"
  >
  TEST
</div>
```
