### PR TITLE
Fix tab adding two spaces and then advancing the cursor two more spaces.

### DIFF
--- a/client/components/codeEditor/extensions/customKeyMaps.js
+++ b/client/components/codeEditor/extensions/customKeyMaps.js
@@ -83,7 +83,7 @@ const insertTab = (view)=>{
 		changes,
 		selection : EditorSelection.create(
 			view.state.selection.ranges.map((range)=>EditorSelection.cursor(
-				mappedChanges.changes.mapPos(range.from, 1) + 2
+				mappedChanges.changes.mapPos(range.from, 1)
 			)
 			)
 		)


### PR DESCRIPTION
## Description

Recent changes to the handling of TAB within code editor make it so that two spaces are added when tab is pressed, and then the cursor advances by two more spaces after that, leading to difficulties, especially if you press tab multiple times.

## Related Issues or Discussions

I believe the error was first introduced in this change: https://github.com/naturalcrit/homebrewery/commit/d440c7c6514efd09c68e715ae548a3ba7f553184

- Closes #

## QA Instructions, Screenshots, Recordings

Go into the editor and press TAB a few times and note the strange behavior without this fix.  After the fix it works (for me).

You can also validate that the multiple cursor behavior still works by using CTRL/CMD + Click to place multiple cursors and then press the tab key to validate that the tabs are inserted correctly and the cursor moves to the correct place.

### Reviewer Checklist

_Replace the list below with specific features you want reviewers to look at._

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Feature A does X
  - [ ] Feature B does Y
- [ ] Verify old features have not broken
  - [ ] Feature Z can still be used
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments
