### PR TITLE
Centralize API.getBrew descended calls to splitTextStyleAndMetadata.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12085,21 +12085,6 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
-      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
-      "extraneous": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "gaxios": "^7.0.0",
-        "google-logging-utils": "^1.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",

--- a/server/admin.api.js
+++ b/server/admin.api.js
@@ -13,7 +13,6 @@ const isProd = nodeEnv === 'production';
 
 import HomebrewAPI  from './homebrew.api.js';
 import asyncHandler from 'express-async-handler';
-import { splitTextStyleAndMetadata } from '../shared/helpers.js';
 
 process.env.ADMIN_USER = process.env.ADMIN_USER || 'admin';
 process.env.ADMIN_PASS = process.env.ADMIN_PASS || 'password3';
@@ -147,8 +146,6 @@ export default function createAdminApi(vite) {
 		properties.forEach((property)=>{
 			brew[property] = cleanText(brew[property]);
 		});
-
-		splitTextStyleAndMetadata(brew);
 
 		req.body = brew;
 

--- a/server/app.js
+++ b/server/app.js
@@ -395,7 +395,6 @@ export default async function createApp(vite) {
 		};
 
 		sanitizeBrew(req.brew, 'edit');
-		splitTextStyleAndMetadata(req.brew);
 		res.header('Cache-Control', 'no-cache, no-store');	//reload the latest saved brew when pressing back button, not the cached version before save.
 		return next();
 	}));
@@ -403,7 +402,6 @@ export default async function createApp(vite) {
 	//New Page from ID
 	app.get('/new/:id', asyncHandler(getBrew('share')), asyncHandler(async(req, res, next)=>{
 		sanitizeBrew(req.brew, 'share');
-		splitTextStyleAndMetadata(req.brew);
 		const brew = {
 			shareId  : req.brew.shareId,
 			title    : `CLONE - ${req.brew.title}`,
@@ -461,7 +459,6 @@ export default async function createApp(vite) {
 		};
 
 		brew.authors.includes(req.account?.username) ? sanitizeBrew(req.brew, 'shareAuthor') : sanitizeBrew(req.brew, 'share');
-		splitTextStyleAndMetadata(req.brew);
 		return next();
 	}));
 

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -192,13 +192,13 @@ const api = {
 
 			const fixedStub = migrateSystemsToTags(stub);
 			req.brew = fixedStub;
+			splitTextStyleAndMetadata(req.brew);
 			next();
 		};
 	},
 	getCSS : async (req, res)=>{
 		const { brew } = req;
 		if(!brew) return res.status(404).send('');
-		splitTextStyleAndMetadata(brew);
 		if(!brew.style) return res.status(404).send('');
 
 		res.set({
@@ -344,7 +344,6 @@ const api = {
 					});
 
 				currentTheme = req.brew;
-				splitTextStyleAndMetadata(currentTheme);
 				if(!currentTheme.tags.some((tag)=>tag === 'meta:theme' || tag === 'meta:Theme'))
 					throw { brewId: req.params.id, name: 'Invalid Theme Selected', message: 'Selected theme does not have the meta:theme tag', status: 422, HBErrorCode: '10' };
 				themeName   ??= currentTheme.title;
@@ -383,7 +382,6 @@ const api = {
 		// Initialize brew from request and body, destructure query params, and set the initial value for the after-save method
 		const brewFromClient = api.excludePropsFromUpdate(req.body);
 		const brewFromServer = req.brew;
-		splitTextStyleAndMetadata(brewFromServer);
 
 		if(brewFromServer?.version !== brewFromClient?.version){
 			console.log(`Version mismatch on brew ${brewFromClient.editId}`);


### PR DESCRIPTION
## Description

This moves the calls to splitTextStyleAndMetadata inside of getBrew()  and removes those few calls that could potentially have failed a race condition.

This does not address "static" pages nor change tests that called splitTextStyleAndMetadata in their own fashion.

## Related Issues or Discussions

- Closes #4975

## QA Instructions, Screenshots, Recordings

Test with large brews on undersized machines.

### Reviewer Checklist

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] Frontmatter is split as expected
  - [ ] Poorly sized and/or slow devices can correctly load large brews.
- [ ] Verify old features have not broken
  - [ ] Tests still pass
- [ ] Check for code legibility and appropriate comments
