### PR TITLE
Fix SharePage crash on FireFox

### DIFF
--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -146,7 +146,7 @@ const printCurrentBrew = async ()=>{
 	}
 };
 
-const fetchThemeBundle = async (setError, setThemeBundle, renderer, theme)=>{
+const fetchThemeBundle = async (setError = ()=>{}, setThemeBundle = ()=>{}, renderer, theme)=>{
 	if(!renderer || !theme) return;
 	const res = await request
 			.get(`/api/theme/${renderer}/${theme}`)


### PR DESCRIPTION
After the recent update, SharePage is crashing on Firefox. Investigation has shown that an error is being thrown in `fetchThemeBundle` due to the function being called with the `setError` parameter set to `undefined`, rather than an actual function.

This PR creates a default value for the `setError` and `setThemeBundle` functions, which is an empty function (`() => {}`).