### PR TITLE
Fix page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,15 @@
 
   			let prefix = '';
 
+			// Default page title
+			let result ='The Homebrewery';
+
+			// Add brew title, if it exists
+			if (title) {
+  				result = `${title} - ${result}`;
+  			}
+
+			// Add prefix for Stage/PR Deployment/Local install
   			if (url && url?.includes('://homebrewery-stage.')) {
   				prefix = `Stage `;
   			} else if (url?.includes('://homebrewery-pr-')) {
@@ -30,11 +39,12 @@
   				prefix = 'Local ';
   			}
 
-  			if (title) {
-  				document.title = `${prefix} - ${title} - The Homebrewery`;
-  			} else if (prefix) {
-				document.title = `${prefix} - The Homebrewery`;
+			if (prefix) {
+				result = `${prefix} - ${result}`;
 			}
+
+			// Set page title
+			document.title = result;
 
 			if (window.location.pathname.startsWith('/admin')) {
 				import('/client/admin/main.jsx');


### PR DESCRIPTION
This PR changes the logic for determining the page title. It should no longer be possible to have page titles with a leading hyphen.

The logic breaks down as follows:

1. Set the result to "The Homebrewery:
2. If a brew title exists, prepend it with a hyphen separator
3. If a staging environment is detected (stage/PR deployment/local install) then prepend the appropriate descriptor, again with a hyphen separator
4. Set the page title to the result