### PR TITLE
Fix background color in local installations

### DIFF
--- a/client/homebrew/homebrew.jsx
+++ b/client/homebrew/homebrew.jsx
@@ -61,7 +61,7 @@ const Homebrew = (props)=>{
 	if(brew.pureError) {
 		return (
 			<Router>
-				<div className={`homebrew${(config?.deployment || config?.local) ? ' deployment' : ''}`} style={backgroundObject()}>
+				<div className={`homebrew${(config?.deployment || (config?.local && config?.development)) ? ' deployment' : ''}`} style={backgroundObject()}>
 					<Routes>
 						<Route path={brew.originalUrl} element={<WithRoute el={ErrorPage} brew={brew} />} />
 					</Routes>
@@ -73,7 +73,7 @@ const Homebrew = (props)=>{
 
 	return (
 		<Router>
-			<div className={`homebrew${(config?.deployment || config?.local) ? ' deployment' : ''}`} style={backgroundObject()}>
+			<div className={`homebrew${(config?.deployment || (config?.local && config?.development)) ? ' deployment' : ''}`} style={backgroundObject()}>
 				<Routes>
 					<Route path='/edit/:id' element={<WithRoute el={EditPage} brew={brew} userThemes={userThemes}/>} />
 					<Route path='/share/:id' element={<WithRoute el={SharePage} brew={brew} />} />

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,5 @@
 {
-	"development": true,
+	"development": false,
 	"host" : "homebrewery.local.naturalcrit.com:8000",
 	"naturalcrit_url" : "local.naturalcrit.com:8010",
 	"secret" : "secret",

--- a/server/app.js
+++ b/server/app.js
@@ -561,7 +561,8 @@ export default async function createApp(vite) {
 			publicUrl   : config.get('publicUrl') ?? '',
 			baseUrl     : `${req.protocol}://${req.get('host')}`,
 			environment : nodeEnv,
-			deployment  : config.get('heroku_app_name') ?? ''
+			deployment  : config.get('heroku_app_name') ?? '',
+			development : config.get('development')
 		};
 		const props = {
 			version     : version,


### PR DESCRIPTION
This PR changes the default value of the `development` config property to FALSE, and adds it to the checks in `homebrew.jsx` to set the class for the background color in exactly the same way that it was already set for the background object (containing the SVG for deployment name, etc).

### Screenshots

`development`: FALSE

<img width="923" height="631" alt="image" src="https://github.com/user-attachments/assets/bd109fbc-fee9-4657-a633-bd318f8a3bff" />

---

`development`: TRUE

<img width="928" height="691" alt="image" src="https://github.com/user-attachments/assets/cb7c292a-e9e7-4b6f-80e3-39802df52a98" />

