### PR TITLE
refactor ErrorIndex as lookup function

### DIFF
--- a/client/homebrew/pages/errorPage/errorPage.jsx
+++ b/client/homebrew/pages/errorPage/errorPage.jsx
@@ -6,7 +6,7 @@ import ErrorIndex from './errors/errorIndex.js';
 
 const ErrorPage = ({ brew })=>{
 	// Retrieving the error text based on the brew's error code from ErrorIndex
-	const errorText = ErrorIndex({ brew })[brew.HBErrorCode.toString()] || '';
+	const errorText = ErrorIndex(error.HBErrorCode.toString(), { brew }) || '';
 
 	return (
 		<UIPage brew={{ title: 'Crit Fail!' }}>

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -312,4 +312,5 @@ const errorIndex = (errorCode, props = {})=>{
 	}
 };
 
+export { escape, authorLinks };
 export default errorIndex;

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -7,265 +7,309 @@ const escape = (text = '')=>{
 	return text.split('').map((char)=>`&#${char.charCodeAt(0)};`).join('');
 };
 
-//001-050 : Brew errors
-//050-100 : Other pages errors
+const authorLinks = (authors = []) =>
+	authors
+		.map((author) => `[${escape(author)}](/user/${encodeURIComponent(author)})`)
+		.join(', ');
 
-const errorIndex = (props)=>{
-	return {
+//NOTE: errorCode is a string, not a number
+//			01-51 : Brew errors
+//			52-99 : Other pages errors
+
+const errorIndex = (errorCode, props = {})=>{
+	switch(errorCode) {
+
 		// Default catch all
-		'00' : dedent`
-			## An unknown error occurred!
-			
-			We aren't sure what happened, but our server wasn't able to find what you
-			were looking for.`,
+		case '00':
+			return dedent`
+				## An unknown error occurred!
+
+				We aren't sure what happened, but our server wasn't able to find what you
+				were looking for.`;
 
 		// General Google load error
-		'01' : dedent`
-			## An error occurred while retrieving this brew from Google Drive!
-			
-			Google is able to see the brew at this link, but reported an error while attempting to retrieve it.
+		case '01':
+			return dedent`
+				## An error occurred while retrieving this brew from Google Drive!
 
-			### Refreshing your Google Credentials
+				Google is able to see the brew at this link, but reported an error while attempting to retrieve it.
 
-			This issue is likely caused by an issue with your Google credentials; if you are the owner of this file, the following steps may resolve the issue:
+				### Refreshing your Google Credentials
 
-			- Go to https://www.naturalcrit.com/login and click logout if present (in small text at the bottom of the page).
-			- Click "Sign In with Google", which will refresh your Google credentials.
-			- After completing the sign in process, return to Homebrewery and refresh/reload the page so that it can pick up the updated credentials.
-			- If this was the source of the issue, it should now be resolved.
+				This issue is likely caused by an issue with your Google credentials; if you are the owner of this file, the following steps may resolve the issue:
 
-			If following these steps does not resolve the issue, please let us know!`,
+				- Go to ${loginUrl} and click logout if present (in small text at the bottom of the page).
+				- Click "Sign In with Google", which will refresh your Google credentials.
+				- After completing the sign in process, return to Homebrewery and refresh/reload the page so that it can pick up the updated credentials.
+				- If this was the source of the issue, it should now be resolved.
+
+				If following these steps does not resolve the issue, please let us know!`;
 
 		// Google Drive - 404 : brew deleted or access denied
-		'02' : dedent`
-			## We can't find this brew in Google Drive!
-			
-			This file was saved on Google Drive, but this link doesn't work anymore.
-			${props.brew.authors?.length > 0
-		? `Note that this brew belongs to the Homebrewery account **${props.brew.authors[0]}**,
+		case '02':
+			return dedent`
+				## We can't find this brew in Google Drive!
+
+				This file was saved on Google Drive, but this link doesn't work anymore.
+				${props.brew.authors?.length > 0
+					? `Note that this brew belongs to the Homebrewery account **${escape(props.brew.authors[0])}**,
 				${props.brew.account
-		? `which is
-						${props.brew.authors[0] == props.brew.account
-		? `your account.`
-		: `not your account (you are currently signed in as **${props.brew.account}**).`
-}`
-		: 'and you are not currently signed in to any account.'
-}`
-		: ''
-}
-			The Homebrewery cannot delete files from Google Drive on its own, so there
-			are three most likely possibilities:
-			:
-			- **The Google Drive files may have been accidentally deleted.** Look in
-			the Google Drive account that owns this brew (or ask the owner to do so),
-			and make sure the Homebrewery folder is still there, and that it holds your brews
-			as text files.
-			- **You may have changed the sharing settings for your files.** If the files
-			are still on Google Drive, change all of them to be shared *with everyone who has
-			the link* so the Homebrewery can access them.
-			- **The Google Account may be closed.** Google may have removed the account
-			due to inactivity or violating a Google policy. Make sure the owner can
-			still access Google Drive normally and upload/download files to it.
-			
-			If the file isn't found, Google Drive usually puts your file in your Trash folder for
-			30 days. Assuming the trash hasn't been emptied yet, it might be worth checking.
-			You can also find the Activity tab on the right side of the Google Drive page, which
-			shows the recent activity on Google Drive. This can help you pin down the exact date
-			the brew was deleted or moved, and by whom.
-			:
-			If the brew still isn't found, some people have had success asking Google to recover
-			accidentally deleted files at this link: 
-			https://support.google.com/drive/answer/1716222?hl=en&ref_topic=7000946.
-			At the bottom of the page there is a button that says *Send yourself an Email*
-			and you will receive instructions on how to request the files be restored.
-			:
-			Also note, if you prefer not to use your Google Drive for storage, you can always
-			change the storage location of a brew by clicking the Google drive icon by the
-			brew title and choosing *transfer my brew to/from Google Drive*.`,
+					? `which is
+				${props.brew.authors[0] === props.brew.account
+					? `your account.`
+					: `not your account (you are currently signed in as **${escape(props.brew.account)}**).`
+				}`
+					: 'and you are not currently signed in to any account.'
+				}`
+					: ''
+				}
+				The Homebrewery cannot delete files from Google Drive on its own, so there
+				are three most likely possibilities:
+				:
+					- **The Google Drive files may have been accidentally deleted.** Look in
+					the Google Drive account that owns this brew (or ask the owner to do so),
+					and make sure the Homebrewery folder is still there, and that it holds your brews
+					as text files.
+
+					- **You may have changed the sharing settings for your files.** If the files
+					are still on Google Drive, change all of them to be shared *with everyone who has
+					the link* so the Homebrewery can access them.
+
+					- **The Google Account may be closed.** Google may have removed the account
+					due to inactivity or violating a Google policy. Make sure the owner can
+					still access Google Drive normally and upload/download files to it.
+
+					If the file isn't found, Google Drive usually puts your file in your Trash folder for
+					30 days. Assuming the trash hasn't been emptied yet, it might be worth checking.
+					You can also find the Activity tab on the right side of the Google Drive page, which
+					shows the recent activity on Google Drive. This can help you pin down the exact date
+					the brew was deleted or moved, and by whom.
+					:
+
+					If the brew still isn't found, some people have had success asking Google to recover
+					accidentally deleted files at this link:
+					https://support.google.com/drive/answer/1716222?hl=en&ref_topic=7000946.
+					At the bottom of the page there is a button that says *Send yourself an Email*
+					and you will receive instructions on how to request the files be restored.
+					:
+					Also note, if you prefer not to use your Google Drive for storage, you can always
+					change the storage location of a brew by clicking the Google drive icon by the
+					brew title and choosing *transfer my brew to/from Google Drive*.`;
 
 		// User is not Authors list
-		'03' : dedent`
-		## Current signed-in user does not have editor access to this brew.
+		case '03':
+			return dedent`
+				## Current signed-in user does not have editor access to this brew.
 
-		If you believe you should have access to this brew, ask one of its authors to invite you
-		as an author by opening the Edit page for the brew, viewing the {{fa,fa-info-circle}}
-		**Properties** tab, and adding your username to the "invited authors" list. You can
-		then try to access this document again.
-		
-		:
+				If you believe you should have access to this brew, ask one of its authors to invite you
+				as an author by opening the Edit page for the brew, viewing the {{fa,fa-info-circle}}
+				**Properties** tab, and adding your username to the "invited authors" list. You can
+				then try to access this document again.
 
-		**Brew Title:** ${escape(props.brew.brewTitle) || 'Unable to show title'}
+				:
 
-		**Current Authors:** ${props.brew.authors?.map((author)=>{return `[${author}](/user/${encodeURIComponent(author)})`;}).join(', ') || 'Unable to list authors'}
-		
-		[Click here to be redirected to the brew's share page.](/share/${props.brew.shareId})`,
+				**Brew Title:** ${escape(props.brew.brewTitle) || 'Unable to show title'}
+
+				**Current Authors:** ${authorLinks(props.brew?.authors) || 'Unable to list authors'}${authorLinks(props.brew?.authors) || 'Unable to list authors'}
+
+				[Click here to be redirected to the brew's share page.](/share/${props.brew.shareId})`;
 
 		// User is not signed in; must be a user on the Authors List
-		'04' : dedent`
-		## Sign-in required to edit this brew.
-		
-		You must be logged in to one of the accounts listed as an author of this brew.
-		User is not logged in. Please log in [here](${loginUrl}).
-		
-		:
+		case '04':
+			return dedent`
+				## Sign-in required to edit this brew.
 
-		**Brew Title:** ${escape(props.brew.brewTitle) || 'Unable to show title'}
+				You must be logged in to one of the accounts listed as an author of this brew.
+				User is not logged in. Please log in [here](${loginUrl}).
 
-		**Current Authors:** ${props.brew.authors?.map((author)=>{return `[${author}](/user/${encodeURIComponent(author)})`;}).join(', ') || 'Unable to list authors'}
+				:
 
-		[Click here to be redirected to the brew's share page.](/share/${props.brew.shareId})`,
+				**Brew Title:** ${escape(props.brew.brewTitle) || 'Unable to show title'}
 
+				**Current Authors:** ${authorLinks(props.brew?.authors) || 'Unable to list authors'}
+
+				[Click here to be redirected to the brew's share page.](/share/${props.brew.shareId})`;
 
 		// Brew load error
-		'05' : dedent`
-		## No Homebrewery document could be found.
-		
-		The server could not locate the Homebrewery document. It was likely deleted by
-		its owner.
-		
-		:
+		case '05':
+			return dedent`
+				## No Homebrewery document could be found.
 
-		**Requested access:** ${props.brew.accessType}
+				The server could not locate the Homebrewery document. It was likely deleted by
+				its owner.
 
-		**Brew ID:**  ${props.brew.brewId}`,
+				:
+
+				**Requested access:** ${props.brew.accessType}
+
+				**Brew ID:**	${props.brew.brewId}`;
 
 		// Brew save error
-		'06' : dedent`
-		## Unable to save Homebrewery document.
-		
-		An error occurred wil attempting to save the Homebrewery document.`,
+		case '06':
+			return dedent`
+				## Unable to save Homebrewery document.
 
-		// Brew delete error
-		'07' : dedent`
-		## Unable to delete Homebrewery document.
-		
-		An error occurred while attempting to remove the Homebrewery document.
-		
-		:
+				An error occurred while attempting to save the Homebrewery document.`;
 
-		**Brew ID:**  ${props.brew.brewId}`,
+		//Brew delete error
+		case '07':
+			return dedent`
+				## Unable to delete Homebrewery document.
 
-		// Author delete error
-		'08' : dedent`
-		## Unable to remove user from Homebrewery document.
-		
-		An error occurred while attempting to remove the user from the Homebrewery document author list!
-		
-		:
+				An error occurred while attempting to remove the Homebrewery document.
 
-		**Brew ID:**  ${props.brew.brewId}`,
+				:
 
-		// Theme load error
-		'09' : dedent`
-		## No Homebrewery theme document could be found.
-		
-		The server could not locate the Homebrewery document. It was likely deleted by
-		its owner.
-		
-		:
+				**Brew ID:**	${props.brew.brewId}`;
 
-		**Requested access:** ${props.brew.accessType}
+		//Author delete error
+		case '08':
+			return dedent`
+				## Unable to remove user from Homebrewery document.
 
-		**Brew ID:**  ${props.brew.brewId}`,
+				An error occurred while attempting to remove the user from the Homebrewery document author list!
 
-		// Theme Not Valid
-		'10' : dedent`
-		## The selected theme is not tagged as a theme.
-		
-		The brew selected as a theme exists, but has not been marked for use as a theme with the \`theme:meta\` tag.
-		
-		If the selected brew is your document, you may designate it as a theme by adding the \`theme:meta\` tag.`,
+				:
 
-		// ID validation error
-		'11' : dedent`
-		## No Homebrewery document could be found.
-		
-		The server could not locate the Homebrewery document. The Brew ID failed the validation check.
-		
-		:
+				**Brew ID:**	${props.brew.brewId}`;
 
-		**Brew ID:**  ${props.brew.brewId}`,
+		//Theme load error
+		case '09':
+			return dedent`
+				## No Homebrewery theme document could be found.
 
-		// Google ID validation error
-		'12' : dedent`
-		## No Google document could be found.
-		
-		The server could not locate the Google document. The Google ID failed the validation check.
-		
-		:
+				The server could not locate the Homebrewery document. It was likely deleted by
+				its owner.
 
-		**Brew ID:**  ${props.brew.brewId}`,
+				:
 
-		// Database Connection Lost
-		'13' : dedent`
-		## Database connection has been lost.
-		
-		The server could not communicate with the database.`,
+				**Requested access:** ${props.brew.accessType}
+
+				**Brew ID:**	${props.brew.brewId}`;
+
+		//Theme Not Valid
+		case '10':
+			return dedent`
+				## The selected theme is not tagged as a theme.
+
+				The brew selected as a theme exists, but has not been marked for use as a theme with the \`theme:meta\` tag.
+
+				If the selected brew is your document, you may designate it as a theme by adding the \`theme:meta\` tag.`;
+
+		//ID validation error
+		case '11':
+			return dedent`
+				## No Homebrewery document could be found.
+
+				The server could not locate the Homebrewery document. The Brew ID failed the validation check.
+
+				:
+
+				**Brew ID:**	${props.brew.brewId}`;
+
+		//Google ID validation error
+		case '12':
+			return dedent`
+				## No Google document could be found.
+
+				The server could not locate the Google document. The Google ID failed the validation check.
+
+				:
+
+				**Brew ID:**	${props.brew.brewId}`;
+
+		//Database Connection Lost
+		case '13':
+			return dedent`
+				## Database connection has been lost.
+
+				The server could not communicate with the database.`;
 
 		//account page when account is not defined
-		'50' : dedent`
-		## You are not signed in
-		
-		You are trying to access the account page, but are not signed in to an account.
-		
-		Please login or signup at our [login page](https://www.naturalcrit.com/login?redirect=https://homebrewery.naturalcrit.com/account).`,
+		case '50':
+			return dedent`
+				## You are not signed in.
 
-		// Brew locked by Administrators error
-		'51' : dedent`
-		## This brew has been locked.
-		
-		Only an author may request that this lock is removed.
-		
-		:
+				You are trying to access the account page, but are not signed in to an account.
 
-		**Brew ID:**  ${props.brew.brewId}
-		
-		**Brew Title:** ${escape(props.brew.brewTitle)}
-		
-		**Brew Authors:**  ${props.brew.authors?.map((author)=>{return `[${author}](/user/${encodeURIComponent(author)})`;}).join(', ') || 'Unable to list authors'}`,
+				Please login or signup at our [login page](${loginUrl}?redirect=https://homebrewery.naturalcrit.com/account).`;
 
-		// ####### Admin page error #######
-		'52' : dedent`
-		## Access Denied
-		You need to provide correct administrator credentials to access this page.`,
+		//Brew locked by Administrators error
+		case '51':
+			return dedent`
+				## This brew has been locked.
+
+				Only an author may request that this lock is removed.
+
+				:
+
+				**Brew ID:**	${props.brew.brewId}
+
+				**Brew Title:** ${escape(props.brew.brewTitle)}
+
+				**Brew Authors:**	 ${authorLinks(props.brew?.authors) || 'Unable to list authors'}`;
+
+		//####### Admin page error #######
+		case '52':
+			return dedent`
+				## Access Denied
+				You need to provide correct administrator credentials to access this page.`;
 
 		// ####### Lock Errors
+		case '60':
+			return dedent`Lock Error: General`;
 
-		'60' : dedent`Lock Error: General`,
+		case '61':
+			return dedent`Lock Get Error: Unable to get lock count`;
 
-		'61' : dedent`Lock Get Error: Unable to get lock count`,
+		case '62':
+			return dedent`Lock Set Error: Cannot lock`;
 
-		'62' : dedent`Lock Set Error: Cannot lock`,
+		case '63':
+			return dedent`Lock Set Error: Brew not found`;
 
-		'63' : dedent`Lock Set Error: Brew not found`,
+		case '64':
+			return dedent`Lock Set Error: Already locked`;
 
-		'64' : dedent`Lock Set Error: Already locked`,
+		case '65':
+			return dedent`Lock Remove Error: Cannot unlock`;
 
-		'65' : dedent`Lock Remove Error: Cannot unlock`,
+		case '66':
+			return dedent`Lock Remove Error: Brew not found`;
 
-		'66' : dedent`Lock Remove Error: Brew not found`,
+		case '67':
+			return dedent`Lock Remove Error: Not locked`;
 
-		'67' : dedent`Lock Remove Error: Not locked`,
+		case '68':
+			return dedent`Lock Get Review Error: Cannot get review requests`;
 
-		'68' : dedent`Lock Get Review Error: Cannot get review requests`,
+		case '69':
+			return dedent`Lock Set Review Error: Cannot set review request`;
 
-		'69' : dedent`Lock Set Review Error: Cannot set review request`,
+		case '70':
+			return dedent`Lock Set Review Error: Brew not found`;
 
-		'70' : dedent`Lock Set Review Error: Brew not found`,
+		case '71':
+			return dedent`Lock Set Review Error: Review already requested`;
 
-		'71' : dedent`Lock Set Review Error: Review already requested`,
+		case '72':
+			return dedent`Lock Remove Review Error: Cannot clear review request`;
 
-		'72' : dedent`Lock Remove Review Error: Cannot clear review request`,
-
-		'73' : dedent`Lock Remove Review Error: Brew not found`,
+		case '73':
+			return dedent`Lock Remove Review Error: Brew not found`;
 
 		// ####### Other Errors
 
-		'90' : dedent` An unexpected error occurred while looking for these brews.  
-            Try again in a few minutes.`,
+		case '90':
+			return dedent`An unexpected error occurred while looking for these brews.
+				Try again in a few minutes.`;
 
-		'91' : dedent` An unexpected error occurred while trying to get the total of brews.`,
-	};
+		case '91':
+			return dedent`An unexpected error occurred while trying to get the total of brews.`;
+
+		default:
+			return dedent`## An unknown error occurred!`;
+	}
 };
 
 export default errorIndex;

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -4,6 +4,7 @@ const loginUrl = 'https://www.naturalcrit.com/login';
 
 // Prevent parsing text (e.g. document titles) as markdown
 const escape = (text = '')=>{
+	text = String(text);
 	return text.replace(/[^a-zA-Z0-9 ]/g, (char)=>`&#${char.charCodeAt(0)};`);
 };
 

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -320,8 +320,9 @@ const errorIndex = (errorCode, props = {})=>{
 		// ####### Default unknown error
 
 		default:
-			return dedent`## An unknown error occurred!`;
-	}
+			return `
+				# An unexpected error occurred.
+				So unexpected we don't even have an error message for the code (${escape(errorCode)}).`;	}
 };
 
 export { escape, authorLinks };

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -12,11 +12,12 @@ const authorLinks = (authors = []) =>
 		.map((author) => `[${escape(author)}](/user/${encodeURIComponent(author)})`)
 		.join(', ');
 
-//NOTE: errorCode is a string, not a number
-//			01-51 : Brew errors
-//			52-99 : Other pages errors
 
 const errorIndex = (errorCode, props = {})=>{
+	//NOTE: errorCode is a string, not a number, and switch() uses strict equality ===
+	//			01-51 : Brew errors
+	//			52-99 : Other pages errors
+
 	switch(errorCode) {
 
 		// Default catch all
@@ -44,6 +45,9 @@ const errorIndex = (errorCode, props = {})=>{
 				- If this was the source of the issue, it should now be resolved.
 
 				If following these steps does not resolve the issue, please let us know!`;
+
+
+		// ####### Brew Page Errors ...
 
 		// Google Drive - 404 : brew deleted or access denied
 		case '02':
@@ -249,11 +253,14 @@ const errorIndex = (errorCode, props = {})=>{
 
 				**Brew Authors:**	 ${authorLinks(props.brew?.authors) || 'Unable to list authors'}`;
 
+
 		//####### Admin page error #######
+
 		case '52':
 			return dedent`
 				## Access Denied
 				You need to provide correct administrator credentials to access this page.`;
+
 
 		// ####### Lock Errors
 		case '60':
@@ -298,6 +305,7 @@ const errorIndex = (errorCode, props = {})=>{
 		case '73':
 			return dedent`Lock Remove Review Error: Brew not found`;
 
+
 		// ####### Other Errors
 
 		case '90':
@@ -306,6 +314,9 @@ const errorIndex = (errorCode, props = {})=>{
 
 		case '91':
 			return dedent`An unexpected error occurred while trying to get the total of brews.`;
+
+
+		// ####### Default unknown error
 
 		default:
 			return dedent`## An unknown error occurred!`;

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -4,7 +4,7 @@ const loginUrl = 'https://www.naturalcrit.com/login';
 
 // Prevent parsing text (e.g. document titles) as markdown
 const escape = (text = '')=>{
-	return text.split('').map((char)=>`&#${char.charCodeAt(0)};`).join('');
+	return text.replace(/[^a-zA-Z0-9 ]/g, (char)=>`&#${char.charCodeAt(0)};`);
 };
 
 const authorLinks = (authors = []) =>

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -3,8 +3,8 @@ import dedent from 'dedent';
 const loginUrl = 'https://www.naturalcrit.com/login';
 
 // Prevent parsing text (e.g. document titles) as markdown
-const escape = (text = '')=>{
-	text = String(text);
+const escape = (text)=>{
+	text = String(text); // undefined => 'undefined', null => 'null'
 	return text.replace(/[^a-zA-Z0-9 ]/g, (char)=>`&#${char.charCodeAt(0)};`);
 };
 

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -310,7 +310,8 @@ const errorIndex = (errorCode, props = {})=>{
 		// ####### Vault Errors
 
 		case '90':
-			return dedent`An unexpected error occurred while looking for these brews.
+			return dedent`
+				An unexpected error occurred while looking for these brews.
 				Try again in a few minutes.`;
 
 		case '91':

--- a/client/homebrew/pages/errorPage/errors/errorIndex.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.js
@@ -307,7 +307,7 @@ const errorIndex = (errorCode, props = {})=>{
 			return dedent`Lock Remove Review Error: Brew not found`;
 
 
-		// ####### Other Errors
+		// ####### Vault Errors
 
 		case '90':
 			return dedent`An unexpected error occurred while looking for these brews.

--- a/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
@@ -2,6 +2,33 @@
 
 import errorIndex, { escape, authorLinks } from './errorIndex.js';
 
+
+// helpers..
+const codeStrings = (from, to, width = String(to).length) => {
+  const values = [];
+  for (let i = Number(from); i <= Number(to); i++) {
+    values.push(String(i).padStart(width, '0'));
+  }
+  return values;
+};
+
+const assertErrorMessages = (errorCodes, props = {}) => {
+  const defaultResult = errorIndex('NO_SUCH_ERROR');
+  errorCodes.forEach((errorCode) => {
+    let result;
+
+    expect(() => {
+      result = errorIndex(errorCode, props);
+    }).not.toThrow();
+
+    expect(typeof result).toBe('string');
+    expect(result).not.toBe(defaultResult);
+    expect(result.length).toBeGreaterThan(0);
+  });
+};
+
+
+// tests..
 describe('errorIndex', () => {
 
   describe('static messages', () => {
@@ -91,12 +118,8 @@ describe('errorIndex', () => {
     it('returns the switch default for an unknown error code', () => {
       const result = errorIndex('NO_SUCH_CODE');
 
-      expect(result).toBe(
-        errorIndex('NO_SUCH_CODE')
-      );
-      expect(result).not.toBe(
-        errorIndex('00')
-      );
+      expect(errorIndex('NO_SUCH_CODE')).toBe(result);
+      expect(errorIndex('00')).not.toBe(result);
     });
 
     it.each([
@@ -109,6 +132,12 @@ describe('errorIndex', () => {
       expect(errorIndex(errorCode)).toBe(
         errorIndex('NO_SUCH_CODE')
       );
+    });
+
+    it('escapes an unexpected error code in the default message', () => {
+      const result = errorIndex('<script>');
+      expect(result).toContain('&#60;script&#62;');
+      expect(result).not.toContain('<script>');
     });
 
   });
@@ -143,10 +172,48 @@ describe('errorIndex', () => {
   });
 
 
-  describe('common typo', () => {
+  describe('defined error codes', () => {
 
-    it('throws if errorIndex is called with the wrong capitalization', () => {
-      expect(() => ErrorIndex('01')).toThrow(ReferenceError);
+    it('returns usable messages for all defined error codes', () => {
+      // generic errors});
+      let errorCodes = [ '00', '01', '02' ];
+      assertErrorMessages(errorCodes);
+
+      // brew errors
+      errorCodes = codeStrings('03', '51');
+      const brewProps = {
+        brew: {
+          authors: [ 'Alice Smith', 'Bob Jones' ],
+          account: 'Alice Smith',
+          brewTitle: 'Test Brew',
+          shareId: 'test-share-id',
+          accessType: 'edit',
+          brewId: 'test-brew-id'
+        }
+      };
+      assertErrorMessages(errorCodes, brewProps);
+
+      // admin errors
+      errorCodes = [ '52' ];
+      assertErrorMessages(errorCodes);
+
+      // lock errors
+      errorCodes = codeStrings('60', '73');
+      assertErrorMessages(errorCodes);
+
+      // other errors
+      errorCodes = [ '90', '91' ];
+      assertErrorMessages(errorCodes);
+
+      // folder errors
+      errorCodes = codeStrings('103', '103');
+      const folderProps = {
+        folder: {
+          folderId: 'test-folder-id',
+          displayName: 'Test Folder'
+        }
+      };
+      assertErrorMessages(errorCodes, folderProps);
     });
 
   });

--- a/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
@@ -122,7 +122,6 @@ describe('errorIndex', () => {
       expect(errorIndex('00')).not.toBe(result);
     });
 
-
     it.each([
       -1,
       undefined,
@@ -150,25 +149,19 @@ describe('errorIndex', () => {
   describe('error-code types', () => {
 
     it('does not treat number 91 as string error code 91', () => {
-      expect(errorIndex(91)).toBe(
-        errorIndex('NO_SUCH_CODE')
-      );
       expect(errorIndex(91)).not.toBe(
         errorIndex('91')
       );
     });
 
     it('does not treat number 1 as string error code 01', () => {
-      expect(errorIndex(1)).toBe(
-        errorIndex('NO_SUCH_CODE')
-      );
-      expect(errorIndex(1)).not.toBe(
-        errorIndex('01')
-      );
+        expect(errorIndex(1)).not.toBe(
+          errorIndex('01')
+        );
     });
 
-    it('treats number 1 and string 01 differently', () => {
-      expect(errorIndex(1)).not.toBe(
+    it('honours leading zeros', () => {
+      expect(errorIndex('1')).not.toBe(
         errorIndex('01')
       );
     });
@@ -180,11 +173,11 @@ describe('errorIndex', () => {
 
     it('returns usable messages for all defined error codes', () => {
       // generic errors});
-      let errorCodes = [ '00', '01', '02' ];
+      let errorCodes = [ '00', '01' ];
       assertErrorMessages(errorCodes);
 
       // brew errors
-      errorCodes = codeStrings('03', '51');
+      errorCodes = codeStrings('02', '51');
       const brewProps = {
         brew: {
           authors: [ 'Alice Smith', 'Bob Jones' ],
@@ -210,14 +203,14 @@ describe('errorIndex', () => {
       assertErrorMessages(errorCodes);
 
       // folder errors
-      errorCodes = codeStrings('103', '103');
-      const folderProps = {
-        folder: {
-          folderId: 'test-folder-id',
-          displayName: 'Test Folder'
-        }
-      };
-      assertErrorMessages(errorCodes, folderProps);
+//       errorCodes = codeStrings('100', '120');
+//       const folderProps = {
+//         folder: {
+//           folderId: 'test-folder-id',
+//           displayName: 'Test Folder'
+//         }
+//       };
+//       assertErrorMessages(errorCodes, folderProps);
     });
 
   });

--- a/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
@@ -122,6 +122,7 @@ describe('errorIndex', () => {
       expect(errorIndex('00')).not.toBe(result);
     });
 
+
     it.each([
       -1,
       undefined,
@@ -129,9 +130,12 @@ describe('errorIndex', () => {
       '',
       'NO_SUCH_CODE'
     ])('uses the switch default for %p', (errorCode) => {
-      expect(errorIndex(errorCode)).toBe(
-        errorIndex('NO_SUCH_CODE')
-      );
+      const result = errorIndex(errorCode);
+
+      expect(result).toContain('An unexpected error occurred.');
+      expect(result).toContain('we don\'t even have an error message');
+      expect(result).toContain(escape(errorCode));
+      expect(result).not.toBe(errorIndex('00'));
     });
 
     it('escapes an unexpected error code in the default message', () => {

--- a/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
@@ -1,0 +1,154 @@
+// /client/homebrew/pages/errorPage/errors/errorIndex.spec.js
+
+import errorIndex, { escape, authorLinks } from './errorIndex.js';
+
+describe('errorIndex', () => {
+
+  describe('static messages', () => {
+
+    it('returns a static string when no props are provided', () => {
+      const result = errorIndex('06');
+
+      expect(typeof result).toBe('string');
+      expect(result).toContain('Unable to save Homebrewery document.');
+    });
+
+    it('uses a supplied prop when required', () => {
+      const result = errorIndex('05', {
+        brew: {
+          accessType: 'edit',
+          brewId: 'abc123'
+        }
+      });
+
+      expect(result).toContain('**Requested access:** edit');
+      expect(result).toContain('**Brew ID:**\tabc123');
+    });
+
+    it('throws when a required prop is not supplied', () => {
+      expect(() => errorIndex('05')).toThrow();
+    });
+
+  });
+
+
+  describe('escape', () => {
+
+    it('leaves alphanumeric characters and spaces unchanged', () => {
+      expect(escape('Bob Smith 123')).toBe('Bob Smith 123');
+    });
+
+    it('escapes non-alphanumeric characters', () => {
+      expect(escape("O'Brien & Co.")).toBe('O&#39;Brien &#38; Co&#46;');
+    });
+
+    it('escapes characters that need HTML protection', () => {
+      expect(escape('<script>')).toBe('&#60;script&#62;');
+    });
+
+  });
+
+
+  describe('authorLinks', () => {
+
+    it('returns an empty string with no array', () => {
+      expect(authorLinks()).toBe('');
+    });
+
+    it('returns an empty string for an empty array', () => {
+      expect(authorLinks([])).toBe('');
+    });
+
+    it('returns a link for a single author', () => {
+      expect(authorLinks(['Alice'])).toBe('[Alice](/user/Alice)');
+    });
+
+    it('returns a link for a simple author', () => {
+      expect(authorLinks(['Alice Smith'])).toBe(
+        '[Alice Smith](/user/Alice%20Smith)'
+      );
+    });
+
+    it('escapes the display name and URI-encodes the URL', () => {
+      const author = "O'Brien & Co.";
+
+      expect(authorLinks([author])).toBe(
+        `[O&#39;Brien &#38; Co&#46;](/user/${encodeURIComponent(author)})`
+      );
+    });
+
+    it('joins multiple authors with commas', () => {
+      expect(authorLinks(['Alice', 'Bob Smith'])).toBe(
+        '[Alice](/user/Alice), [Bob Smith](/user/Bob%20Smith)'
+      );
+    });
+
+  });
+
+
+  describe('unexpected error codes', () => {
+
+    it('returns the switch default for an unknown error code', () => {
+      const result = errorIndex('NO_SUCH_CODE');
+
+      expect(result).toBe(
+        errorIndex('NO_SUCH_CODE')
+      );
+      expect(result).not.toBe(
+        errorIndex('00')
+      );
+    });
+
+    it.each([
+      -1,
+      undefined,
+      null,
+      '',
+      'NO_SUCH_CODE'
+    ])('uses the switch default for %p', (errorCode) => {
+      expect(errorIndex(errorCode)).toBe(
+        errorIndex('NO_SUCH_CODE')
+      );
+    });
+
+  });
+
+
+  describe('error-code types', () => {
+
+    it('does not treat number 91 as string error code 91', () => {
+      expect(errorIndex(91)).toBe(
+        errorIndex('NO_SUCH_CODE')
+      );
+      expect(errorIndex(91)).not.toBe(
+        errorIndex('91')
+      );
+    });
+
+    it('does not treat number 1 as string error code 01', () => {
+      expect(errorIndex(1)).toBe(
+        errorIndex('NO_SUCH_CODE')
+      );
+      expect(errorIndex(1)).not.toBe(
+        errorIndex('01')
+      );
+    });
+
+    it('treats number 1 and string 01 differently', () => {
+      expect(errorIndex(1)).not.toBe(
+        errorIndex('01')
+      );
+    });
+
+  });
+
+
+  describe('common typo', () => {
+
+    it('throws if errorIndex is called with the wrong capitalization', () => {
+      expect(() => ErrorIndex('01')).toThrow(ReferenceError);
+    });
+
+  });
+
+});

--- a/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
+++ b/client/homebrew/pages/errorPage/errors/errorIndex.spec.js
@@ -198,7 +198,7 @@ describe('errorIndex', () => {
       errorCodes = codeStrings('60', '73');
       assertErrorMessages(errorCodes);
 
-      // other errors
+      // Vault errors
       errorCodes = [ '90', '91' ];
       assertErrorMessages(errorCodes);
 

--- a/client/homebrew/pages/vaultPage/vaultPage.jsx
+++ b/client/homebrew/pages/vaultPage/vaultPage.jsx
@@ -364,7 +364,7 @@ const VaultPage = (props)=>{
 		}
 
 		if(error) {
-			const errorText = ErrorIndex()[error.HBErrorCode.toString()] || '';
+			const errorText = ErrorIndex(error.HBErrorCode.toString()) || '';
 
 			return (
 				<div className='foundBrews noBrews'>


### PR DESCRIPTION
See #5003

`errorIndex()` wanted to return a fully hydrated array of error texts .. 
.. but some of those array entries would rely on props being passed in to be evaluated

Now, `errorIndex()` only wants to return the relevant error text, 
and so only evaluates the relevant array entry.

Now use 
- `errorIndex(errorCode, {props})`

instead of 
- `errorIndex({props})[errorCode]`

----

Also, updated the two places where `errorIndex()` is actually called.