### PR TITLE
New/Edit/Home Move setup effects to common functions

### DIFF
--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -8,7 +8,6 @@ import { hbfm } from 'hbmarkedwrapper';
 import _                                      from 'lodash';
 
 import { DEFAULT_BREW_LOAD }                  from '../../../../server/brewDefaults.js';
-import { printCurrentBrew, fetchThemeBundle } from '@shared/helpers.js';
 
 import useCommonEditPageFunctions from '../../utils/commonEditPageFunctions.js'
 
@@ -43,7 +42,6 @@ const SAVE_TIMEOUT = 10000;
 const UNSAVED_WARNING_TIMEOUT = 900000; //Warn user afer 15 minutes of unsaved changes
 const UNSAVED_WARNING_POPUP_TIMEOUT = 4000; //Show the warning for 4 seconds
 
-const AUTOSAVE_KEY = 'HB_editor_autoSaveOn';
 const BREWKEY  = 'HB_newPage_content';
 const STYLEKEY = 'HB_newPage_style';
 const SNIPKEY  = 'HB_newPage_snippets';
@@ -90,14 +88,21 @@ const EditPage = (props)=>{
 		setThemeBundle,
 		HTMLErrors,
 		setHTMLErrors,
+		currentBrew,
 		setCurrentBrew,
 		useLocalStorage,
 		BREWKEY,
 		STYLEKEY,
 		SNIPKEY,
 		METAKEY,
-		fetchThemeBundle,
-		hbfm	
+		hbfm,
+		autoSaveEnabled,
+		setAutoSaveEnabled,
+		setWarnUnsavedChanges,
+		trySaveRef,
+		unsavedChangesRef,
+		sandbox,
+		saveGoogle
 	});
 
 	useEffect(()=>{

--- a/client/homebrew/pages/editPage/editPage.jsx
+++ b/client/homebrew/pages/editPage/editPage.jsx
@@ -101,36 +101,6 @@ const EditPage = (props)=>{
 	});
 
 	useEffect(()=>{
-		const autoSavePref = !sandbox && JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
-
-		setAutoSaveEnabled(autoSavePref);
-		setWarnUnsavedChanges(!autoSavePref);
-		setHTMLErrors(hbfm.validate(currentBrew.text));
-		fetchThemeBundle(setError, setThemeBundle, currentBrew.renderer, currentBrew.theme);
-
-		const handleControlKeys = (e)=>{
-			if(!(e.ctrlKey || e.metaKey)) return;
-			if(e.keyCode === 83) trySaveRef.current(true, true, saveGoogle);
-			if(e.keyCode === 80) printCurrentBrew();
-			if([83, 80].includes(e.keyCode)) {
-				e.stopPropagation();
-				e.preventDefault();
-			}
-		};
-
-		document.addEventListener('keydown', handleControlKeys);
-		window.onbeforeunload = ()=>{
-			if(unsavedChangesRef.current)
-				return 'You have unsaved changes!';
-		};
-
-		return ()=>{
-			document.removeEventListener('keydown', handleControlKeys);
-			window.onbeforeunload = null;
-		};
-	}, []);
-
-	useEffect(()=>{
 		trySaveRef.current = trySave;
 		unsavedChangesRef.current = unsavedChanges;
 	});

--- a/client/homebrew/pages/homePage/homePage.jsx
+++ b/client/homebrew/pages/homePage/homePage.jsx
@@ -87,36 +87,6 @@ const HomePage =(props)=>{
 	});
 
 	useEffect(()=>{
-		const autoSavePref = !sandbox && JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
-
-		setAutoSaveEnabled(autoSavePref);
-		setWarnUnsavedChanges(!autoSavePref);
-		setHTMLErrors(hbfm.validate(currentBrew.text));
-		fetchThemeBundle(setError, setThemeBundle, currentBrew.renderer, currentBrew.theme);
-
-		const handleControlKeys = (e)=>{
-			if(!(e.ctrlKey || e.metaKey)) return;
-			if(e.keyCode === 83) trySaveRef.current(true);
-			if(e.keyCode === 80) printCurrentBrew();
-			if([83, 80].includes(e.keyCode)) {
-				e.stopPropagation();
-				e.preventDefault();
-			}
-		};
-
-		document.addEventListener('keydown', handleControlKeys);
-		window.onbeforeunload = ()=>{
-			if(unsavedChangesRef.current)
-				return 'You have unsaved changes!';
-		};
-
-		return ()=>{
-			document.removeEventListener('keydown', handleControlKeys);
-			window.onbeforeunload = null;
-		};
-	}, []);
-
-	useEffect(()=>{
 		unsavedChangesRef.current = unsavedChanges;
 	}, [unsavedChanges]);
 

--- a/client/homebrew/pages/homePage/homePage.jsx
+++ b/client/homebrew/pages/homePage/homePage.jsx
@@ -8,7 +8,6 @@ import { hbfm } from 'hbmarkedwrapper';
 import _                                      from 'lodash';
 
 import { DEFAULT_BREW }                       from '../../../../server/brewDefaults.js';
-import { printCurrentBrew, fetchThemeBundle } from '@shared/helpers.js';
 
 import useCommonEditPageFunctions from '../../utils/commonEditPageFunctions.js'
 
@@ -36,7 +35,6 @@ const SAVE_TIMEOUT = 10000;
 const UNSAVED_WARNING_TIMEOUT = 900000; //Warn user afer 15 minutes of unsaved changes
 const UNSAVED_WARNING_POPUP_TIMEOUT = 4000; //Show the warning for 4 seconds
 
-const AUTOSAVE_KEY = 'HB_editor_autoSaveOn';
 const BREWKEY  = 'HB_newPage_content';
 const STYLEKEY = 'HB_newPage_style';
 const SNIPKEY  = 'HB_newPage_snippets';
@@ -67,6 +65,7 @@ const HomePage =(props)=>{
 	const editorRef         = useRef(null);
 	const lastSavedBrew     = useRef(_.cloneDeep(props.brew));
 	const warnUnsavedTimeout = useRef(null);
+	const trySaveRef         = useRef(null); // CTRL+S listener lives outside React and needs ref to use trySave with latest copy of brew
 	const unsavedChangesRef = useRef(unsavedChanges);
 
 	const {
@@ -76,14 +75,20 @@ const HomePage =(props)=>{
 		setThemeBundle,
 		HTMLErrors,
 		setHTMLErrors,
+		currentBrew,
 		setCurrentBrew,
 		useLocalStorage,
 		BREWKEY,
 		STYLEKEY,
 		SNIPKEY,
 		METAKEY,
-		fetchThemeBundle,
-		hbfm	
+		hbfm,
+		autoSaveEnabled,
+		setAutoSaveEnabled,
+		setWarnUnsavedChanges,
+		trySaveRef,
+		unsavedChangesRef,
+		sandbox
 	});
 
 	useEffect(()=>{

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -32,7 +32,6 @@ const SAVE_TIMEOUT = 10000;
 const UNSAVED_WARNING_TIMEOUT = 900000; //Warn user afer 15 minutes of unsaved changes
 const UNSAVED_WARNING_POPUP_TIMEOUT = 4000; //Show the warning for 4 seconds
 
-const AUTOSAVE_KEY = 'HB_editor_autoSaveOn';
 const BREWKEY  = 'HB_newPage_content';
 const STYLEKEY = 'HB_newPage_style';
 const SNIPKEY  = 'HB_newPage_snippets';
@@ -81,14 +80,20 @@ const NewPage = (props)=>{
 		setThemeBundle,
 		HTMLErrors,
 		setHTMLErrors,
+		currentBrew,
 		setCurrentBrew,
 		useLocalStorage,
 		BREWKEY,
 		STYLEKEY,
 		SNIPKEY,
 		METAKEY,
-		fetchThemeBundle,
-		hbfm	
+		hbfm,
+		autoSaveEnabled,
+		setAutoSaveEnabled,
+		setWarnUnsavedChanges,
+		trySaveRef,
+		unsavedChangesRef,
+		sandbox
 	});
 
 	const loadBrew = ()=>{

--- a/client/homebrew/pages/newPage/newPage.jsx
+++ b/client/homebrew/pages/newPage/newPage.jsx
@@ -91,36 +91,6 @@ const NewPage = (props)=>{
 		hbfm	
 	});
 
-	useEffect(()=>{
-		const autoSavePref = !sandbox && JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
-
-		setAutoSaveEnabled(autoSavePref);
-		setWarnUnsavedChanges(!autoSavePref);
-		setHTMLErrors(hbfm.validate(currentBrew.text));
-		fetchThemeBundle(setError, setThemeBundle, currentBrew.renderer, currentBrew.theme);
-
-		const handleControlKeys = (e)=>{
-			if(!(e.ctrlKey || e.metaKey)) return;
-			if(e.keyCode === 83) trySaveRef.current(true);
-			if(e.keyCode === 80) printCurrentBrew();
-			if([83, 80].includes(e.keyCode)) {
-				e.stopPropagation();
-				e.preventDefault();
-			}
-		};
-
-		document.addEventListener('keydown', handleControlKeys);
-		window.onbeforeunload = ()=>{
-			if(unsavedChangesRef.current)
-				return 'You have unsaved changes!';
-		};
-
-		return ()=>{
-			document.removeEventListener('keydown', handleControlKeys);
-			window.onbeforeunload = null;
-		};
-	}, []);
-
 	const loadBrew = ()=>{
 		const brew = { ...currentBrew };
 		if(!brew.shareId && typeof window !== 'undefined') { //Load from localStorage if in client browser

--- a/client/homebrew/utils/commonEditPageFunctions.js
+++ b/client/homebrew/utils/commonEditPageFunctions.js
@@ -1,23 +1,36 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { printCurrentBrew, fetchThemeBundle } from '@shared/helpers.js';
+
+const AUTOSAVE_KEY = 'HB_editor_autoSaveOn';
+
 export default function useCommonEditPageFunctions(dependencies) {
     const {
         setError,
         setThemeBundle,
         HTMLErrors,
         setHTMLErrors,
+        currentBrew,
         setCurrentBrew,
         useLocalStorage,
         BREWKEY,
         STYLEKEY,
         SNIPKEY,
         METAKEY,
-        fetchThemeBundle,
-        hbfm
+        hbfm,
+        autoSaveEnabled,
+        setAutoSaveEnabled,
+        setWarnUnsavedChanges,
+        trySaveRef,
+        sandbox,
+        saveGoogle = false,
+        unsavedChangesRef
         } = dependencies;
 
     //==--------- Page setup ----------==//
     useEffect(()=>{
-		const autoSavePref = JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
+		const autoSavePref = !sandbox && JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
 		setAutoSaveEnabled(autoSavePref);
+        console.log(autoSavePref)
 		setWarnUnsavedChanges(!autoSavePref);
 		setHTMLErrors(hbfm.validate(currentBrew.text));
 		fetchThemeBundle(setError, setThemeBundle, currentBrew.renderer, currentBrew.theme);

--- a/client/homebrew/utils/commonEditPageFunctions.js
+++ b/client/homebrew/utils/commonEditPageFunctions.js
@@ -4,33 +4,33 @@ import { printCurrentBrew, fetchThemeBundle } from '@shared/helpers.js';
 const AUTOSAVE_KEY = 'HB_editor_autoSaveOn';
 
 export default function useCommonEditPageFunctions(dependencies) {
-    const {
-        setError,
-        setThemeBundle,
-        HTMLErrors,
-        setHTMLErrors,
-        currentBrew,
-        setCurrentBrew,
-        useLocalStorage,
-        BREWKEY,
-        STYLEKEY,
-        SNIPKEY,
-        METAKEY,
-        hbfm,
-        autoSaveEnabled,
-        setAutoSaveEnabled,
-        setWarnUnsavedChanges,
-        trySaveRef,
-        sandbox,
-        saveGoogle = false,
-        unsavedChangesRef
-        } = dependencies;
+	const {
+		setError,
+		setThemeBundle,
+		HTMLErrors,
+		setHTMLErrors,
+		currentBrew,
+		setCurrentBrew,
+		useLocalStorage,
+		BREWKEY,
+		STYLEKEY,
+		SNIPKEY,
+		METAKEY,
+		hbfm,
+		autoSaveEnabled,
+		setAutoSaveEnabled,
+		setWarnUnsavedChanges,
+		trySaveRef,
+		sandbox,
+		saveGoogle = false,
+		unsavedChangesRef
+	} = dependencies;
 
-    //==--------- Page setup ----------==//
-    useEffect(()=>{
+	//==--------- Page setup ----------==//
+	useEffect(()=>{
 		const autoSavePref = !sandbox && JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
 		setAutoSaveEnabled(autoSavePref);
-        console.log(autoSavePref)
+		console.log(autoSavePref)
 		setWarnUnsavedChanges(!autoSavePref);
 		setHTMLErrors(hbfm.validate(currentBrew.text));
 		fetchThemeBundle(setError, setThemeBundle, currentBrew.renderer, currentBrew.theme);
@@ -56,30 +56,30 @@ export default function useCommonEditPageFunctions(dependencies) {
 		};
 	}, []);
 
-    const handleBrewChange = (field)=>(value, subfield)=>{	//'text', 'style', 'snippets', 'metadata'
-        if(subfield == 'renderer' || subfield == 'theme')
-            fetchThemeBundle(setError, setThemeBundle, value.renderer, value.theme);
+	const handleBrewChange = (field)=>(value, subfield)=>{	//'text', 'style', 'snippets', 'metadata'
+		if(subfield == 'renderer' || subfield == 'theme')
+			fetchThemeBundle(setError, setThemeBundle, value.renderer, value.theme);
 
-        //If there are HTML errors, run the validator on every change to give quick feedback
-        if(HTMLErrors.length && (field == 'text' || field == 'snippets'))
-            setHTMLErrors(hbfm.validate(value));
+		//If there are HTML errors, run the validator on every change to give quick feedback
+		if(HTMLErrors.length && (field == 'text' || field == 'snippets'))
+			setHTMLErrors(hbfm.validate(value));
 
-        if(field == 'metadata') setCurrentBrew((prev)=>({ ...prev, ...value }));
-        else                    setCurrentBrew((prev)=>({ ...prev, [field]: value }));
+		if(field == 'metadata') setCurrentBrew((prev)=>({ ...prev, ...value }));
+		else                    setCurrentBrew((prev)=>({ ...prev, [field]: value }));
 
-        if(useLocalStorage) {
-            if(field == 'text')     localStorage.setItem(BREWKEY, value);
-            if(field == 'style')    localStorage.setItem(STYLEKEY, value);
-            if(field == 'snippets') localStorage.setItem(SNIPKEY, value);
-            if(field == 'metadata') localStorage.setItem(METAKEY, JSON.stringify({
-                renderer : value.renderer,
-                theme    : value.theme,
-                lang     : value.lang
-            }));
-        }
-    };
+		if(useLocalStorage) {
+			if(field == 'text')	    localStorage.setItem(BREWKEY, value);
+			if(field == 'style')	  localStorage.setItem(STYLEKEY, value);
+			if(field == 'snippets') localStorage.setItem(SNIPKEY, value);
+			if(field == 'metadata') localStorage.setItem(METAKEY, JSON.stringify({
+				renderer : value.renderer,
+				theme	   : value.theme,
+				lang	   : value.lang
+			}));
+		}
+	};
 
-    return {
-        handleBrewChange
-    }
+	return {
+		handleBrewChange
+	}
 }

--- a/client/homebrew/utils/commonEditPageFunctions.js
+++ b/client/homebrew/utils/commonEditPageFunctions.js
@@ -14,6 +14,35 @@ export default function useCommonEditPageFunctions(dependencies) {
         hbfm
         } = dependencies;
 
+    //==--------- Page setup ----------==//
+    useEffect(()=>{
+		const autoSavePref = JSON.parse(localStorage.getItem(AUTOSAVE_KEY) ?? true);
+		setAutoSaveEnabled(autoSavePref);
+		setWarnUnsavedChanges(!autoSavePref);
+		setHTMLErrors(hbfm.validate(currentBrew.text));
+		fetchThemeBundle(setError, setThemeBundle, currentBrew.renderer, currentBrew.theme);
+
+		const handleControlKeys = (e)=>{
+			if(!(e.ctrlKey || e.metaKey)) return;
+			if(e.keyCode === 83) trySaveRef.current(true, true, saveGoogle);
+			if(e.keyCode === 80) printCurrentBrew();
+			if([83, 80].includes(e.keyCode)) {
+				e.stopPropagation();
+				e.preventDefault();
+			}
+		};
+
+		document.addEventListener('keydown', handleControlKeys);
+		window.onbeforeunload = ()=>{
+			if(unsavedChangesRef.current)
+				return 'You have unsaved changes!';
+		};
+		return ()=>{
+			document.removeEventListener('keydown', handleControlKeys);
+			window.onBeforeUnload = null;
+		};
+	}, []);
+
     const handleBrewChange = (field)=>(value, subfield)=>{	//'text', 'style', 'snippets', 'metadata'
         if(subfield == 'renderer' || subfield == 'theme')
             fetchThemeBundle(setError, setThemeBundle, value.renderer, value.theme);


### PR DESCRIPTION
Moves the page setup effects (register key listeners, load settings from localstorage, etc.) into the useCommonEditFunctions hook.

Should be no function change.