### PR TITLE
Add a sandbox property to the renderer iframe

### DIFF
--- a/client/homebrew/brewRenderer/brewRenderer.jsx
+++ b/client/homebrew/brewRenderer/brewRenderer.jsx
@@ -352,6 +352,7 @@ const BrewRenderer = (props)=>{
 				style={{ width: '100%', height: '100%', visibility: state.visibility }}
 				contentDidMount={frameDidMount}
 				onClick={()=>{emitClick();}}
+				sandbox="allow-same-origin allow-modals allow-top-navigation"
 			>
 				<div className='brewRenderer'
 					onKeyDown={handleControlKeys}


### PR DESCRIPTION
Prevents any script execution from within the the brew renderer.

Still allow for print (via allow-modals), same-origin downloads, and top navigation (so that links work).
