### PR TITLE
Fix broken-image getting into a failure loop on /edit/ pages

### DIFF
--- a/client/components/codeEditor/extensions/customHighlight.js
+++ b/client/components/codeEditor/extensions/customHighlight.js
@@ -356,7 +356,7 @@ class ImageWidget extends WidgetType {
 		
 
 		img.onerror = ()=>{
-			img.src  = 'client/icons/broken-image.jpg';
+			img.src  = '/client/icons/broken-image.jpg';
 		};
 
 		return img;


### PR DESCRIPTION
This worked only on /new before, and not on /edit/ due to the lack of leading slash.

And because this request gets spammed due to it constantly failing, it causes a rather annoying CPU usage spike, especially if you're watching for network traffic in the console.
