### PR TITLE
Add "Style" snippets

### DIFF
--- a/client/homebrew/editor/snippetbar/snippetbar.jsx
+++ b/client/homebrew/editor/snippetbar/snippetbar.jsx
@@ -149,7 +149,8 @@ const Snippetbar = createReactClass({
 		}
 
 		const userSnippetsasJSON = brewSnippetsToJSON(this.props.brew.title || 'New Document', this.props.brew.snippets, this.props.themeBundle.snippets);
-		compiledSnippets.push(userSnippetsasJSON);
+		compiledSnippets.push(userSnippetsasJSON.snippets);
+		compiledSnippets.push(userSnippetsasJSON.styles);
 
 		return compiledSnippets;
 	},

--- a/server/homebrew.api.js
+++ b/server/homebrew.api.js
@@ -216,8 +216,8 @@ const api = {
 				`${text}`;
 		}
 		const metadata = _.pick(brew, ['title', 'description', 'tags', 'renderer', 'theme']);
-		const snippetsArray = brewSnippetsToJSON('brew_snippets', brew.snippets, null, false).snippets;
-		metadata.snippets = snippetsArray.length > 0 ? snippetsArray : undefined;
+		const snippetsStyles = brewSnippetsToJSON(null, brew.snippets, null, false);
+		metadata.snippets = snippetsStyles ? snippetsStyles : undefined;
 		metadata.bleedSize = { top: brew?.bleedSize?.top, bottom: brew?.bleedSize?.bottom, inner: brew?.bleedSize?.inner, outer: brew?.bleedSize?.outer };
 		metadata.safetySpace = { top: brew?.safetySpace?.top, bottom: brew?.safetySpace?.bottom, outer: brew?.safetySpace?.outer, inner: brew?.safetySpace?.inner };
 		metadata.trimSize  = { width: brew?.trimSize?.width, height: brew?.trimSize?.height };

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -4,31 +4,46 @@ import request from '../client/homebrew/utils/request-middleware.js';
 
 // Convert the templates from a brew to a Snippets Structure.
 const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=null, full=true)=>{
-	const textSplit  = /^(\\snippet +.+\n)/gm;
+	const textSplit  = /^(\\(snippet|style) +.+\n)/gm;
+	const titleSplit  = /^(\\(snippet|style) +(.+))/;
 	const mpAsSnippets = [];
+	const mpAsStyles = [];
 	// Snippets from Themes first.
 	if(themeBundleSnippets) {
 		for (const themes of themeBundleSnippets) {
 			if(typeof themes !== 'string') {
-				const userSnippets = [];
-				const snipSplit = themes.snippets.trim().split(textSplit).slice(1);
-				for (let snips = 0; snips < snipSplit.length; snips+=2) {
-					if(!snipSplit[snips].startsWith('\\snippet ')) break;
-					const snippetName = snipSplit[snips].split(/\\snippet +/)[1].split('\n')[0].trim();
+				const userSnippets = {
+						snippet : [],
+						style :[]
+				};
+				const snipSplit = userBrewSnippets.trim().split(textSplit).slice(1);
+				for (let snips = 0; snips < snipSplit.length; snips+=3) {
+					if((!snipSplit[snips].startsWith('\\snippet ')) && (!snipSplit[snips].startsWith('\\style '))) break;
+					const snipStyleLabel = titleSplit.exec(snipSplit[snips]);
+					if(!['style', 'snippet'].includes(snipStyleLabel[2])) break;
+					const snippetName = snipStyleLabel[3].trim();
 					if(snippetName.length != 0) {
 						userSnippets.push({
 							name : snippetName,
 							icon : '',
-							gen  : snipSplit[snips + 1].replace(/\n$/, ''),
+							gen  : snipSplit[snips + 2].replace(/\n$/, ''),
 						});
 					}
 				}
-				if(userSnippets.length > 0) {
+				if(userSnippets.snippet.length > 0) {
 					mpAsSnippets.push({
 						name        : themes.name,
 						icon        : '',
 						gen         : '',
-						subsnippets : userSnippets
+						subsnippets : userSnippets.snippet
+					});
+				}
+				if(userSnippets.style.length > 0) {
+					mpAsSnippets.push({
+						name        : themes.name,
+						icon        : '',
+						gen         : '',
+						subsnippets : userSnippets.style
 					});
 				}
 			}
@@ -36,37 +51,56 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=nul
 	}
 	// Local Snippets
 	if(userBrewSnippets) {
-		const userSnippets = [];
+		const userSnippets = {
+				snippet : [],
+				style :[]
+		};
 		const snipSplit = userBrewSnippets.trim().split(textSplit).slice(1);
-		for (let snips = 0; snips < snipSplit.length; snips+=2) {
-			if(!snipSplit[snips].startsWith('\\snippet ')) break;
-			const snippetName = snipSplit[snips].split(/\\snippet +/)[1].split('\n')[0].trim();
+		for (let snips = 0; snips < snipSplit.length; snips+=3) {
+			const snipStyleLabel = titleSplit.exec(snipSplit[snips]);
+			if(!['style', 'snippet'].includes(snipStyleLabel[2])) break;
+			const snippetName = snipStyleLabel[3].trim();
 			if(snippetName.length != 0) {
 				const subSnip = {
 					name : snippetName,
-					gen  : snipSplit[snips + 1].replace(/\n$/, ''),
+					gen  : snipSplit[snips + 2].replace(/\n$/, ''),
 				};
 				// if(full) subSnip.icon = '';
-				userSnippets.push(subSnip);
+				userSnippets[snipStyleLabel[2]].push(subSnip);
 			}
 		}
-		if(userSnippets.length) {
+		if(userSnippets.snippet?.length) {
 			mpAsSnippets.push({
-				name        : menuTitle,
+				name        : menuTitle || 'brew_snippets',
 				// icon        : '',
-				subsnippets : userSnippets
+				subsnippets : userSnippets.snippet
+			});
+		}
+		if(userSnippets.style?.length) {
+			mpAsStyles.push({
+				name        : menuTitle || 'brew_styles',
+				// icon        : '',
+				subsnippets : userSnippets.style
 			});
 		}
 	}
 
 	const returnObj = {
-		snippets : mpAsSnippets
+		snippets :  {
+			snippets: mpAsSnippets,
+		},
+		styles :   {
+			snippets: mpAsStyles
+		}
 	};
 
 	if(full) {
-		returnObj.groupName = 'Brew Snippets';
-		returnObj.icon = 'fas fa-th-list';
-		returnObj.view = 'text';
+		returnObj.snippets.groupName = 'Brew Snippets';
+		returnObj.snippets.icon = 'fas fa-th-list';
+		returnObj.snippets.view = 'text';
+		returnObj.styles.groupName = 'Brew Styles';
+		returnObj.styles.icon = 'fas fa-th-list';
+		returnObj.styles.view = 'style';
 	}
 
 	return returnObj;
@@ -77,9 +111,25 @@ const yamlSnippetsToText = (yamlObj)=>{
 
 	let snippetsText = '';
 
-	for (const snippet of yamlObj) {
+	console.log(yamlObj);
+	if(!yamlObj?.snippets) {
+		for (const snippet of yamlObj) {
+			for (const subSnippet of snippet.subsnippets) {
+				snippetsText = `${snippetsText}\\snippet ${subSnippet.name}\n${subSnippet.gen || ''}\n`;
+			}
+		}
+
+		return snippetsText;
+	}
+
+	for (const snippet of yamlObj.snippets) {
 		for (const subSnippet of snippet.subsnippets) {
 			snippetsText = `${snippetsText}\\snippet ${subSnippet.name}\n${subSnippet.gen || ''}\n`;
+		}
+	}
+	for (const snippet of yamlObj.styles) {
+		for (const subSnippet of snippet.subsnippets) {
+			snippetsText = `${snippetsText}\\style ${subSnippet.name}\n${subSnippet.gen || ''}\n`;
 		}
 	}
 	return snippetsText;

--- a/shared/helpers.js
+++ b/shared/helpers.js
@@ -12,38 +12,38 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=nul
 	if(themeBundleSnippets) {
 		for (const themes of themeBundleSnippets) {
 			if(typeof themes !== 'string') {
-				const userSnippets = {
-						snippet : [],
-						style :[]
+				const themeSnippets = {
+					snippet : [],
+					style   : []
 				};
-				const snipSplit = userBrewSnippets.trim().split(textSplit).slice(1);
+				const snipSplit = themes.snippets.trim().split(textSplit).slice(1);
 				for (let snips = 0; snips < snipSplit.length; snips+=3) {
 					if((!snipSplit[snips].startsWith('\\snippet ')) && (!snipSplit[snips].startsWith('\\style '))) break;
 					const snipStyleLabel = titleSplit.exec(snipSplit[snips]);
 					if(!['style', 'snippet'].includes(snipStyleLabel[2])) break;
 					const snippetName = snipStyleLabel[3].trim();
 					if(snippetName.length != 0) {
-						userSnippets.push({
+						themeSnippets[snipStyleLabel[2]].push({
 							name : snippetName,
 							icon : '',
 							gen  : snipSplit[snips + 2].replace(/\n$/, ''),
 						});
 					}
 				}
-				if(userSnippets.snippet.length > 0) {
+				if(themeSnippets.snippet.length > 0) {
 					mpAsSnippets.push({
 						name        : themes.name,
 						icon        : '',
 						gen         : '',
-						subsnippets : userSnippets.snippet
+						subsnippets : themeSnippets.snippet
 					});
 				}
-				if(userSnippets.style.length > 0) {
-					mpAsSnippets.push({
+				if(themeSnippets.style.length > 0) {
+					mpAsStyles.push({
 						name        : themes.name,
 						icon        : '',
 						gen         : '',
-						subsnippets : userSnippets.style
+						subsnippets : themeSnippets.style
 					});
 				}
 			}
@@ -52,8 +52,8 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=nul
 	// Local Snippets
 	if(userBrewSnippets) {
 		const userSnippets = {
-				snippet : [],
-				style :[]
+			snippet : [],
+			style :[]
 		};
 		const snipSplit = userBrewSnippets.trim().split(textSplit).slice(1);
 		for (let snips = 0; snips < snipSplit.length; snips+=3) {
@@ -86,11 +86,11 @@ const brewSnippetsToJSON = (menuTitle, userBrewSnippets, themeBundleSnippets=nul
 	}
 
 	const returnObj = {
-		snippets :  {
-			snippets: mpAsSnippets,
+		snippets : {
+			snippets : mpAsSnippets,
 		},
-		styles :   {
-			snippets: mpAsStyles
+		styles : {
+			snippets : mpAsStyles
 		}
 	};
 
@@ -111,7 +111,6 @@ const yamlSnippetsToText = (yamlObj)=>{
 
 	let snippetsText = '';
 
-	console.log(yamlObj);
 	if(!yamlObj?.snippets) {
 		for (const snippet of yamlObj) {
 			for (const subSnippet of snippet.subsnippets) {
@@ -122,12 +121,12 @@ const yamlSnippetsToText = (yamlObj)=>{
 		return snippetsText;
 	}
 
-	for (const snippet of yamlObj.snippets) {
+	for (const snippet of yamlObj.snippets.snippets) {
 		for (const subSnippet of snippet.subsnippets) {
 			snippetsText = `${snippetsText}\\snippet ${subSnippet.name}\n${subSnippet.gen || ''}\n`;
 		}
 	}
-	for (const snippet of yamlObj.styles) {
+	for (const snippet of yamlObj.styles.snippets) {
 		for (const subSnippet of snippet.subsnippets) {
 			snippetsText = `${snippetsText}\\style ${subSnippet.name}\n${subSnippet.gen || ''}\n`;
 		}


### PR DESCRIPTION
## Description

Adds a new snippet opening tag `\style`. This tells the snippets parser to place the snippet in a separate menu object that has a view of `style`.

As a clarifier, `\text` is an in-place replacement for `\snippet` to indicate  a text-inserting snippet.

Some of this is a little ugly trying to dance around refactoring too much.

To-do:
 - [ ] Update Tests
 - [ ] Update style editor syntax highlighting

## Related Issues or Discussions

- Closes #4998
- Blocked by #4972

### Reviewer Checklist

DO NOT TEST WITH BREWS YOU WANT TO RECOVER. CLONE FIRST.

*Reviewers, refer to this list when testing features, or suggest new items *
- [ ] Verify new features are functional
  - [ ] `\style` is picked up and added to Style editor menu
  - [ ] `\style` is inherited from Brew templates.
- [ ] Verify old features have not broken
  - [ ] User snippets still work
  - [ ] Theme-inherited snippets still work.
- [ ] Test for edge cases / try to break things
  - [ ] Feature A handles negative numbers
- [ ] Identify opportunities for simplification and refactoring
- [ ] Check for code legibility and appropriate comments
