### PR TITLE
tweak filter placeholder on userpages

### DIFF
--- a/client/homebrew/pages/basePages/listPage/listPage.jsx
+++ b/client/homebrew/pages/basePages/listPage/listPage.jsx
@@ -165,7 +165,7 @@ const ListPage = ({ brewCollection = [{ title: '', class: '', brews: [] }], navI
 			<div className='filter-option'>
 				<label>
 					<i className='fas fa-search'></i>
-					<input type='search' placeholder='filter title/description' onChange={handleFilterTextChange} value={filterString} />
+					<input type='search' placeholder='filter title/description/tags' onChange={handleFilterTextChange} value={filterString} />
 				</label>
 			</div>
 		);


### PR DESCRIPTION
## Description

Per #4979, the userpage filter does search the text of brew tags.

was "filter title/description"
now "filter title/description/tags"


## Related Issues or Discussions

- Closes #4979

### Reviewer Checklist

- [ ] did I spell "tags" right?