### PR TITLE
Prefer position at the start of a tab insertion for the new cursor position

### DIFF
--- a/client/components/codeEditor/extensions/customKeyMaps.js
+++ b/client/components/codeEditor/extensions/customKeyMaps.js
@@ -83,7 +83,7 @@ const insertTab = (view)=>{
 		changes,
 		selection : EditorSelection.create(
 			view.state.selection.ranges.map((range)=>EditorSelection.cursor(
-				mappedChanges.changes.mapPos(range.from, 1) + 2
+				mappedChanges.changes.mapPos(range.from, -1) + 2
 			)
 			)
 		)


### PR DESCRIPTION
## Description

Currently on `master` when you insert a single tab two `space` characters are inserted and then the cursor is moved two more spaces.

This seems to be because the changeset we get back from the state update was passing `1` to mapPos so it was preferring to find the cursor position at the end of the insertion. This worked for some types of tab presses but not others (see the test cases below). By passing a negative number it prefers to keep the position before the insertion.

[Code Mirror mapPos reference](https://codemirror.net/docs/ref/#state.ChangeDesc.mapPos)

## Related Issues or Discussions

I believe the error was first introduced in this change: https://github.com/naturalcrit/homebrewery/commit/d440c7c6514efd09c68e715ae548a3ba7f553184

- Closes #

## QA Instructions, Screenshots, Recordings

Multiple insertion modes should be tested.

* Press `tab` while only having a single cursor and nothing highlight. Two spaces should be inserted and the cursor should be at the end of the two spaces.
* Highlight one character and press `tab`.  The character should be replaced by two spaces and the cursor ends up at the end.
* Highlight multiple characters or words and press `tab`. The selection should be replaced by two spaces and the cursor is at the end of the two new spaces.
* Do the above in any combination using CTRL/CMD + Click to place multiple cursors or create multiple selections.

### Reviewer Checklist

_Replace the list below with specific features you want reviewers to look at._

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Feature A does X
  - [ ] Feature B does Y
- [ ] Verify old features have not broken
  - [ ] Feature Z can still be used
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments
