### PR TITLE
Add nav buttons to the tab order and use semantic buttons so they are interactable with the keyboard

### DIFF
--- a/client/homebrew/navbar/nav.jsx
+++ b/client/homebrew/navbar/nav.jsx
@@ -61,10 +61,10 @@ const Nav = {
 					{icon}
 				</a>;
 			} else {
-				return <div {...props} className={classes} onClick={this.handleClick} >
+				return <button {...props} className={classes} onClick={this.handleClick} >
 					{this.props.children}
 					{icon}
-				</div>;
+				</button>;
 			}
 		}
 	}),

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -320,7 +320,7 @@ const EditPage = (props)=>{
 
 		// #5 - No unsaved changes, and has never been saved, hide the button
 		if(neverSaved)
-			return <Nav.item className='save neverSaved'>save now</Nav.item>;
+			return <Nav.item className='save neverSaved' disabled={true}>save now</Nav.item>;
 
 		// DEFAULT - No unsaved changes, show SAVED
 		return <Nav.item className='save saved'>saved</Nav.item>;

--- a/client/homebrew/pages/homePage/homePage.jsx
+++ b/client/homebrew/pages/homePage/homePage.jsx
@@ -164,7 +164,7 @@ const HomePage =(props)=>{
 
 		// #5 - No unsaved changes, and has never been saved, hide the button
 		if(neverSaved)
-			return <Nav.item className='save neverSaved'>save now</Nav.item>;
+			return <Nav.item className='save neverSaved' disabled={true}>save now</Nav.item>;
 
 		// DEFAULT - No unsaved changes, show SAVED
 		return <Nav.item className='save saved'>saved</Nav.item>;

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -207,7 +207,7 @@ const NewPage = (props)=>{
 
 		// #5 - No unsaved changes, and has never been saved, hide the button
 		if(neverSaved)
-			return <Nav.item className='save neverSaved'>save now</Nav.item>;
+			return <Nav.item className='save neverSaved' disabled={true}>save now</Nav.item>;
 
 		// DEFAULT - No unsaved changes, show SAVED
 		return <Nav.item className='save saved'>saved</Nav.item>;


### PR DESCRIPTION
## Description

This change modifies many of the nav buttons to use semantic button elements instead of divs so that they are in the tab order and intractable with keyboard navigation.

## Related Issues or Discussions

[Make the Homebrewery meet Web Content Accessibility Guidelines(WCAG)](https://github.com/naturalcrit/homebrewery/issues/3032)

- Closes # None. This PR gets closer to WCAG accessibility getting more buttons in homebrewery to conform to [WCAG 2.1.1](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html)

## QA Instructions, Screenshots, Recordings

Use the TAB key to navigate the buttons in the nav and the ENTER key to activate them. Prior to this change, any element in the nav that wasn't a link was not accessible by keyboard.

### Reviewer Checklist

_Replace the list below with specific features you want reviewers to look at._

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Feature A does X
  - [ ] Feature B does Y
- [ ] Verify old features have not broken
  - [ ] Feature Z can still be used
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments
